### PR TITLE
Update zexe & use num_traits crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 **/*.rs.bk
+Cargo.lock
 notes.md
 scrap.rs
 kzg10.rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,10 @@
 [[package]]
 name = "algebra"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe/#e094e2127430521b7a882b0773bf1dc6852237b4"
+source = "git+https://github.com/scipr-lab/zexe/#2c22b770afffc8ed99dfca6677bfcea3cf2ff406"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "derivative 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -17,21 +17,26 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "autocfg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bench-utils"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe/#e094e2127430521b7a882b0773bf1dc6852237b4"
+source = "git+https://github.com/scipr-lab/zexe/#2c22b770afffc8ed99dfca6677bfcea3cf2ff406"
 
 [[package]]
 name = "bls12_381"
-version = "0.1.0"
-source = "git+https://github.com/zkcrypto/bls12_381#e32494e72011b9811bd7f5c34af5ff6785cc75db"
+version = "0.1.1"
+source = "git+https://github.com/zkcrypto/bls12_381#d0ea5d4958cae999dea1800207704171aa07a9ef"
 dependencies = [
  "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "byteorder"
-version = "1.3.2"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -66,7 +71,7 @@ dependencies = [
  "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -106,7 +111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ff-fft"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe/#e094e2127430521b7a882b0773bf1dc6852237b4"
+source = "git+https://github.com/scipr-lab/zexe/#2c22b770afffc8ed99dfca6677bfcea3cf2ff406"
 dependencies = [
  "algebra 0.1.0 (git+https://github.com/scipr-lab/zexe/)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -125,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -167,10 +172,18 @@ name = "merlin"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -178,7 +191,7 @@ name = "num_cpus"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -187,10 +200,11 @@ name = "plonk"
 version = "0.1.0"
 dependencies = [
  "algebra 0.1.0 (git+https://github.com/scipr-lab/zexe/)",
- "bls12_381 0.1.0 (git+https://github.com/zkcrypto/bls12_381)",
+ "bls12_381 0.1.1 (git+https://github.com/zkcrypto/bls12_381)",
  "ff-fft 0.1.0 (git+https://github.com/scipr-lab/zexe/)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "merlin 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "poly-commit 0.1.0 (git+https://github.com/scipr-lab/poly-commit)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -201,7 +215,7 @@ dependencies = [
 [[package]]
 name = "poly-commit"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/poly-commit#5f5b1116ba784924e5c732224691130f7baaf7b0"
+source = "git+https://github.com/scipr-lab/poly-commit#77676213c10069b376960ab824ddcc436ac66a67"
 dependencies = [
  "algebra 0.1.0 (git+https://github.com/scipr-lab/zexe/)",
  "bench-utils 0.1.0 (git+https://github.com/scipr-lab/zexe/)",
@@ -317,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -406,9 +420,10 @@ dependencies = [
 [metadata]
 "checksum algebra 0.1.0 (git+https://github.com/scipr-lab/zexe/)" = "<none>"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum bench-utils 0.1.0 (git+https://github.com/scipr-lab/zexe/)" = "<none>"
-"checksum bls12_381 0.1.0 (git+https://github.com/zkcrypto/bls12_381)" = "<none>"
-"checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
+"checksum bls12_381 0.1.1 (git+https://github.com/zkcrypto/bls12_381)" = "<none>"
+"checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
@@ -419,13 +434,14 @@ dependencies = [
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum ff-fft 0.1.0 (git+https://github.com/scipr-lab/zexe/)" = "<none>"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
-"checksum hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
+"checksum hermit-abi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "e2c55f143919fbc0bc77e427fe2d74cf23786d7c1875666f2fde3ac3c659bb67"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
 "checksum merlin 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6feca46f4fa3443a01769d768727f10c10a20fdb65e52dc16a81f0c8269bb78"
+"checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 "checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
 "checksum poly-commit 0.1.0 (git+https://github.com/scipr-lab/poly-commit)" = "<none>"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
@@ -440,7 +456,7 @@ dependencies = [
 "checksum rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
 "checksum rayon-core 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-"checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
+"checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 merlin = "2.0.0"
 rand = "0.7.2"
 rand_core = { version = "0.5", default-features = false }
+num-traits = { version = "0.2", default-features = true }
 bls12_381 = { git = "https://github.com/zkcrypto/bls12_381", branch = "master" }
 algebra = { git = "https://github.com/scipr-lab/zexe/", features = [ "parallel" ]}
 ff-fft = { git = "https://github.com/scipr-lab/zexe/"}

--- a/src/cs/composer.rs
+++ b/src/cs/composer.rs
@@ -7,6 +7,7 @@ use super::{
 use crate::{cs::quotient_poly::QuotientToolkit, srs, transcript::TranscriptProtocol};
 use algebra::{curves::PairingEngine, fields::Field};
 use ff_fft::EvaluationDomain;
+use num_traits::{One, Zero};
 use poly_commit::kzg10::Powers;
 use rand_core::{CryptoRng, RngCore};
 /// A composer is a circuit builder

--- a/src/cs/linearisation.rs
+++ b/src/cs/linearisation.rs
@@ -3,6 +3,7 @@ use crate::cs::poly_utils::Poly_utils;
 use algebra::fields::PrimeField;
 use algebra::{curves::PairingEngine, fields::Field};
 use ff_fft::EvaluationDomain;
+use num_traits::{One, Zero};
 use std::marker::PhantomData;
 
 pub struct Lineariser<E: PairingEngine> {

--- a/src/cs/opening.rs
+++ b/src/cs/opening.rs
@@ -4,6 +4,7 @@ use crate::transcript::TranscriptProtocol;
 use algebra::{curves::PairingEngine, fields::Field};
 use ff_fft::DensePolynomial as Polynomial;
 use itertools::izip;
+use num_traits::{One, Zero};
 use rayon::prelude::*;
 use std::marker::PhantomData;
 pub struct commitmentOpener<E: PairingEngine> {

--- a/src/cs/permutation.rs
+++ b/src/cs/permutation.rs
@@ -6,6 +6,7 @@ use algebra::{
 };
 use ff_fft::{DensePolynomial as Polynomial, EvaluationDomain};
 use itertools::izip;
+use num_traits::{One, Zero};
 use rayon::iter::*;
 use rayon::prelude::*;
 use std::collections::HashMap;
@@ -797,24 +798,24 @@ mod test {
 
         let mut prod_left_sigma = Fr::one();
         for element in perm.left_sigma_mapping.unwrap().iter() {
-            prod_left_sigma = prod_left_sigma * &element;
+            prod_left_sigma = prod_left_sigma * *element;
         }
         let mut prod_right_sigma = Fr::one();
         for element in perm.right_sigma_mapping.unwrap().iter() {
-            prod_right_sigma = prod_right_sigma * &element;
+            prod_right_sigma = prod_right_sigma * *element;
         }
         let mut prod_out_sigma = Fr::one();
         for element in perm.out_sigma_mapping.unwrap().iter() {
-            prod_out_sigma = prod_out_sigma * &element;
+            prod_out_sigma = prod_out_sigma * *element;
         }
 
-        let copy_grand_prod = (prod_left_sigma * &prod_right_sigma) * &prod_out_sigma;
+        let copy_grand_prod = (prod_left_sigma * prod_right_sigma) * prod_out_sigma;
 
         let mut identity_grand_prod = Fr::one();
         for element in domain.elements() {
             let root_cubed = element.pow(&[3 as u64]);
             let prod = (root_cubed * &k1) * &k2;
-            identity_grand_prod = identity_grand_prod * &prod;
+            identity_grand_prod = identity_grand_prod * prod;
         }
 
         assert_eq!(identity_grand_prod / &copy_grand_prod, Fr::one());
@@ -896,10 +897,10 @@ mod test {
         // Where f_i and g_i are the numerator and denominator components in the permutation polynomial
         let (mut a_0, mut b_0) = (Fr::one(), Fr::one());
         for n in numerator_components.iter() {
-            a_0 = a_0 * &n;
+            a_0 = a_0 * n;
         }
         for n in denominator_components.iter() {
-            b_0 = b_0 * &n;
+            b_0 = b_0 * n;
         }
         assert_eq!(a_0 / &b_0, Fr::one());
 
@@ -938,9 +939,9 @@ mod test {
             assert_ne!(z_eval_shifted, Fr::zero());
 
             // Z(Xw) * copy_perm
-            let lhs = z_eval_shifted * &current_copy_perm_product;
+            let lhs = z_eval_shifted * current_copy_perm_product;
             // Z(X) * iden_perm
-            let rhs = z_eval * &current_identity_perm_product;
+            let rhs = z_eval * current_identity_perm_product;
             assert_eq!(
                 lhs, rhs,
                 "check failed at index: {}\'n lhs is : {:?} \n rhs is :{:?}",

--- a/src/cs/poly_utils.rs
+++ b/src/cs/poly_utils.rs
@@ -1,5 +1,6 @@
 use algebra::curves::PairingEngine;
 use algebra::fields::Field;
+use num_traits::{One, Zero};
 use rayon::prelude::*;
 use std::marker::PhantomData;
 

--- a/src/cs/proof.rs
+++ b/src/cs/proof.rs
@@ -9,6 +9,7 @@ use algebra::{
 };
 use ff_fft::DensePolynomial as Polynomial;
 use ff_fft::EvaluationDomain;
+use num_traits::{One, Zero};
 use poly_commit::data_structures::PCCommitment;
 use poly_commit::kzg10::{Commitment, VerifierKey};
 pub struct Proof<E: PairingEngine> {

--- a/src/cs/quotient_poly.rs
+++ b/src/cs/quotient_poly.rs
@@ -5,6 +5,7 @@ use algebra::{
     fields::{Field, PrimeField},
 };
 use ff_fft::{DensePolynomial as Polynomial, EvaluationDomain};
+use num_traits::{One, Zero};
 use rayon::prelude::*;
 use std::marker::PhantomData;
 


### PR DESCRIPTION
This will no longer require us to use specific `rev`s of zexe's crates.