### PR TITLE
Speed up TravisCI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ matrix:
   fast_finish: false
   include:
   - rust: stable
-  - rust: beta
-  - rust: nightly
 
 
 before_install:
@@ -18,7 +16,7 @@ before_install:
 # Main build
 script:
   - cargo check
-  - cargo build --release --verbose --all
+  - cargo build --verbose --all
   - cargo test --verbose --all
 
 


### PR DESCRIPTION
- Now we just run the build for `stable` rust.
- The cargo builds are no longer done in `release`
mode. Instead are done in debug.

Since `cfg` is enabled on all of the testing mods, this is pretty much everything.

Fixes #12