### PR TITLE
[zexe_branch] Fix `add` and `mul`  to evaluate `w_o` correct

### DIFF
--- a/src/cs/composer.rs
+++ b/src/cs/composer.rs
@@ -411,7 +411,7 @@ impl<E: PairingEngine> StandardComposer<E> {
         pi: E::Fr,
     ) -> Variable {
         // o =
-        let o = (q_l * &self.eval(&l)) + &(q_r * &self.eval(&r)) + &pi + &q_c;
+        let o = ((q_l * &self.eval(&l)) + &(q_r * &self.eval(&r)) + &pi + &q_c) * &-q_o;
         let o = self.add_input(o);
 
         self.add_gate(l, r, o, q_l, q_r, q_o, q_c, pi);
@@ -459,7 +459,7 @@ impl<E: PairingEngine> StandardComposer<E> {
         q_c: E::Fr,
         pi: E::Fr,
     ) -> Variable {
-        let o = ((self.eval(&l) * &self.eval(&r)) * &q_m) + &q_c + &pi;
+        let o = (((self.eval(&l) * &self.eval(&r)) * &q_m) + &q_c + &pi) * &-q_o;
         let o = self.add_input(o);
 
         self.mul_gate(l, r, o, q_m, q_o, q_c, pi);


### PR DESCRIPTION
While I was coding the gadgets, I realized there's an error on the implementation of `add` and `mul` functions. 
- They were not evaluating correctly the value `w_o` since they were just adding or multiplying the `w_l` and `w_r` instead of also operating them with the selector poly values like now.
- It was also not possible to scale the output value since `q_o` selector poly term was not being counted on the `w_o` computation. 
This has also been fixed with the following modif:

```rust
// Previously, whatever subtraction, or scaling value would fail:
let o = self.eval(&l) + &self.eval(&r)
// This is the propper way of computing the correct `w_o` val:
let o = ((q_l * &self.eval(&l)) + &(q_r * &self.eval(&r)) + &pi + &q_c)  *&-q_c;
```

Note that atm, we need to use `-Fr::one()` for the `q_o` term of the gate, this can be avoided by just removing the - on the `&-q_c` in the `w_o` computation so we can do this:
```rust
// Compute C
        let C = composer.mul(
            self.Z,
            self.Z,
            Fr::one(),
            Fr::from(2),
            Fr::zero(),
            Fr::zero(),
        );
```
Instead of doing this:
```rust
// Compute C
        let C = composer.mul(
            self.Z,
            self.Z,
            Fr::one(),
            -Fr::from(2),
            Fr::zero(),
            Fr::zero(),
        );
```
Since the `-` symbol is quite annoying and anti-intuitive if you're not too familiar with the gate structure.
@vlopes11 @decentralisedkev any thoughts on that?