### PR TITLE
Implement struct LinEval

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "plonk"
 version = "0.1.0"
-authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>"]
+authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>",
+           "Luke Pearson <luke@dusk.network>", 
+           "CPerezz <carlos@dusk.network>"] 
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This commit implements a stucture
for the evaluations of the linearisation,
which are returned by the whole lineariser
polynomial.
This closes #34 