### PR TITLE
Fix references usage

### DIFF
--- a/src/constraint_system/standard/linearisation_poly.rs
+++ b/src/constraint_system/standard/linearisation_poly.rs
@@ -63,11 +63,11 @@ pub fn compute(
     let perm_eval = z_poly.evaluate(&(z_challenge * domain.group_gen));
 
     let f_1 = compute_circuit_satisfiability(
-        *alpha,
-        a_eval,
-        b_eval,
-        c_eval,
-        d_eval,
+        alpha,
+        &a_eval,
+        &b_eval,
+        &c_eval,
+        &d_eval,
         preprocessed_circuit.qm_poly(),
         preprocessed_circuit.ql_poly(),
         preprocessed_circuit.qr_poly(),
@@ -76,29 +76,29 @@ pub fn compute(
     );
 
     let f_2 = grand_product_lineariser::compute_identity_polynomial(
-        a_eval,
-        b_eval,
-        c_eval,
-        d_eval,
-        *z_challenge,
-        alpha_sq,
-        *beta,
-        *gamma,
+        &a_eval,
+        &b_eval,
+        &c_eval,
+        &d_eval,
+        z_challenge,
+        &alpha_sq,
+        beta,
+        gamma,
         &z_poly,
     );
 
     let f_3 = grand_product_lineariser::compute_copy_polynomial(
-        (a_eval, b_eval, c_eval),
-        perm_eval,
-        left_sigma_eval,
-        right_sigma_eval,
-        out_sigma_eval,
-        (alpha_sq, *beta, *gamma),
+        &(a_eval, b_eval, c_eval),
+        &perm_eval,
+        &left_sigma_eval,
+        &right_sigma_eval,
+        &out_sigma_eval,
+        &(alpha_sq, *beta, *gamma),
         preprocessed_circuit.fourth_sigma_poly(),
     );
 
     let f_4 =
-        grand_product_lineariser::compute_is_one_polynomial(domain, *z_challenge, alpha_cu, z_poly);
+        grand_product_lineariser::compute_is_one_polynomial(domain, z_challenge, &alpha_cu, z_poly);
 
     let mut lin_poly = &f_1 + &f_2;
     lin_poly = &lin_poly + &f_3;
@@ -127,11 +127,11 @@ pub fn compute(
 }
 
 fn compute_circuit_satisfiability(
-    alpha: Scalar,
-    a_eval: Scalar,
-    b_eval: Scalar,
-    c_eval: Scalar,
-    d_eval: Scalar,
+    alpha: &Scalar,
+    a_eval: &Scalar,
+    b_eval: &Scalar,
+    c_eval: &Scalar,
+    d_eval: &Scalar,
     q_m_poly: &Polynomial,
     q_l_poly: &Polynomial,
     q_r_poly: &Polynomial,
@@ -139,17 +139,17 @@ fn compute_circuit_satisfiability(
     q_c_poly: &Polynomial,
 ) -> Polynomial {
     // a_eval * b_eval * q_m_poly
-    let ab = a_eval * &b_eval;
+    let ab = a_eval * b_eval;
     let a_0 = q_m_poly * &ab;
 
     // a_eval * q_l
-    let a_1 = q_l_poly * &a_eval;
+    let a_1 = q_l_poly * a_eval;
 
     // b_eval * q_r
-    let a_2 = q_r_poly * &b_eval;
+    let a_2 = q_r_poly * b_eval;
 
     //c_eval * q_o
-    let a_3 = q_o_poly * &c_eval;
+    let a_3 = q_o_poly * c_eval;
 
     //d_eval
     let a_4 = d_eval;
@@ -157,7 +157,7 @@ fn compute_circuit_satisfiability(
     let mut a = &a_0 + &a_1;
     a = &a + &a_2;
     a = &a + &a_3;
-    a = &a + &a_4;
+    a = &a + a_4;
     a = &a + q_c_poly;
-    &a * &alpha // (a_eval * b_eval * q_m_poly + a_eval * q_l + b_eval * q_r + c_eval * q_o + d_eval + q_c) * alpha
+    &a * alpha // (a_eval * b_eval * q_m_poly + a_eval * q_l + b_eval * q_r + c_eval * q_o + d_eval + q_c) * alpha
 }

--- a/src/constraint_system/standard/proof.rs
+++ b/src/constraint_system/standard/proof.rs
@@ -128,12 +128,12 @@ impl Proof {
         let t_eval = self.compute_quotient_evaluation(
             &domain,
             pub_inputs,
-            alpha,
-            beta,
-            gamma,
-            z_challenge,
-            l1_eval,
-            self.evaluations.perm_eval,
+            &alpha,
+            &beta,
+            &gamma,
+            &z_challenge,
+            &l1_eval,
+            &self.evaluations.perm_eval,
         );
 
         // Compute commitment to quotient polynomial
@@ -154,12 +154,12 @@ impl Proof {
 
         // Compute linearisation commitment
         let r_comm = self.compute_linearisation_commitment(
-            verifier_key.g,
-            alpha,
-            beta,
-            gamma,
-            z_challenge,
-            l1_eval,
+            &verifier_key.g,
+            &alpha,
+            &beta,
+            &gamma,
+            &z_challenge,
+            &l1_eval,
             &preprocessed_circuit,
         );
 
@@ -215,12 +215,12 @@ impl Proof {
         &self,
         domain: &EvaluationDomain,
         pub_inputs: &[Scalar],
-        alpha: Scalar,
-        beta: Scalar,
-        gamma: Scalar,
-        z_challenge: Scalar,
-        l1_eval: Scalar,
-        z_hat_eval: Scalar,
+        alpha: &Scalar,
+        beta: &Scalar,
+        gamma: &Scalar,
+        z_challenge: &Scalar,
+        l1_eval: &Scalar,
+        z_hat_eval: &Scalar,
     ) -> Scalar {
         // Compute zero polynomial evaluated at `z_challenge`
         let z_h_eval = domain.evaluate_vanishing_polynomial(z_challenge);
@@ -230,32 +230,32 @@ impl Proof {
         let pi_eval = pi_poly.evaluate(&z_challenge);
 
         let alpha_sq = alpha.square();
-        let alpha_cu = alpha_sq * &alpha;
+        let alpha_cu = alpha_sq * alpha;
 
         // r + PI(z) * alpha
-        let a = self.evaluations.lin_poly_eval + &(pi_eval * &alpha);
+        let a = self.evaluations.lin_poly_eval + (pi_eval * alpha);
 
         // a + beta * sigma_1 + gamma
-        let beta_sig1 = beta * &self.evaluations.left_sigma_eval;
-        let b_0 = self.evaluations.a_eval + &beta_sig1 + &gamma;
+        let beta_sig1 = beta * self.evaluations.left_sigma_eval;
+        let b_0 = self.evaluations.a_eval + beta_sig1 + gamma;
 
         // b+ beta * sigma_2 + gamma
-        let beta_sig2 = beta * &self.evaluations.right_sigma_eval;
-        let b_1 = self.evaluations.b_eval + &beta_sig2 + &gamma;
+        let beta_sig2 = beta * self.evaluations.right_sigma_eval;
+        let b_1 = self.evaluations.b_eval + beta_sig2 + gamma;
 
         // c+ beta * sigma_3 + gamma
-        let beta_sig3 = beta * &self.evaluations.out_sigma_eval;
-        let b_2 = self.evaluations.c_eval + &beta_sig3 + &gamma;
+        let beta_sig3 = beta * self.evaluations.out_sigma_eval;
+        let b_2 = self.evaluations.c_eval + beta_sig3 + gamma;
 
         // ((d + gamma) * z_hat) * alpha^2
-        let b_3 = (self.evaluations.d_eval + &gamma) * &z_hat_eval * &alpha_sq;
+        let b_3 = (self.evaluations.d_eval + gamma) * z_hat_eval * alpha_sq;
 
         let b = b_0 * b_1 * b_2 * b_3;
 
         // l_1(z) * alpha^3
-        let c = l1_eval * &alpha_cu;
+        let c = l1_eval * alpha_cu;
 
-        let t_eval = (a - &b - &c) * &z_h_eval.invert().unwrap();
+        let t_eval = (a - b - c) * z_h_eval.invert().unwrap();
 
         t_eval
     }
@@ -274,12 +274,12 @@ impl Proof {
     // Commitment to [r]_1
     fn compute_linearisation_commitment(
         &self,
-        g: G1Affine,
-        alpha: Scalar,
-        beta: Scalar,
-        gamma: Scalar,
-        z_challenge: Scalar,
-        l1_eval: Scalar,
+        g: &G1Affine,
+        alpha: &Scalar,
+        beta: &Scalar,
+        gamma: &Scalar,
+        z_challenge: &Scalar,
+        l1_eval: &Scalar,
         preprocessed_circuit: &PreProcessedCircuit,
     ) -> Commitment {
         let mut scalars: Vec<_> = Vec::with_capacity(6);
@@ -288,59 +288,59 @@ impl Proof {
         let alpha_sq = alpha * alpha;
         let alpha_cu = alpha_sq * alpha;
 
-        scalars.push(self.evaluations.a_eval * &self.evaluations.b_eval * &alpha);
+        scalars.push(self.evaluations.a_eval * self.evaluations.b_eval * alpha);
         points.push(preprocessed_circuit.qm_comm().0);
 
-        scalars.push(self.evaluations.a_eval * &alpha);
+        scalars.push(self.evaluations.a_eval * alpha);
         points.push(preprocessed_circuit.ql_comm().0);
 
-        scalars.push(self.evaluations.b_eval * &alpha);
+        scalars.push(self.evaluations.b_eval * alpha);
         points.push(preprocessed_circuit.qr_comm().0);
 
-        scalars.push(self.evaluations.c_eval * &alpha);
+        scalars.push(self.evaluations.c_eval * alpha);
         points.push(preprocessed_circuit.qo_comm().0);
 
         scalars.push(self.evaluations.d_eval * alpha);
-        points.push(g);
+        points.push(*g);
 
-        scalars.push(alpha);
+        scalars.push(*alpha);
         points.push(preprocessed_circuit.qc_comm().0);
 
         // (a_eval + beta * z + gamma)(b_eval + beta * z * k1 + gamma)(c_eval + beta * k2* z + gamma)(d_eval + beta * k3* z + gamma) * alpha^2
         let x = {
-            let beta_z = beta * &z_challenge;
-            let q_0 = self.evaluations.a_eval + &beta_z + &gamma;
+            let beta_z = beta * z_challenge;
+            let q_0 = self.evaluations.a_eval + beta_z + gamma;
 
-            let beta_k1_z = beta * &K1 * &z_challenge;
-            let q_1 = self.evaluations.b_eval + &beta_k1_z + &gamma;
+            let beta_k1_z = beta * K1 * z_challenge;
+            let q_1 = self.evaluations.b_eval + beta_k1_z + gamma;
 
-            let beta_k2_z = beta * &K2 * &z_challenge;
-            let q_2 = self.evaluations.c_eval + &beta_k2_z + &gamma;
+            let beta_k2_z = beta * K2 * z_challenge;
+            let q_2 = self.evaluations.c_eval + beta_k2_z + gamma;
 
-            let beta_k3_z = beta * &K3 * &z_challenge;
-            let q_3 = (self.evaluations.d_eval + &beta_k3_z + &gamma) * alpha_sq;
+            let beta_k3_z = beta * K3 * z_challenge;
+            let q_3 = (self.evaluations.d_eval + beta_k3_z + gamma) * alpha_sq;
 
-            q_0 * &q_1 * &q_2 * &q_3
+            q_0 * q_1 * q_2 * q_3
         };
 
         // l1(z) * alpha^3
         let r = l1_eval * alpha_cu;
 
-        scalars.push(x + &r);
+        scalars.push(x + r);
         points.push(self.z_comm.0);
 
         // -(a_eval + beta * sigma_1_eval + gamma)(b_eval + beta * sigma_2_eval + gamma)(c_eval + beta * sigma_3_eval + gamma) *alpha^2
         let y = {
-            let beta_sigma_1 = beta * &self.evaluations.left_sigma_eval;
-            let q_0 = self.evaluations.a_eval + &beta_sigma_1 + &gamma;
+            let beta_sigma_1 = beta * self.evaluations.left_sigma_eval;
+            let q_0 = self.evaluations.a_eval + beta_sigma_1 + gamma;
 
-            let beta_sigma_2 = beta * &self.evaluations.right_sigma_eval;
-            let q_1 = self.evaluations.b_eval + &beta_sigma_2 + &gamma;
+            let beta_sigma_2 = beta * self.evaluations.right_sigma_eval;
+            let q_1 = self.evaluations.b_eval + beta_sigma_2 + gamma;
 
-            let beta_sigma_3 = beta * &self.evaluations.out_sigma_eval;
-            let q_2 = self.evaluations.c_eval + &beta_sigma_3 + &gamma;
+            let beta_sigma_3 = beta * self.evaluations.out_sigma_eval;
+            let q_2 = self.evaluations.c_eval + beta_sigma_3 + gamma;
 
-            let q_3 = beta * &self.evaluations.perm_eval * &alpha * &alpha;
+            let q_3 = beta * self.evaluations.perm_eval * alpha * alpha;
 
             -(q_0 * q_1 * q_2 * q_3)
         };

--- a/src/fft/domain.rs
+++ b/src/fft/domain.rs
@@ -178,7 +178,7 @@ impl EvaluationDomain {
         } else {
             use crate::util::batch_inversion;
 
-            let mut l = (t_size - &one) * &self.size_inv;
+            let mut l = (t_size - one) * self.size_inv;
             let mut r = one;
             let mut u = vec![Scalar::zero(); size];
             let mut ls = vec![Scalar::zero(); size];
@@ -202,8 +202,8 @@ impl EvaluationDomain {
     /// This evaluates the vanishing polynomial for this domain at tau.
     /// For multiplicative subgroups, this polynomial is `z(X) = X^self.size -
     /// 1`.
-    pub fn evaluate_vanishing_polynomial(&self, tau: Scalar) -> Scalar {
-        tau.pow(&[self.size, 0, 0, 0]) - &Scalar::one()
+    pub fn evaluate_vanishing_polynomial(&self, tau: &Scalar) -> Scalar {
+        tau.pow(&[self.size, 0, 0, 0]) - Scalar::one()
     }
 
     /// Given that the domain size is `D`  
@@ -218,8 +218,7 @@ impl EvaluationDomain {
         let v_h: Vec<_> = (0..self.size())
             .into_iter()
             .map(|i| {
-                (coset_gen * self.group_gen.pow(&[poly_degree * i as u64, 0, 0, 0]))
-                    - &Scalar::one()
+                (coset_gen * self.group_gen.pow(&[poly_degree * i as u64, 0, 0, 0])) - Scalar::one()
             })
             .collect();
         Evaluations::from_vec_and_domain(v_h, self.clone())
@@ -239,7 +238,7 @@ impl EvaluationDomain {
     /// a coset.
     pub fn divide_by_vanishing_poly_on_coset_in_place(&self, evals: &mut [Scalar]) {
         let i = self
-            .evaluate_vanishing_polynomial(GENERATOR)
+            .evaluate_vanishing_polynomial(&GENERATOR)
             .invert()
             .unwrap();
 

--- a/src/fft/polynomial.rs
+++ b/src/fft/polynomial.rs
@@ -35,7 +35,7 @@ impl Polynomial {
 
     /// Checks if the given polynomial is zero.
     pub fn is_zero(&self) -> bool {
-        self.coeffs.is_empty() || self.coeffs.iter().all(|coeff| coeff == &Scalar::zero())
+        self.coeffs.is_empty() || self.coeffs.par_iter().all(|coeff| coeff == &Scalar::zero())
     }
 
     /// Constructs a new polynomial from a list of coefficients.

--- a/src/permutation/grand_product_lineariser.rs
+++ b/src/permutation/grand_product_lineariser.rs
@@ -5,87 +5,87 @@ use bls12_381::Scalar;
 // XXX: We need better names for these functions
 /// Computes the semi evaluted Identity permutation polynomial component of the grand product
 pub fn compute_identity_polynomial(
-    a_eval: Scalar,
-    b_eval: Scalar,
-    c_eval: Scalar,
-    d_eval: Scalar,
-    z_challenge: Scalar,
-    alpha_sq: Scalar,
-    beta: Scalar,
-    gamma: Scalar,
+    a_eval: &Scalar,
+    b_eval: &Scalar,
+    c_eval: &Scalar,
+    d_eval: &Scalar,
+    z_challenge: &Scalar,
+    alpha_sq: &Scalar,
+    beta: &Scalar,
+    gamma: &Scalar,
     z_poly: &Polynomial,
 ) -> Polynomial {
-    let beta_z = beta * &z_challenge;
+    let beta_z = beta * z_challenge;
 
     // a_eval + beta * z_challenge + gamma
-    let mut a_0 = a_eval + &beta_z;
-    a_0 += &gamma;
+    let mut a_0 = a_eval + beta_z;
+    a_0 += gamma;
 
     // b_eval + beta * K1 * z_challenge + gamma
-    let beta_z_K1 = K1 * &beta_z;
-    let mut a_1 = b_eval + &beta_z_K1;
-    a_1 += &gamma;
+    let beta_z_K1 = K1 * beta_z;
+    let mut a_1 = b_eval + beta_z_K1;
+    a_1 += gamma;
 
     // c_eval + beta * K2 * z_challenge + gamma
-    let beta_z_K2 = K2 * &beta_z;
-    let mut a_2 = c_eval + &beta_z_K2;
-    a_2 += &gamma;
+    let beta_z_K2 = K2 * beta_z;
+    let mut a_2 = c_eval + beta_z_K2;
+    a_2 += gamma;
 
     // d_eval + beta * K3 * z_challenge + gamma
-    let beta_z_K3 = K3 * &beta_z;
-    let mut a_3 = d_eval + &beta_z_K3;
-    a_3 += &gamma;
+    let beta_z_K3 = K3 * beta_z;
+    let mut a_3 = d_eval + beta_z_K3;
+    a_3 += gamma;
 
-    let mut a = a_0 * &a_1;
-    a = a * &a_2;
-    a = a * &a_3;
-    a = a * &alpha_sq; // (a_eval + beta * z_challenge + gamma)(b_eval + beta * K1 * z_challenge + gamma)(c_eval + beta * K2 * z_challenge + gamma)(d_eval + beta * K3 * z_challenge + gamma) * alpha^2
+    let mut a = a_0 * a_1;
+    a = a * a_2;
+    a = a * a_3;
+    a = a * alpha_sq; // (a_eval + beta * z_challenge + gamma)(b_eval + beta * K1 * z_challenge + gamma)(c_eval + beta * K2 * z_challenge + gamma)(d_eval + beta * K3 * z_challenge + gamma) * alpha^2
 
     z_poly * &a // (a_eval + beta * z_challenge + gamma)(b_eval + beta * K1 * z_challenge + gamma)(c_eval + beta * K2 * z_challenge + gamma) * alpha^2 z(X)
 }
 
 /// Computes the semi-evaluated Copy permutation polynomial component of the grand product
 pub fn compute_copy_polynomial(
-    (a_eval, b_eval, c_eval): (Scalar, Scalar, Scalar),
-    z_eval: Scalar,
-    sigma_1_eval: Scalar,
-    sigma_2_eval: Scalar,
-    sigma_3_eval: Scalar,
-    (alpha_sq, beta, gamma): (Scalar, Scalar, Scalar),
+    (a_eval, b_eval, c_eval): &(Scalar, Scalar, Scalar),
+    z_eval: &Scalar,
+    sigma_1_eval: &Scalar,
+    sigma_2_eval: &Scalar,
+    sigma_3_eval: &Scalar,
+    (alpha_sq, beta, gamma): &(Scalar, Scalar, Scalar),
     fourth_sigma_poly: &Polynomial,
 ) -> Polynomial {
     // a_eval + beta * sigma_1 + gamma
-    let beta_sigma_1 = beta * &sigma_1_eval;
-    let mut a_0 = a_eval + &beta_sigma_1;
-    a_0 += &gamma;
+    let beta_sigma_1 = beta * sigma_1_eval;
+    let mut a_0 = a_eval + beta_sigma_1;
+    a_0 += gamma;
 
     // b_eval + beta * sigma_2 + gamma
-    let beta_sigma_2 = beta * &sigma_2_eval;
-    let mut a_1 = b_eval + &beta_sigma_2;
-    a_1 += &gamma;
+    let beta_sigma_2 = beta * sigma_2_eval;
+    let mut a_1 = b_eval + beta_sigma_2;
+    a_1 += gamma;
 
     // c_eval + beta * sigma_3 + gamma
-    let beta_sigma_3 = beta * &sigma_3_eval;
-    let mut a_2 = c_eval + &beta_sigma_3;
-    a_2 += &gamma;
+    let beta_sigma_3 = beta * sigma_3_eval;
+    let mut a_2 = c_eval + beta_sigma_3;
+    a_2 += gamma;
 
-    let beta_z_eval = beta * &z_eval;
+    let beta_z_eval = beta * z_eval;
 
     let mut a = a_0 * a_1 * a_2;
-    a = a * &beta_z_eval;
-    a = a * &alpha_sq; // (a_eval + beta * sigma_1 + gamma)(b_eval + beta * sigma_2 + gamma)(c_eval + beta * sigma_3 + gamma) * beta *z_eval * alpha^2
+    a = a * beta_z_eval;
+    a = a * alpha_sq; // (a_eval + beta * sigma_1 + gamma)(b_eval + beta * sigma_2 + gamma)(c_eval + beta * sigma_3 + gamma) * beta *z_eval * alpha^2
 
     fourth_sigma_poly * &-a // -(a_eval + beta * sigma_1 + gamma)(b_eval + beta * sigma_2 + gamma) (c_eval + beta * sigma_3 + gamma) * beta *z_eval * alpha^2 * Sigma_4(X)
 }
 /// Computes the semi-evaluated check that the first L_1(w^1) = 1
 pub fn compute_is_one_polynomial(
     domain: &EvaluationDomain,
-    z_challenge: Scalar,
-    alpha_cu: Scalar,
+    z_challenge: &Scalar,
+    alpha_cu: &Scalar,
     z_coeffs: &Polynomial,
 ) -> Polynomial {
     // Evaluate l_1(z)
-    let l_1_z = domain.evaluate_all_lagrange_coefficients(z_challenge)[0];
+    let l_1_z = domain.evaluate_all_lagrange_coefficients(*z_challenge)[0];
 
     z_coeffs * &(l_1_z * alpha_cu)
 }
@@ -111,14 +111,14 @@ mod test {
         let z_poly = Polynomial::rand(10, &mut rand::thread_rng());
 
         let got_poly = compute_identity_polynomial(
-            a_eval,
-            b_eval,
-            c_eval,
-            d_eval,
-            z_challenge,
-            alpha,
-            beta,
-            gamma,
+            &a_eval,
+            &b_eval,
+            &c_eval,
+            &d_eval,
+            &z_challenge,
+            &alpha,
+            &beta,
+            &gamma,
             &z_poly,
         );
 
@@ -151,12 +151,12 @@ mod test {
         let sig4_poly = Polynomial::rand(10, &mut rand::thread_rng());
 
         let got_poly = compute_copy_polynomial(
-            (a_eval, b_eval, c_eval),
-            z_eval,
-            sig1_eval,
-            sig2_eval,
-            sig3_eval,
-            (alpha, beta, gamma),
+            &(a_eval, b_eval, c_eval),
+            &z_eval,
+            &sig1_eval,
+            &sig2_eval,
+            &sig3_eval,
+            &(alpha, beta, gamma),
             &sig4_poly,
         );
 
@@ -179,7 +179,7 @@ mod test {
         let domain = EvaluationDomain::new(10).unwrap();
         let z_poly = Polynomial::rand(10, &mut rand::thread_rng());
 
-        let got_poly = compute_is_one_polynomial(&domain, z_challenge, alpha, &z_poly);
+        let got_poly = compute_is_one_polynomial(&domain, &z_challenge, &alpha, &z_poly);
 
         let l1_eval = domain.evaluate_all_lagrange_coefficients(z_challenge)[0];
         let l1_eval_poly = Polynomial::from_coefficients_vec(vec![l1_eval]);

--- a/src/permutation/grand_product_quotient.rs
+++ b/src/permutation/grand_product_quotient.rs
@@ -108,7 +108,7 @@ pub fn compute_copy_polynomial(
         .map(|i| {
             let z_shifted = &z_eval_4n[i + 4];
 
-            let mut product = a_fft[i] * &b_fft[i] * &c_fft[i] * &d_fft[i]; // (a(x) + beta * Sigma1(X) + gamma) (b(X) + beta * Sigma2(X) + gamma) (c(X) + beta * Sigma3(X) + gamma)(d(X) + beta * Sigma4(X) + gamma)
+            let mut product = a_fft[i] * b_fft[i] * c_fft[i] * d_fft[i]; // (a(x) + beta * Sigma1(X) + gamma) (b(X) + beta * Sigma2(X) + gamma) (c(X) + beta * Sigma3(X) + gamma)(d(X) + beta * Sigma4(X) + gamma)
             product = product * z_shifted;
 
             -product * alpha_sq // (a(x) + beta* Sigma1(X) + gamma) (b(X) + beta * Sigma2(X) + gamma) (c(X) + beta * Sigma3(X) + gamma)(d(X) + beta * Sigma4(X) + gamma) Z(X.omega) * alpha^2
@@ -131,14 +131,14 @@ pub fn compute_is_one_polynomial(
 
     // (Z(x) - 1)
     let mut z_coeffs = z_poly.to_vec();
-    z_coeffs[0] = z_coeffs[0] - &Scalar::one();
+    z_coeffs[0] = z_coeffs[0] - Scalar::one();
 
     let z_evals = domain_4n.coset_fft(&z_coeffs);
     let alpha_cu_l1_evals = domain_4n.coset_fft(&alpha_cu_l1_poly.coeffs);
 
     let t_4: Vec<_> = (0..domain_4n.size())
         .into_par_iter()
-        .map(|i| alpha_cu_l1_evals[i] * &z_evals[i])
+        .map(|i| alpha_cu_l1_evals[i] * z_evals[i])
         .collect();
     Evaluations::from_vec_and_domain(t_4, domain_4n)
 }

--- a/src/permutation/permutation.rs
+++ b/src/permutation/permutation.rs
@@ -235,13 +235,13 @@ impl Permutation {
         let beta_roots_iter = domain.elements().map(|root| root * beta);
 
         // Compute beta * roots * K1
-        let beta_roots_K1_iter = domain.elements().map(|root| (K1 * beta) * &root);
+        let beta_roots_K1_iter = domain.elements().map(|root| K1 * beta * root);
 
         // Compute beta * roots * K2
-        let beta_roots_K2_iter = domain.elements().map(|root| (K2 * beta) * &root);
+        let beta_roots_K2_iter = domain.elements().map(|root| K2 * beta * root);
 
         // Compute beta * roots * K3
-        let beta_roots_K3_iter = domain.elements().map(|root| (K3 * beta) * &root);
+        let beta_roots_K3_iter = domain.elements().map(|root| K3 * beta * root);
 
         // Compute left_wire + gamma
         let wL_gamma: Vec<_> = w_l.map(|w| w + gamma).collect();
@@ -327,16 +327,16 @@ impl Permutation {
             beta_fourth_sigma_iter,
         ) {
             // (w_L + beta * root + gamma)
-            let prod_a = beta_left_sigma + &w_l_gamma;
+            let prod_a = beta_left_sigma + w_l_gamma;
 
             // (w_R + beta * root * k_1 + gamma)
-            let prod_b = beta_right_sigma + &w_r_gamma;
+            let prod_b = beta_right_sigma + w_r_gamma;
 
             // (w_O + beta * root * k_2 + gamma)
-            let prod_c = beta_out_sigma + &w_o_gamma;
+            let prod_c = beta_out_sigma + w_o_gamma;
 
             // (w_4 + beta * root * k_3 + gamma)
-            let prod_d = beta_fourth_sigma + &w_4_gamma;
+            let prod_d = beta_fourth_sigma + w_4_gamma;
 
             let mut prod = prod_a * prod_b * prod_c * prod_d;
 
@@ -474,28 +474,28 @@ impl Permutation {
                     beta_fourth_sigma,
                 )| {
                     // w_j + beta * root^j-1 + gamma
-                    let ac1 = w_l_gamma + &beta_root;
+                    let ac1 = w_l_gamma + beta_root;
 
                     // w_{n+j} + beta * K1 * root^j-1 + gamma
-                    let ac2 = w_r_gamma + &beta_root_K1;
+                    let ac2 = w_r_gamma + beta_root_K1;
 
                     // w_{2n+j} + beta * K2 * root^j-1 + gamma
-                    let ac3 = w_o_gamma + &beta_root_K2;
+                    let ac3 = w_o_gamma + beta_root_K2;
 
                     // w_{3n+j} + beta * K3 * root^j-1 + gamma
-                    let ac4 = w_4_gamma + &beta_root_K3;
+                    let ac4 = w_4_gamma + beta_root_K3;
 
                     // 1 / w_j + beta * sigma(j) + gamma
-                    let ac5 = (w_l_gamma + &beta_left_sigma).invert().unwrap();
+                    let ac5 = (w_l_gamma + beta_left_sigma).invert().unwrap();
 
                     // 1 / w_{n+j} + beta * sigma(n+j) + gamma
-                    let ac6 = (w_r_gamma + &beta_right_sigma).invert().unwrap();
+                    let ac6 = (w_r_gamma + beta_right_sigma).invert().unwrap();
 
                     // 1 / w_{2n+j} + beta * sigma(2n+j) + gamma
-                    let ac7 = (w_o_gamma + &beta_out_sigma).invert().unwrap();
+                    let ac7 = (w_o_gamma + beta_out_sigma).invert().unwrap();
 
                     // 1 / w_{3n+j} + beta * sigma(3n+j) + gamma
-                    let ac8 = (w_4_gamma + &beta_fourth_sigma).invert().unwrap();
+                    let ac8 = (w_4_gamma + beta_fourth_sigma).invert().unwrap();
 
                     (ac1, ac2, ac3, ac4, ac5, ac6, ac7, ac8)
                 },
@@ -532,14 +532,14 @@ impl Permutation {
         );
         let product_acumulated_components: Vec<_> = accumulator_components
             .map(move |current_component| {
-                prev.0 *= &current_component.0;
-                prev.1 *= &current_component.1;
-                prev.2 *= &current_component.2;
-                prev.3 *= &current_component.3;
-                prev.4 *= &current_component.4;
-                prev.5 *= &current_component.5;
-                prev.6 *= &current_component.6;
-                prev.7 *= &current_component.7;
+                prev.0 *= current_component.0;
+                prev.1 *= current_component.1;
+                prev.2 *= current_component.2;
+                prev.3 *= current_component.3;
+                prev.4 *= current_component.4;
+                prev.5 *= current_component.5;
+                prev.6 *= current_component.6;
+                prev.7 *= current_component.7;
 
                 prev
             })
@@ -557,14 +557,14 @@ impl Permutation {
             .par_iter()
             .map(move |current_component| {
                 let mut prev = Scalar::one();
-                prev *= &current_component.0;
-                prev *= &current_component.1;
-                prev *= &current_component.2;
-                prev *= &current_component.3;
-                prev *= &current_component.4;
-                prev *= &current_component.5;
-                prev *= &current_component.6;
-                prev *= &current_component.7;
+                prev *= current_component.0;
+                prev *= current_component.1;
+                prev *= current_component.2;
+                prev *= current_component.3;
+                prev *= current_component.4;
+                prev *= current_component.5;
+                prev *= current_component.6;
+                prev *= current_component.7;
 
                 prev
             })


### PR DESCRIPTION
Closes #111 and fixes some docs nitpicks.

This also forces all of the `Scalar` sent as params to functions to be `&Scalar` so we don't force the copy always.

Enables also the usage of `par_iter` in places where it was not being used.