### PR TITLE
Remove unnecessary scalar references

### DIFF
--- a/src/constraint_system/standard/linearisation_poly.rs
+++ b/src/constraint_system/standard/linearisation_poly.rs
@@ -71,10 +71,10 @@ pub fn compute(
     let perm_eval = z_poly.evaluate(&(z_challenge * domain.group_gen));
 
     let f_1 = compute_circuit_satisfiability(
-        *alpha,
-        a_eval,
-        b_eval,
-        c_eval,
+        alpha,
+        &a_eval,
+        &b_eval,
+        &c_eval,
         preprocessed_circuit.qm_poly(),
         preprocessed_circuit.ql_poly(),
         preprocessed_circuit.qr_poly(),
@@ -83,31 +83,31 @@ pub fn compute(
     );
 
     let f_2 = grand_product_lineariser::compute_identity_polynomial(
-        a_eval,
-        b_eval,
-        c_eval,
-        *z_challenge,
-        alpha_sq,
-        *beta,
-        *gamma,
+        &a_eval,
+        &b_eval,
+        &c_eval,
+        z_challenge,
+        &alpha_sq,
+        &beta,
+        &gamma,
         &z_poly,
     );
 
     let f_3 = grand_product_lineariser::compute_copy_polynomial(
-        (a_eval, b_eval),
-        perm_eval,
-        left_sigma_eval,
-        right_sigma_eval,
-        (alpha_sq, *beta, *gamma),
+        &(a_eval, b_eval),
+        &perm_eval,
+        &left_sigma_eval,
+        &right_sigma_eval,
+        &(alpha_sq, *beta, *gamma),
         preprocessed_circuit.out_sigma_poly(),
     );
 
     let f_4 =
-        grand_product_lineariser::compute_is_one_polynomial(domain, *z_challenge, alpha_cu, z_poly);
+        grand_product_lineariser::compute_is_one_polynomial(domain, z_challenge, &alpha_cu, z_poly);
 
-    let mut lin_poly = &f_1 + &f_2;
-    lin_poly = &lin_poly + &f_3;
-    lin_poly = &lin_poly + &f_4;
+    let mut lin_poly = f_1 + f_2;
+    lin_poly = lin_poly + f_3;
+    lin_poly = lin_poly + f_4;
 
     // Evaluate linearisation polynomial at z_challenge
     let lin_poly_eval = lin_poly.evaluate(z_challenge);
@@ -130,10 +130,10 @@ pub fn compute(
 }
 
 fn compute_circuit_satisfiability(
-    alpha: Scalar,
-    a_eval: Scalar,
-    b_eval: Scalar,
-    c_eval: Scalar,
+    alpha: &Scalar,
+    a_eval: &Scalar,
+    b_eval: &Scalar,
+    c_eval: &Scalar,
     q_m_poly: &Polynomial,
     q_l_poly: &Polynomial,
     q_r_poly: &Polynomial,
@@ -141,21 +141,21 @@ fn compute_circuit_satisfiability(
     q_c_poly: &Polynomial,
 ) -> Polynomial {
     // a_eval * b_eval * q_m_poly
-    let ab = a_eval * &b_eval;
+    let ab = a_eval * b_eval;
     let a_0 = q_m_poly * &ab;
 
     // a_eval * q_l
-    let a_1 = q_l_poly * &a_eval;
+    let a_1 = q_l_poly * a_eval;
 
     // b_eval * q_r
-    let a_2 = q_r_poly * &b_eval;
+    let a_2 = q_r_poly * b_eval;
 
     //c_eval * q_o
-    let a_3 = q_o_poly * &c_eval;
+    let a_3 = q_o_poly * c_eval;
 
-    let mut a = &a_0 + &a_1;
-    a = &a + &a_2;
-    a = &a + &a_3;
+    let mut a = a_0 + a_1;
+    a = a + a_2;
+    a = a + a_3;
     a = &a + q_c_poly;
-    &a * &alpha // (a_eval * b_eval * q_m_poly + a_eval * q_l + b_eval * q_r + c_eval * q_o + q_c) * alpha
+    &a * alpha // (a_eval * b_eval * q_m_poly + a_eval * q_l + b_eval * q_r + c_eval * q_o + q_c) * alpha
 }

--- a/src/constraint_system/standard/quotient_poly.rs
+++ b/src/constraint_system/standard/quotient_poly.rs
@@ -67,8 +67,11 @@ pub(crate) fn compute(
         preprocessed_circuit.out_sigma_poly(),
     );
 
-    let t_4 =
-        grand_product_quotient::compute_is_one_polynomial(domain, z_poly, alpha.square() * alpha);
+    let t_4 = grand_product_quotient::compute_is_one_polynomial(
+        domain,
+        z_poly,
+        &(alpha.square() * alpha),
+    );
     // Compute 4n evaluations for X^n -1
     let v_h_coset_4n = domain_4n.compute_vanishing_poly_over_coset(domain.size() as u64);
 

--- a/src/fft/domain.rs
+++ b/src/fft/domain.rs
@@ -159,7 +159,7 @@ impl EvaluationDomain {
 
     /// Evaluate all the lagrange polynomials defined by this domain at the
     /// point `tau`.
-    pub fn evaluate_all_lagrange_coefficients(&self, tau: Scalar) -> Vec<Scalar> {
+    pub fn evaluate_all_lagrange_coefficients(&self, tau: &Scalar) -> Vec<Scalar> {
         // Evaluate all Lagrange polynomials
         let size = self.size as usize;
         let t_size = tau.pow(&[self.size, 0, 0, 0]);
@@ -168,7 +168,7 @@ impl EvaluationDomain {
             let mut u = vec![Scalar::zero(); size];
             let mut omega_i = one;
             for i in 0..size {
-                if omega_i == tau {
+                if &omega_i == tau {
                     u[i] = one;
                     break;
                 }
@@ -178,15 +178,15 @@ impl EvaluationDomain {
         } else {
             use crate::util::batch_inversion;
 
-            let mut l = (t_size - &one) * &self.size_inv;
+            let mut l = (t_size - one) * self.size_inv;
             let mut r = one;
             let mut u = vec![Scalar::zero(); size];
             let mut ls = vec![Scalar::zero(); size];
             for i in 0..size {
-                u[i] = tau - &r;
+                u[i] = tau - r;
                 ls[i] = l;
-                l *= &self.group_gen;
-                r *= &self.group_gen;
+                l *= self.group_gen;
+                r *= self.group_gen;
             }
 
             batch_inversion(u.as_mut_slice());
@@ -202,8 +202,8 @@ impl EvaluationDomain {
     /// This evaluates the vanishing polynomial for this domain at tau.
     /// For multiplicative subgroups, this polynomial is `z(X) = X^self.size -
     /// 1`.
-    pub fn evaluate_vanishing_polynomial(&self, tau: Scalar) -> Scalar {
-        tau.pow(&[self.size, 0, 0, 0]) - &Scalar::one()
+    pub fn evaluate_vanishing_polynomial(&self, tau: &Scalar) -> Scalar {
+        tau.pow(&[self.size, 0, 0, 0]) - Scalar::one()
     }
 
     /// Given that the domain size is `D`  
@@ -239,7 +239,7 @@ impl EvaluationDomain {
     /// a coset.
     pub fn divide_by_vanishing_poly_on_coset_in_place(&self, evals: &mut [Scalar]) {
         let i = self
-            .evaluate_vanishing_polynomial(GENERATOR)
+            .evaluate_vanishing_polynomial(&GENERATOR)
             .invert()
             .unwrap();
 
@@ -249,7 +249,7 @@ impl EvaluationDomain {
     /// Given an index which assumes the first elements of this domain are the
     /// elements of another (sub)domain with size size_s,
     /// this returns the actual index into this domain.
-    pub fn reindex_by_subdomain(&self, other: Self, index: usize) -> usize {
+    pub fn reindex_by_subdomain(&self, other: &Self, index: usize) -> usize {
         assert!(self.size() >= other.size());
         // Let this subgroup be G, and the subgroup we're re-indexing by be S.
         // Since its a subgroup, the 0th element of S is at index 0 in G, the first

--- a/src/fft/domain.rs
+++ b/src/fft/domain.rs
@@ -124,8 +124,8 @@ impl EvaluationDomain {
     fn distribute_powers(coeffs: &mut [Scalar], g: Scalar) {
         let mut pow = Scalar::one();
         coeffs.iter_mut().for_each(|c| {
-            *c *= &pow;
-            pow *= &g
+            *c *= pow;
+            pow *= g
         })
     }
 
@@ -386,9 +386,9 @@ pub(crate) fn parallel_fft(a: &mut [Scalar], omega: Scalar, log_n: u32, log_cpus
             for s in 0..num_cpus {
                 let idx = (i + (s << log_new_n)) % (1 << log_n);
                 let mut t = a[idx];
-                t *= &elt;
-                tmp[i] += &t;
-                elt *= &omega_step;
+                t *= elt;
+                tmp[i] += t;
+                elt *= omega_step;
             }
             elt *= &omega_j;
         }
@@ -417,7 +417,7 @@ impl Iterator for Elements {
             None
         } else {
             let cur_elem = self.cur_elem;
-            self.cur_elem *= &self.domain.group_gen;
+            self.cur_elem *= self.domain.group_gen;
             self.cur_pow += 1;
             Some(cur_elem)
         }

--- a/src/fft/polynomial.rs
+++ b/src/fft/polynomial.rs
@@ -91,7 +91,7 @@ impl Polynomial {
             .collect();
         let mut sum = Scalar::zero();
         for eval in p_evals.into_iter() {
-            sum += &eval;
+            sum += eval;
         }
         sum
     }
@@ -115,7 +115,7 @@ impl Sum for Polynomial {
         I: Iterator<Item = Self>,
     {
         let sum: Polynomial = iter.fold(Polynomial::zero(), |mut res, val| {
-            res = &res + &val;
+            res = res + val;
             res
         });
         sum
@@ -133,7 +133,6 @@ pub(crate) fn random_scalar<R: Rng>(rng: &mut R) -> Scalar {
     ])
 }
 
-///////////
 impl<'a, 'b> Add<&'a Polynomial> for &'b Polynomial {
     type Output = Polynomial;
 

--- a/src/fft/polynomial.rs
+++ b/src/fft/polynomial.rs
@@ -160,6 +160,14 @@ impl<'a, 'b> Add<&'a Polynomial> for &'b Polynomial {
     }
 }
 
+impl Add<Polynomial> for Polynomial {
+    type Output = Polynomial;
+
+    fn add(self, other: Polynomial) -> Polynomial {
+        &self + &other
+    }
+}
+
 // Addition method tht uses iterators to add polynomials
 // Benchmark this against the original method
 fn iter_add(poly_a: &Polynomial, poly_b: &Polynomial) -> Polynomial {

--- a/src/fft/polynomial.rs
+++ b/src/fft/polynomial.rs
@@ -35,7 +35,7 @@ impl Polynomial {
 
     /// Checks if the given polynomial is zero.
     pub fn is_zero(&self) -> bool {
-        self.coeffs.is_empty() || self.coeffs.iter().all(|coeff| coeff == &Scalar::zero())
+        self.coeffs.is_empty() || self.coeffs.par_iter().all(|coeff| coeff == &Scalar::zero())
     }
 
     /// Constructs a new polynomial from a list of coefficients.

--- a/src/permutation/grand_product_lineariser.rs
+++ b/src/permutation/grand_product_lineariser.rs
@@ -1,4 +1,3 @@
-use crate::constraint_system::standard::PreProcessedCircuit;
 use crate::fft::{EvaluationDomain, Polynomial};
 use crate::permutation::constants::{K1, K2};
 use bls12_381::Scalar;

--- a/src/permutation/grand_product_lineariser.rs
+++ b/src/permutation/grand_product_lineariser.rs
@@ -6,70 +6,70 @@ use bls12_381::Scalar;
 // XXX: We need better names for these functions
 /// Computes the semi evaluted Identity permutation polynomial component of the grand product
 pub fn compute_identity_polynomial(
-    a_eval: Scalar,
-    b_eval: Scalar,
-    c_eval: Scalar,
-    z_challenge: Scalar,
-    alpha_sq: Scalar,
-    beta: Scalar,
-    gamma: Scalar,
+    a_eval: &Scalar,
+    b_eval: &Scalar,
+    c_eval: &Scalar,
+    z_challenge: &Scalar,
+    alpha_sq: &Scalar,
+    beta: &Scalar,
+    gamma: &Scalar,
     z_poly: &Polynomial,
 ) -> Polynomial {
-    let beta_z = beta * &z_challenge;
+    let beta_z = beta * z_challenge;
 
     // a_eval + beta * z_challenge + gamma
-    let mut a_0 = a_eval + &beta_z;
-    a_0 += &gamma;
+    let mut a_0 = a_eval + beta_z;
+    a_0 += gamma;
 
     // b_eval + beta * K1 * z_challenge + gamma
-    let beta_z_K1 = K1 * &beta_z;
-    let mut a_1 = b_eval + &beta_z_K1;
-    a_1 += &gamma;
+    let beta_z_K1 = K1 * beta_z;
+    let mut a_1 = b_eval + beta_z_K1;
+    a_1 += gamma;
 
     // c_eval + beta * K2 * z_challenge + gamma
-    let beta_z_K2 = K2 * &beta_z;
-    let mut a_2 = c_eval + &beta_z_K2;
-    a_2 += &gamma;
+    let beta_z_K2 = K2 * beta_z;
+    let mut a_2 = c_eval + beta_z_K2;
+    a_2 += gamma;
 
-    let mut a = a_0 * &a_1;
-    a = a * &a_2;
-    a = a * &alpha_sq; // (a_eval + beta * z_challenge + gamma)(b_eval + beta * K1 * z_challenge + gamma)(c_eval + beta * K2 * z_challenge + gamma) * alpha^2
+    let mut a = a_0 * a_1;
+    a = a * a_2;
+    a = a * alpha_sq; // (a_eval + beta * z_challenge + gamma)(b_eval + beta * K1 * z_challenge + gamma)(c_eval + beta * K2 * z_challenge + gamma) * alpha^2
 
     z_poly * &a // (a_eval + beta * z_challenge + gamma)(b_eval + beta * K1 * z_challenge + gamma)(c_eval + beta * K2 * z_challenge + gamma) * alpha^2 z(X)
 }
 
 /// Computes the semi-evaluated Copy permutation polynomial component of the grand product
 pub fn compute_copy_polynomial(
-    (a_eval, b_eval): (Scalar, Scalar),
-    z_eval: Scalar,
-    sigma_1_eval: Scalar,
-    sigma_2_eval: Scalar,
-    (alpha_sq, beta, gamma): (Scalar, Scalar, Scalar),
+    (a_eval, b_eval): &(Scalar, Scalar),
+    z_eval: &Scalar,
+    sigma_1_eval: &Scalar,
+    sigma_2_eval: &Scalar,
+    (alpha_sq, beta, gamma): &(Scalar, Scalar, Scalar),
     out_sigma_poly: &Polynomial,
 ) -> Polynomial {
     // a_eval + beta * sigma_1 + gamma
-    let beta_sigma_1 = beta * &sigma_1_eval;
-    let mut a_0 = a_eval + &beta_sigma_1;
-    a_0 += &gamma;
+    let beta_sigma_1 = beta * sigma_1_eval;
+    let mut a_0 = a_eval + beta_sigma_1;
+    a_0 += gamma;
 
     // b_eval + beta * sigma_2 + gamma
-    let beta_sigma_2 = beta * &sigma_2_eval;
-    let mut a_1 = b_eval + &beta_sigma_2;
-    a_1 += &gamma;
+    let beta_sigma_2 = beta * sigma_2_eval;
+    let mut a_1 = b_eval + beta_sigma_2;
+    a_1 += gamma;
 
-    let beta_z_eval = beta * &z_eval;
+    let beta_z_eval = beta * z_eval;
 
-    let mut a = a_0 * &a_1;
-    a = a * &beta_z_eval;
-    a = a * &alpha_sq; // (a_eval + beta * sigma_1 + gamma)(b_eval + beta * sigma_2 + gamma) * beta *z_eval * alpha^2
+    let mut a = a_0 * a_1;
+    a = a * beta_z_eval;
+    a = a * alpha_sq; // (a_eval + beta * sigma_1 + gamma)(b_eval + beta * sigma_2 + gamma) * beta *z_eval * alpha^2
 
     out_sigma_poly * &-a // -(a_eval + beta * sigma_1 + gamma)(b_eval + beta * sigma_2 + gamma) * beta *z_eval * alpha^2 * Sigma_3(X)
 }
 /// Computes the semi-evaluted check that the first L_1(w^1) = 1
 pub fn compute_is_one_polynomial(
     domain: &EvaluationDomain,
-    z_challenge: Scalar,
-    alpha_cu: Scalar,
+    z_challenge: &Scalar,
+    alpha_cu: &Scalar,
     z_coeffs: &Polynomial,
 ) -> Polynomial {
     // Evaluate l_1(z)
@@ -98,19 +98,19 @@ mod test {
         let z_poly = Polynomial::rand(10, &mut rand::thread_rng());
 
         let got_poly = compute_identity_polynomial(
-            a_eval,
-            b_eval,
-            c_eval,
-            z_challenge,
-            alpha,
-            beta,
-            gamma,
+            &a_eval,
+            &b_eval,
+            &c_eval,
+            &z_challenge,
+            &alpha,
+            &beta,
+            &gamma,
             &z_poly,
         );
 
         let first_bracket = Polynomial::from_coefficients_vec(vec![Fr::from(3)]);
-        let second_bracket = Polynomial::from_coefficients_vec(vec![Fr::from(2) + &K1]);
-        let third_bracket = Polynomial::from_coefficients_vec(vec![Fr::from(2) + &K2]);
+        let second_bracket = Polynomial::from_coefficients_vec(vec![Fr::from(2) + K1]);
+        let third_bracket = Polynomial::from_coefficients_vec(vec![Fr::from(2) + K2]);
 
         let mut expected_poly = &first_bracket * &second_bracket;
         expected_poly = &expected_poly * &third_bracket;
@@ -133,11 +133,11 @@ mod test {
         let sig3_poly = Polynomial::rand(10, &mut rand::thread_rng());
 
         let got_poly = compute_copy_polynomial(
-            (a_eval, b_eval),
-            z_eval,
-            sig1_eval,
-            sig2_eval,
-            (alpha, beta, gamma),
+            &(a_eval, b_eval),
+            &z_eval,
+            &sig1_eval,
+            &sig2_eval,
+            &(alpha, beta, gamma),
             &sig3_poly,
         );
 
@@ -158,9 +158,9 @@ mod test {
         let domain = EvaluationDomain::new(10).unwrap();
         let z_poly = Polynomial::rand(10, &mut rand::thread_rng());
 
-        let got_poly = compute_is_one_polynomial(&domain, z_challenge, alpha, &z_poly);
+        let got_poly = compute_is_one_polynomial(&domain, &z_challenge, &alpha, &z_poly);
 
-        let l1_eval = domain.evaluate_all_lagrange_coefficients(z_challenge)[0];
+        let l1_eval = domain.evaluate_all_lagrange_coefficients(&z_challenge)[0];
         let l1_eval_poly = Polynomial::from_coefficients_vec(vec![l1_eval]);
 
         let expected_poly = &z_poly * &l1_eval_poly;

--- a/src/permutation/grand_product_quotient.rs
+++ b/src/permutation/grand_product_quotient.rs
@@ -24,12 +24,12 @@ pub fn compute_identity_polynomial(
 
     let mut b = wr_coeffs.to_vec();
     b[0] = b[0] + gamma;
-    let beta_k1 = *beta * K1;
+    let beta_k1 = beta * K1;
     b[1] = b[1] + beta_k1;
 
     let mut c = wo_coeffs.to_vec();
     c[0] = c[0] + gamma;
-    let beta_k2 = *beta * K2;
+    let beta_k2 = beta * K2;
     c[1] = c[1] + beta_k2;
 
     domain_4n.coset_fft_in_place(&mut a);
@@ -106,17 +106,17 @@ pub fn compute_copy_polynomial(
 pub fn compute_is_one_polynomial(
     domain: &EvaluationDomain,
     z_poly: &Polynomial,
-    alpha_cu: Scalar,
+    alpha_cu: &Scalar,
 ) -> Evaluations {
     let n = domain.size();
     let domain_4n = EvaluationDomain::new(4 * n).unwrap();
 
     let l1_poly = compute_first_lagrange_poly(domain);
-    let alpha_cu_l1_poly = &l1_poly * &alpha_cu;
+    let alpha_cu_l1_poly = &l1_poly * alpha_cu;
 
     // (Z(x) - 1)
     let mut z_coeffs = z_poly.to_vec();
-    z_coeffs[0] = z_coeffs[0] - &Scalar::one();
+    z_coeffs[0] = z_coeffs[0] - Scalar::one();
 
     let z_evals = domain_4n.coset_fft(&z_coeffs);
     let alpha_cu_l1_evals = domain_4n.coset_fft(&alpha_cu_l1_poly.coeffs);

--- a/src/permutation/grand_product_quotient.rs
+++ b/src/permutation/grand_product_quotient.rs
@@ -25,12 +25,12 @@ pub fn compute_identity_polynomial(
     let mut b = wr_coeffs.to_vec();
     b[0] = b[0] + gamma;
     let beta_k1 = *beta * K1;
-    b[1] = b[1] + &beta_k1;
+    b[1] = b[1] + beta_k1;
 
     let mut c = wo_coeffs.to_vec();
     c[0] = c[0] + gamma;
     let beta_k2 = *beta * K2;
-    c[1] = c[1] + &beta_k2;
+    c[1] = c[1] + beta_k2;
 
     domain_4n.coset_fft_in_place(&mut a);
     domain_4n.coset_fft_in_place(&mut b);
@@ -41,7 +41,7 @@ pub fn compute_identity_polynomial(
         .map(|i| {
             let z = &z_eval_4n[i];
 
-            let mut product = a[i] * &b[i] * &c[i]; // (a(x) + beta * X + gamma) (b(X) + beta * k1 * X + gamma) (c(X) + beta * k2 * X + gamma)
+            let mut product = a[i] * b[i] * c[i]; // (a(x) + beta * X + gamma) (b(X) + beta * k1 * X + gamma) (c(X) + beta * k2 * X + gamma)
             product = product * z; // (a(x) + beta * X + gamma) (b(X) + beta * k1 * X + gamma) (c(X) + beta * k2 * X + gamma)z(X) * alpha^2
 
             product * alpha_sq
@@ -93,7 +93,7 @@ pub fn compute_copy_polynomial(
         .map(|i| {
             let z_shifted = &z_eval_4n[i + 4];
 
-            let mut product = a_fft[i] * &b_fft[i] * &c_fft[i]; // (a(x) + beta * Sigma1(X) + gamma) (b(X) + beta * Sigma2(X) + gamma) (c(X) + beta * Sigma3(X) + gamma)
+            let mut product = a_fft[i] * b_fft[i] * c_fft[i]; // (a(x) + beta * Sigma1(X) + gamma) (b(X) + beta * Sigma2(X) + gamma) (c(X) + beta * Sigma3(X) + gamma)
             product = product * z_shifted;
 
             -product * alpha_sq // (a(x) + beta* Sigma1(X) + gamma) (b(X) + beta * Sigma2(X) + gamma) (c(X) + beta * Sigma3(X) + gamma) Z(X.omega) * alpha^2
@@ -123,7 +123,7 @@ pub fn compute_is_one_polynomial(
 
     let t_4: Vec<_> = (0..domain_4n.size())
         .into_par_iter()
-        .map(|i| alpha_cu_l1_evals[i] * &z_evals[i])
+        .map(|i| alpha_cu_l1_evals[i] * z_evals[i])
         .collect();
     Evaluations::from_vec_and_domain(t_4, domain_4n)
 }
@@ -149,7 +149,7 @@ mod test {
         assert_ne!(rand_point, Fr::zero());
 
         // Compute l1_eval according to the Domain
-        let l1_a = domain.evaluate_all_lagrange_coefficients(rand_point)[0];
+        let l1_a = domain.evaluate_all_lagrange_coefficients(&rand_point)[0];
         // Compute l1 eval using IFFT
         let b = compute_first_lagrange_poly(&domain);
         let l1_b = b.evaluate(&rand_point);

--- a/src/permutation/permutation.rs
+++ b/src/permutation/permutation.rs
@@ -209,10 +209,10 @@ impl Permutation {
         let beta_roots_iter = domain.elements().map(|root| root * beta);
 
         // Compute beta * roots * K1
-        let beta_roots_K1_iter = domain.elements().map(|root| (K1 * beta) * &root);
+        let beta_roots_K1_iter = domain.elements().map(|root| (K1 * beta) * root);
 
         // Compute beta * roots * K2
-        let beta_roots_K2_iter = domain.elements().map(|root| (K2 * beta) * &root);
+        let beta_roots_K2_iter = domain.elements().map(|root| (K2 * beta) * root);
 
         // Compute left_wire + gamma
         let wL_gamma: Vec<_> = w_l.map(|w| w + gamma).collect();
@@ -251,8 +251,8 @@ impl Permutation {
             // (w_O + beta * root * k_2 + gamma)
             let prod_c = beta_root_K2 + w_o_gamma;
 
-            let mut prod = prod_a * &prod_b;
-            prod = prod * &prod_c;
+            let mut prod = prod_a * prod_b;
+            prod = prod * prod_c;
 
             numerator_partial_components.push(prod);
 
@@ -271,15 +271,15 @@ impl Permutation {
             beta_out_sigma_iter,
         ) {
             // (w_L + beta * root + gamma)
-            let prod_a = beta_left_sigma + &w_l_gamma;
+            let prod_a = beta_left_sigma + w_l_gamma;
 
             // (w_R + beta * root * k_1 + gamma)
-            let prod_b = beta_right_sigma + &w_r_gamma;
+            let prod_b = beta_right_sigma + w_r_gamma;
 
             // (w_O + beta * root * k_2 + gamma)
-            let prod_c = beta_out_sigma + &w_o_gamma;
+            let prod_c = beta_out_sigma + w_o_gamma;
 
-            let mut prod = prod_a * &prod_b;
+            let mut prod = prod_a * prod_b;
             prod = prod * &prod_c;
 
             denominator_partial_components.push(prod);
@@ -398,22 +398,22 @@ impl Permutation {
                     beta_out_sigma,
                 )| {
                     // w_j + beta * root^j-1 + gamma
-                    let ac1 = w_l_gamma + &beta_root;
+                    let ac1 = w_l_gamma + beta_root;
 
                     // w_{n+j} + beta * K1 * root^j-1 + gamma
-                    let ac2 = w_r_gamma + &beta_root_K1;
+                    let ac2 = w_r_gamma + beta_root_K1;
 
                     // w_{2n+j} + beta * K2 * root^j-1 + gamma
-                    let ac3 = w_o_gamma + &beta_root_K2;
+                    let ac3 = w_o_gamma + beta_root_K2;
 
                     // 1 / w_j + beta * sigma(j) + gamma
-                    let ac4 = (w_l_gamma + &beta_left_sigma).invert().unwrap();
+                    let ac4 = (w_l_gamma + beta_left_sigma).invert().unwrap();
 
                     // 1 / w_{n+j} + beta * sigma(n+j) + gamma
-                    let ac5 = (w_r_gamma + &beta_right_sigma).invert().unwrap();
+                    let ac5 = (w_r_gamma + beta_right_sigma).invert().unwrap();
 
                     // 1 / w_{2n+j} + beta * sigma(2n+j) + gamma
-                    let ac6 = (w_o_gamma + &beta_out_sigma).invert().unwrap();
+                    let ac6 = (w_o_gamma + beta_out_sigma).invert().unwrap();
 
                     (ac1, ac2, ac3, ac4, ac5, ac6)
                 },
@@ -446,12 +446,12 @@ impl Permutation {
         );
         let product_acumulated_components: Vec<_> = accumulator_components
             .map(move |current_component| {
-                prev.0 *= &current_component.0;
-                prev.1 *= &current_component.1;
-                prev.2 *= &current_component.2;
-                prev.3 *= &current_component.3;
-                prev.4 *= &current_component.4;
-                prev.5 *= &current_component.5;
+                prev.0 *= current_component.0;
+                prev.1 *= current_component.1;
+                prev.2 *= current_component.2;
+                prev.3 *= current_component.3;
+                prev.4 *= current_component.4;
+                prev.5 *= current_component.5;
 
                 prev
             })
@@ -469,12 +469,12 @@ impl Permutation {
             .par_iter()
             .map(move |current_component| {
                 let mut prev = Scalar::one();
-                prev *= &current_component.0;
-                prev *= &current_component.1;
-                prev *= &current_component.2;
-                prev *= &current_component.3;
-                prev *= &current_component.4;
-                prev *= &current_component.5;
+                prev *= current_component.0;
+                prev *= current_component.1;
+                prev *= current_component.2;
+                prev *= current_component.3;
+                prev *= current_component.4;
+                prev *= current_component.5;
 
                 prev
             })
@@ -596,7 +596,7 @@ mod test {
         // Left_sigma = {R0, L2,L3, L0}
         // Should turn into {1 * K1, w^2, w^3, 1}
         let encoded_left_sigma = perm.compute_permutation_lagrange(left_sigma, &domain);
-        assert_eq!(encoded_left_sigma[0], Fr::one() * &K1);
+        assert_eq!(encoded_left_sigma[0], Fr::one() * K1);
         assert_eq!(encoded_left_sigma[1], w_squared);
         assert_eq!(encoded_left_sigma[2], w_cubed);
         assert_eq!(encoded_left_sigma[3], Fr::one());
@@ -606,18 +606,18 @@ mod test {
         // Should turn into {w, w * K1, w^2 * K1, w^3 * K1}
         let encoded_right_sigma = perm.compute_permutation_lagrange(right_sigma, &domain);
         assert_eq!(encoded_right_sigma[0], w);
-        assert_eq!(encoded_right_sigma[1], w * &K1);
-        assert_eq!(encoded_right_sigma[2], w_squared * &K1);
-        assert_eq!(encoded_right_sigma[3], w_cubed * &K1);
+        assert_eq!(encoded_right_sigma[1], w * K1);
+        assert_eq!(encoded_right_sigma[2], w_squared * K1);
+        assert_eq!(encoded_right_sigma[3], w_cubed * K1);
 
         // check the output sigmas have been encoded properly
         // Out_sigma = {O0, O1, O2, O3, O4}
         // Should turn into {1 * K2, w * K2, w^2 * K2, w^3 * K2}
         let encoded_output_sigma = perm.compute_permutation_lagrange(out_sigma, &domain);
-        assert_eq!(encoded_output_sigma[0], Fr::one() * &K2);
-        assert_eq!(encoded_output_sigma[1], w * &K2);
-        assert_eq!(encoded_output_sigma[2], w_squared * &K2);
-        assert_eq!(encoded_output_sigma[3], w_cubed * &K2);
+        assert_eq!(encoded_output_sigma[0], Fr::one() * K2);
+        assert_eq!(encoded_output_sigma[1], w * K2);
+        assert_eq!(encoded_output_sigma[2], w_squared * K2);
+        assert_eq!(encoded_output_sigma[3], w_cubed * K2);
 
         let w_l = vec![Fr::from(2), Fr::from(2), Fr::from(2), Fr::from(2)];
         let w_r = vec![Fr::from(2), Fr::one(), Fr::one(), Fr::one()];
@@ -702,22 +702,22 @@ mod test {
         // check the left sigmas have been encoded properly
         let encoded_left_sigma = perm.compute_permutation_lagrange(left_sigma, &domain);
         assert_eq!(encoded_left_sigma[0], K1);
-        assert_eq!(encoded_left_sigma[1], w * &K2);
-        assert_eq!(encoded_left_sigma[2], w_squared * &K1);
-        assert_eq!(encoded_left_sigma[3], Fr::one() * &K2);
+        assert_eq!(encoded_left_sigma[1], w * K2);
+        assert_eq!(encoded_left_sigma[2], w_squared * K1);
+        assert_eq!(encoded_left_sigma[3], Fr::one() * K2);
 
         // check the right sigmas have been encoded properly
         let encoded_right_sigma = perm.compute_permutation_lagrange(right_sigma, &domain);
-        assert_eq!(encoded_right_sigma[0], w * &K1);
-        assert_eq!(encoded_right_sigma[1], w_squared * &K2);
-        assert_eq!(encoded_right_sigma[2], w_cubed * &K2);
+        assert_eq!(encoded_right_sigma[0], w * K1);
+        assert_eq!(encoded_right_sigma[1], w_squared * K2);
+        assert_eq!(encoded_right_sigma[2], w_cubed * K2);
         assert_eq!(encoded_right_sigma[3], Fr::one());
 
         // check the output sigmas have been encoded properly
         let encoded_output_sigma = perm.compute_permutation_lagrange(out_sigma, &domain);
         assert_eq!(encoded_output_sigma[0], w);
         assert_eq!(encoded_output_sigma[1], w_cubed);
-        assert_eq!(encoded_output_sigma[2], w_cubed * &K1);
+        assert_eq!(encoded_output_sigma[2], w_cubed * K1);
         assert_eq!(encoded_output_sigma[3], w_squared);
     }
 
@@ -757,12 +757,12 @@ mod test {
             prod_out_sigma = prod_out_sigma * element;
         }
 
-        let copy_grand_prod = (prod_left_sigma * prod_right_sigma) * prod_out_sigma;
+        let copy_grand_prod = prod_left_sigma * prod_right_sigma * prod_out_sigma;
 
         let mut identity_grand_prod = Fr::one();
         for element in domain.elements() {
             let root_cubed = element.pow(&[3, 0, 0, 0]);
-            let prod = (root_cubed * &K1) * &K2;
+            let prod = root_cubed * K1 * K2;
             identity_grand_prod = identity_grand_prod * prod;
         }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
 use bls12_381::{G1Projective, Scalar};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
-// Computes 1,v, v^2, v^3,..v^max_degree
+/// Computes 1,v, v^2, v^3,..v^max_degree
 pub fn powers_of(scalar: &Scalar, max_degree: usize) -> Vec<Scalar> {
     let mut powers = Vec::with_capacity(max_degree + 1);
     powers.push(Scalar::one());


### PR DESCRIPTION
Closes #111 and fixes some docs nitpicks.

This also forces all of the `Scalar` sent as params to functions to be `&Scalar` so we don't force the copy always.