### PR TITLE
Switch Polynomial Long Division for Ruffini

### DIFF
--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -81,11 +81,8 @@ impl ProverKey {
     /// it is invariant under f(z) . We can therefore compute the witness polynomial as
     /// f(x) / x - z
     pub fn compute_single_witness(&self, polynomial: &Polynomial, point: &Scalar) -> Polynomial {
-        // X - z
-        let divisor = Polynomial::from_coefficients_vec(vec![-point, Scalar::one()]);
-
         // Compute witness for regular polynomial
-        let witness_poly = polynomial / &divisor;
+        let witness_poly = polynomial.ruffini(*point);
         witness_poly
     }
 
@@ -98,9 +95,6 @@ impl ProverKey {
         point: &Scalar,
         transcript: &mut dyn TranscriptProtocol,
     ) -> Polynomial {
-        // X - z
-        let divisor = Polynomial::from_coefficients_vec(vec![-point, Scalar::one()]);
-
         let challenge = transcript.challenge_scalar(b"aggregate_witness");
         let powers = powers_of(&challenge, polynomials.len() - 1);
 
@@ -111,7 +105,7 @@ impl ProverKey {
             .zip(powers.iter())
             .map(|(poly, challenge)| poly * challenge)
             .sum();
-        let witness_poly = &numerator / &divisor;
+        let witness_poly = numerator.ruffini(*point);
         witness_poly
     }
 

--- a/src/constraint_system/standard/composer.rs
+++ b/src/constraint_system/standard/composer.rs
@@ -259,26 +259,14 @@ impl Composer for StandardComposer {
                 preprocessed_circuit.left_sigma_poly().clone(),
                 preprocessed_circuit.right_sigma_poly().clone(),
             ],
-            &[
-                evaluations.quot_eval,
-                evaluations.proof.lin_poly_eval,
-                evaluations.proof.a_eval,
-                evaluations.proof.b_eval,
-                evaluations.proof.c_eval,
-                evaluations.proof.left_sigma_eval,
-                evaluations.proof.right_sigma_eval,
-            ],
             &z_challenge,
             transcript,
         );
         let w_z_comm = commit_key.commit(&aggregate_witness).unwrap();
 
         // Compute W_zx
-        let shifted_witness = commit_key.compute_single_witness(
-            &z_poly,
-            &evaluations.proof.perm_eval,
-            &(z_challenge * domain.group_gen),
-        );
+        let shifted_witness =
+            commit_key.compute_single_witness(&z_poly, &(z_challenge * domain.group_gen));
         let w_zx_comm = commit_key.commit(&shifted_witness).unwrap();
         //
         // Create Proof

--- a/src/constraint_system/standard/composer.rs
+++ b/src/constraint_system/standard/composer.rs
@@ -252,10 +252,10 @@ impl Composer for StandardComposer {
         let aggregate_witness = commit_key.compute_aggregate_witness(
             &[
                 quot,
-                lin_poly.clone(),
-                w_l_poly.clone(),
-                w_r_poly.clone(),
-                w_o_poly.clone(),
+                lin_poly,
+                w_l_poly,
+                w_r_poly,
+                w_o_poly,
                 preprocessed_circuit.left_sigma_poly().clone(),
                 preprocessed_circuit.right_sigma_poly().clone(),
             ],


### PR DESCRIPTION
Since we do not use Polynomial long division, we can remove it for a simpler method which contains our use case.

Closes #128 