### PR TITLE
Cleans up Commitment Scheme Module

### DIFF
--- a/src/commitment_scheme/kzg10/errors.rs
+++ b/src/commitment_scheme/kzg10/errors.rs
@@ -1,22 +1,22 @@
 //! Errors related to KZG10
 
-// Represents an error in SRS creation and or modification
+/// Represents an error in SRS creation and or modification.
 #[derive(Fail, Debug)]
 pub enum Error {
-    // This error occurs when the user tries to create an SRS and supplies the max degree as zero
+    /// This error occurs when the user tries to create an SRS and supplies the max degree as zero.
     #[fail(display = "cannot create an srs with max degree as 0")]
     DegreeIsZero,
-    // This error occurs when the user tries to trim an srs down to a degree that is larger than the maximum degree
+    /// This error occurs when the user tries to trim an srs to a degree that is larger than the maximum degree.
     #[fail(display = "cannot trim more than the maximum degree")]
     TruncatedDegreeTooLarge,
-    // This error occurs when the user tries to trim an srs down to a degree that is zero
+    /// This error occurs when the user tries to trim an srs down to a degree that is zero.
     #[fail(display = "cannot trim srs to a maximum size of zero")]
     TruncatedDegreeIsZero,
-    // This error occurs when the user tries to commit to a polynomial whose degree is larger than
-    // the supported degree for that proving key
+    /// This error occurs when the user tries to commit to a polynomial whose degree is larger than
+    /// the supported degree for that proving key.
     #[fail(display = "proving key is not large enough to commit to said polynomial")]
     PolynomialDegreeTooLarge,
-    // This error occurs when the user tries to commit to a polynomial whose degree is zero
+    /// This error occurs when the user tries to commit to a polynomial whose degree is zero.
     #[fail(display = "cannot commit to polynomial of zero degree")]
     PolynomialDegreeIsZero,
 }

--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -1,5 +1,5 @@
 use super::{errors::Error, AggregateProof, Commitment, Proof};
-use crate::{fft::Polynomial, transcript::TranscriptProtocol, util::powers_of};
+use crate::{fft::Polynomial, transcript::TranscriptProtocol, util};
 use bls12_381::{
     multiscalar_mul::msm_variable_base, G1Affine, G1Projective, G2Affine, G2Prepared, Scalar,
 };
@@ -92,7 +92,7 @@ impl ProverKey {
         transcript: &mut dyn TranscriptProtocol,
     ) -> Polynomial {
         let challenge = transcript.challenge_scalar(b"aggregate_witness");
-        let powers = powers_of(&challenge, polynomials.len() - 1);
+        let powers = util::powers_of(&challenge, polynomials.len() - 1);
 
         assert_eq!(powers.len(), polynomials.len());
 
@@ -182,7 +182,7 @@ impl VerifierKey {
         let mut total_w = G1Projective::identity();
 
         let challenge = transcript.challenge_scalar(b"batch"); // XXX: Verifier can add their own randomness at this point
-        let powers = powers_of(&challenge, proofs.len() - 1);
+        let powers = util::powers_of(&challenge, proofs.len() - 1);
         // Instead of multiplying g and gamma_g in each turn, we simply accumulate
         // their coefficients and perform a final multiplication at the end.
         let mut g_multiplier = Scalar::zero();

--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -137,7 +137,7 @@ impl ProverKey {
             polynomial_commitments.push(self.commit(poly)?)
         }
 
-        // Compute the aggregate Witness for polynomials
+        // Compute the aggregate witness for polynomials
         let witness_poly = self.compute_aggregate_witness(polynomials, point, transcript);
 
         // Commit to witness polynomial
@@ -211,7 +211,7 @@ impl VerifierKey {
     }
 }
 
-/// Check whether the polynomial we are committing to:
+/// Checks whether the polynomial we are committing to:
 /// - has zero degree
 /// - has a degree which is more than the max supported degree
 /// Returns an error if any of the above conditions are true.

--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -232,7 +232,7 @@ mod test {
 
     // Creates a proving key and verifier key based on a specified degree
     fn setup_test(degree: usize) -> (ProverKey, VerifierKey) {
-        let srs = SRS::setup(degree, &mut rand::thread_rng()).unwrap();
+        let srs = PublicParameters::setup(degree, &mut rand::thread_rng()).unwrap();
         srs.trim(degree).unwrap()
     }
     #[test]

--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -1,15 +1,10 @@
-use super::errors::Error;
-use super::Commitment;
-use super::{AggregateProof, Proof};
-use crate::fft::Polynomial;
-use crate::transcript::TranscriptProtocol;
-use crate::util::powers_of;
-
+use super::{errors::Error, AggregateProof, Commitment, Proof};
+use crate::{fft::Polynomial, transcript::TranscriptProtocol, util::powers_of};
 use bls12_381::{
     multiscalar_mul::msm_variable_base, G1Affine, G1Projective, G2Affine, G2Prepared, Scalar,
 };
 
-/// Verifier Key is used to verify claims made about a committed polynomial
+/// Verifier Key is used to verify claims made about a committed polynomial.
 #[derive(Clone, Debug)]
 pub struct VerifierKey {
     /// The generator of G1.
@@ -24,21 +19,22 @@ pub struct VerifierKey {
     pub prepared_beta_h: G2Prepared,
 }
 
-/// Prover key is used to commit to a polynomial which is bounded by the max_degree parameter
-/// specified when building the SRS
+/// Prover key is used to commit to a polynomial which is bounded by the max_degree.
 pub struct ProverKey {
     /// Group elements of the form `{ \beta^i G }`, where `i` ranges from 0 to `degree`.
     pub powers_of_g: Vec<G1Affine>,
 }
 
 impl ProverKey {
-    /// Returns the maximum degree polynomial that you can commit to
-    pub(crate) fn max_degree(&self) -> usize {
+    /// Returns the maximum degree polynomial that you can commit to.
+    pub fn max_degree(&self) -> usize {
         self.powers_of_g.len() - 1
     }
 
-    /// Truncates the prover key to a new max degree
-    pub(crate) fn truncate(&self, mut truncated_degree: usize) -> Result<ProverKey, Error> {
+    /// Truncates the prover key to a lower max degree.
+    /// Returns an error if the truncated degree is zero or if the truncated degree
+    /// is larger than the max degree of the prover key.
+    pub fn truncate(&self, mut truncated_degree: usize) -> Result<ProverKey, Error> {
         if truncated_degree == 1 {
             truncated_degree += 1;
         }
@@ -63,7 +59,8 @@ impl ProverKey {
         check_degree_is_within_bounds(self.max_degree(), poly_degree)
     }
 
-    /// Commits to a polynomial bounded by the max degree of the Prover key
+    /// Commits to a polynomial.
+    /// Returns an error if the polynomial's degree is more than the max degree of the prover key.
     pub fn commit(&self, polynomial: &Polynomial) -> Result<Commitment, Error> {
         // Check whether we can safely commit to this polynomial
         self.check_commit_degree_is_within_bounds(polynomial.degree())?;
@@ -73,21 +70,21 @@ impl ProverKey {
         Ok(Commitment::from_projective(commitment))
     }
 
-    /// For a given commitment to a polynomial
-    /// Computes a witness that the polynomial was evaluated at the point `z`
-    /// And its output was p(z)
-    /// Witness is computed as f(x) - f(z) / x-z however since the witness is the quotient polynomial
-    /// it is invariant under f(z) . We can therefore compute the witness polynomial as
-    /// f(x) / x - z
+    /// For a given polynomial `p` and a point `z`, compute the witness
+    /// for p(z) using Ruffini's method for simplicity.
+    /// The Witness is the quotient of f(x) - f(z) / x-z.
+    /// However we note that the quotient polynomial is invariant under the value f(z)
+    /// ie. only the remainder changes. we can therefore compute the witness as f(x) / x - z
+    /// and only use the remainder term f(z) during verification.
     pub fn compute_single_witness(&self, polynomial: &Polynomial, point: &Scalar) -> Polynomial {
-        // Compute witness for regular polynomial
+        // Computes f(x) / x-z
         let witness_poly = polynomial.ruffini(*point);
         witness_poly
     }
 
-    /// Allows you to compute a witness for multiple polynomials at the same point
-    /// We apply the same optimisation mentioned in `compute_single` by removing f(z) from
-    /// the computation of the witness
+    /// Computes a single witness for multiple polynomials at the same point, by taking
+    /// a random linear combination of the individual witnesses.
+    /// We apply the same optimisation mentioned in when computing each witness; removing f(z).
     pub(crate) fn compute_aggregate_witness(
         &self,
         polynomials: &[Polynomial],
@@ -108,6 +105,9 @@ impl ProverKey {
         witness_poly
     }
 
+    /// Creates an opening proof that a polynomial `p` was correctly evaluated at p(z) and produced the value
+    /// `v`. ie v = p(z).
+    /// Returns an error if the polynomials degree is too large.
     pub fn open_single(
         &self,
         polynomial: &Polynomial,
@@ -121,7 +121,9 @@ impl ProverKey {
             commitment_to_polynomial: self.commit(polynomial)?,
         })
     }
-    // Creates a proof that multiple polynomials were evaluated at the same point
+    /// Creates an opening proof that multiple polynomials were evaluated at the same point
+    /// and that each evaluation produced the correct evaluation point.
+    /// Returns an error if any of the polynomial's degrees are too large.
     pub fn open_multiple(
         &self,
         polynomials: &[Polynomial],
@@ -129,7 +131,6 @@ impl ProverKey {
         point: &Scalar,
         transcript: &mut dyn TranscriptProtocol,
     ) -> Result<AggregateProof, Error> {
-        //
         // Commit to polynomials
         let mut polynomial_commitments = Vec::with_capacity(polynomials.len());
         for poly in polynomials.iter() {
@@ -137,11 +138,9 @@ impl ProverKey {
         }
 
         // Compute the aggregate Witness for polynomials
-        //
         let witness_poly = self.compute_aggregate_witness(polynomials, point, transcript);
 
         // Commit to witness polynomial
-        //
         let witness_commitment = self.commit(&witness_poly)?;
 
         let aggregate_proof = AggregateProof {
@@ -154,20 +153,25 @@ impl ProverKey {
 }
 
 impl VerifierKey {
-    // XXX: refactor this to use one pairing
-    // Checks that single polynomial was evaluated at a specified point and returns the value specified.
+    /// Checks that a polynomial `p` was evaluated at a point `z` and returned the value specified `v`.
+    /// ie. v = p(z).
     pub fn check(&self, point: Scalar, proof: Proof) -> bool {
-        use bls12_381::pairing;
-        let inner: G1Affine =
+        let inner_a: G1Affine =
             (proof.commitment_to_polynomial.0 - (self.g * proof.evaluated_point)).into();
-        let lhs = pairing(&inner, &self.h);
 
-        let inner: G2Affine = (self.beta_h - (self.h * point)).into();
-        let rhs = pairing(&proof.commitment_to_witness.0, &inner);
+        let inner_b: G2Affine = (self.beta_h - (self.h * point)).into();
+        let prepared_inner_b = G2Prepared::from(-inner_b);
 
-        lhs == rhs
+        let pairing = bls12_381::multi_miller_loop(&[
+            (&inner_a, &self.prepared_h),
+            (&proof.commitment_to_witness.0, &prepared_inner_b),
+        ])
+        .final_exponentiation();
+
+        pairing == bls12_381::Gt::identity()
     }
 
+    /// Checks whether a batch of polynomials evaluated at different points, returned their specified value.
     pub fn batch_check(
         &self,
         points: &[Scalar],
@@ -207,9 +211,10 @@ impl VerifierKey {
     }
 }
 
-// Check whether the polynomial we are committing to:
-// - has zero degree
-// - has a degree which is more than the max supported degree
+/// Check whether the polynomial we are committing to:
+/// - has zero degree
+/// - has a degree which is more than the max supported degree
+/// Returns an error if any of the above conditions are true.
 fn check_degree_is_within_bounds(max_degree: usize, poly_degree: usize) -> Result<(), Error> {
     if poly_degree == 0 {
         return Err(Error::PolynomialDegreeIsZero);
@@ -219,36 +224,39 @@ fn check_degree_is_within_bounds(max_degree: usize, poly_degree: usize) -> Resul
     }
     Ok(())
 }
-
+#[cfg(test)]
 mod test {
     use super::super::srs::*;
     use super::*;
     use merlin::Transcript;
 
+    // Creates a proving key and verifier key based on a specified degree
+    fn setup_test(degree: usize) -> (ProverKey, VerifierKey) {
+        let srs = SRS::setup(degree, &mut rand::thread_rng()).unwrap();
+        srs.trim(degree).unwrap()
+    }
     #[test]
     fn test_basic_commit() {
         let degree = 25;
-        let srs = SRS::setup(degree, &mut rand::thread_rng()).unwrap();
-        let (proving_key, vk) = srs.trim(degree).unwrap();
-
+        let (proving_key, verifier_key) = setup_test(degree);
         let point = Scalar::from(10);
 
-        // Compute secret polynomial
         let poly = Polynomial::rand(degree, &mut rand::thread_rng());
         let value = poly.evaluate(&point);
 
         let proof = proving_key.open_single(&poly, &value, &point).unwrap();
 
-        let ok = vk.check(point, proof);
+        let ok = verifier_key.check(point, proof);
         assert!(ok);
     }
     #[test]
     fn test_batch_verification() {
         let degree = 25;
-        let srs = SRS::setup(degree, &mut rand::thread_rng()).unwrap();
-        let (proving_key, vk) = srs.trim(degree).unwrap();
+        let (proving_key, vk) = setup_test(degree);
+
         let point_a = Scalar::from(10);
         let point_b = Scalar::from(11);
+
         // Compute secret polynomial a
         let poly_a = Polynomial::rand(degree, &mut rand::thread_rng());
         let value_a = poly_a.evaluate(&point_a);
@@ -256,6 +264,7 @@ mod test {
             .open_single(&poly_a, &value_a, &point_a)
             .unwrap();
         assert!(vk.check(point_a, proof_a));
+
         // Compute secret polynomial b
         let poly_b = Polynomial::rand(degree, &mut rand::thread_rng());
         let value_b = poly_b.evaluate(&point_b);
@@ -273,37 +282,36 @@ mod test {
     }
     #[test]
     fn test_aggregate_witness() {
-        let max_degree = 100;
-        let srs = SRS::setup(max_degree, &mut rand::thread_rng()).unwrap();
+        let max_degree = 27;
+        let (proving_key, verifier_key) = setup_test(max_degree);
         let point = Scalar::from(10);
-        // Prover View
+
+        // Prover's View
         let aggregated_proof = {
-            let degree = 25;
-            let (ck, _) = srs.trim(degree + 2).unwrap();
-            let mut transcript = Transcript::new(b"");
             // Compute secret polynomials and their evaluations
-            let poly_a = Polynomial::rand(degree, &mut rand::thread_rng());
+            let poly_a = Polynomial::rand(25, &mut rand::thread_rng());
             let poly_a_eval = poly_a.evaluate(&point);
-            let poly_b = Polynomial::rand(degree + 1, &mut rand::thread_rng());
+
+            let poly_b = Polynomial::rand(26 + 1, &mut rand::thread_rng());
             let poly_b_eval = poly_b.evaluate(&point);
-            let poly_c = Polynomial::rand(degree + 2, &mut rand::thread_rng());
+
+            let poly_c = Polynomial::rand(27, &mut rand::thread_rng());
             let poly_c_eval = poly_c.evaluate(&point);
 
-            ck.open_multiple(
-                &[poly_a, poly_b, poly_c],
-                vec![poly_a_eval, poly_b_eval, poly_c_eval],
-                &point,
-                &mut transcript,
-            )
-            .unwrap()
+            proving_key
+                .open_multiple(
+                    &[poly_a, poly_b, poly_c],
+                    vec![poly_a_eval, poly_b_eval, poly_c_eval],
+                    &point,
+                    &mut Transcript::new(b"agg_flatten"),
+                )
+                .unwrap()
         };
 
-        //Verifiers view
+        // Verifier's View
         let ok = {
-            let vk = srs.verifier_key;
-            let mut transcript = Transcript::new(b"");
-            let flattened_proof = aggregated_proof.flatten(&mut transcript);
-            vk.check(point, flattened_proof)
+            let flattened_proof = aggregated_proof.flatten(&mut Transcript::new(b"agg_flatten"));
+            verifier_key.check(point, flattened_proof)
         };
 
         assert!(ok);
@@ -311,15 +319,13 @@ mod test {
 
     #[test]
     fn test_batch_with_aggregation() {
-        let max_degree = 100;
-        let srs = SRS::setup(max_degree, &mut rand::thread_rng()).unwrap();
+        let max_degree = 28;
+        let (proving_key, verifier_key) = setup_test(max_degree);
         let point_a = Scalar::from(10);
         let point_b = Scalar::from(11);
-        // Prover View
+
+        // Prover's View
         let (aggregated_proof, single_proof) = {
-            let local_max_degree = 28;
-            let (ck, _) = srs.trim(local_max_degree).unwrap();
-            let mut transcript = Transcript::new(b"");
             // Compute secret polynomial and their evaluations
             let poly_a = Polynomial::rand(25, &mut rand::thread_rng());
             let poly_a_eval = poly_a.evaluate(&point_a);
@@ -333,26 +339,28 @@ mod test {
             let poly_d = Polynomial::rand(28, &mut rand::thread_rng());
             let poly_d_eval = poly_d.evaluate(&point_b);
 
-            let aggregated_proof = ck
+            let aggregated_proof = proving_key
                 .open_multiple(
                     &[poly_a, poly_b, poly_c],
                     vec![poly_a_eval, poly_b_eval, poly_c_eval],
                     &point_a,
-                    &mut transcript,
+                    &mut Transcript::new(b"agg_batch"),
                 )
                 .unwrap();
 
-            let single_proof = ck.open_single(&poly_d, &poly_d_eval, &point_b).unwrap();
+            let single_proof = proving_key
+                .open_single(&poly_d, &poly_d_eval, &point_b)
+                .unwrap();
 
             (aggregated_proof, single_proof)
         };
 
-        //Verifiers view
+        // Verifier's View
         let ok = {
-            let vk = srs.verifier_key;
-            let mut transcript = Transcript::new(b"");
+            let mut transcript = Transcript::new(b"agg_batch");
             let flattened_proof = aggregated_proof.flatten(&mut transcript);
-            vk.batch_check(
+
+            verifier_key.batch_check(
                 &[point_a, point_b],
                 &[flattened_proof, single_proof],
                 &mut transcript,
@@ -360,40 +368,5 @@ mod test {
         };
 
         assert!(ok);
-    }
-
-    #[test]
-    fn test_polynomial_shortening() {
-        let n = 3;
-        let three_n = 3 * n;
-        let full_poly = Polynomial::rand(three_n, &mut rand::thread_rng());
-        let (low, mid, high) = split_poly(n, &full_poly);
-
-        let degree = n;
-        let srs = SRS::setup(degree, &mut rand::thread_rng()).unwrap();
-        let (proving_key, vk) = srs.trim(degree).unwrap();
-
-        let point = Scalar::from(10);
-        let point_n = point.pow(&[n as u64, 0, 0, 0]);
-        let mid_poly = &mid * &point_n;
-        let point_2n = point.pow(&[2 * n as u64, 0, 0, 0]);
-        let high_poly = &high * &point_2n;
-
-        let splitted_poly = &(&low + &mid_poly) + &high_poly;
-        let full_poly_eval = full_poly.evaluate(&point);
-        let proof = proving_key
-            .open_single(&splitted_poly, &full_poly_eval, &point)
-            .unwrap();
-
-        let ok = vk.check(point, proof);
-        assert!(ok);
-    }
-
-    pub fn split_poly(n: usize, t_x: &Polynomial) -> (Polynomial, Polynomial, Polynomial) {
-        (
-            Polynomial::from_coefficients_vec(t_x[0..n].to_vec()),
-            Polynomial::from_coefficients_vec(t_x[n..2 * n].to_vec()),
-            Polynomial::from_coefficients_vec(t_x[2 * n..].to_vec()),
-        )
     }
 }

--- a/src/commitment_scheme/kzg10/mod.rs
+++ b/src/commitment_scheme/kzg10/mod.rs
@@ -8,36 +8,30 @@ use crate::util::powers_of;
 pub use key::{ProverKey, VerifierKey};
 pub use srs::SRS;
 #[derive(Copy, Clone, Debug)]
+/// Proof that a polynomial `p` was correctly evaluated at a point `z`
+/// producing the evaluated point p(z).
 pub struct Proof {
-    /// This is a commitment to the witness polynomial `w`
-    /// w = p(x) - p(z) / x - z
+    /// This is a commitment to the witness polynomial.
     pub commitment_to_witness: Commitment,
-    /// This is the evaluation `y` of the committed polynomial
-    /// y = p(z)
+    /// This is the result of evaluating a polynomial at the point `z`.
     pub evaluated_point: Scalar,
-    /// These is the commitment to the polynomial that you want to prove a statement about
+    /// This is the commitment to the polynomial that you want to prove a statement about.
     pub commitment_to_polynomial: Commitment,
-    // This is the evaluated_point `z` of the committed polynomial
-    // y = p(z)
-    // pub evaluation_point: Scalar,
 }
 
-/// Due to KZG10 being homomorphic, we can supply a single witness commitment
-/// for multiple polynomials at the same point
+/// Proof that multiple polynomials were correctly evaluated at a point `z`,
+/// each producing their respective evaluated points p_i(z).
 pub struct AggregateProof {
-    /// This is a commitment to the witness polynomial `w`
-    /// w is a witness for multiple polynomials
+    /// This is a commitment to the aggregated witness polynomial.
     pub commitment_to_witness: Commitment,
-    /// This is the evaluations `y` of the committed polynomials
+    /// These are the results of the evaluating each polynomial at the point `z`.
     pub evaluated_points: Vec<Scalar>,
-    /// These are the commitments to the polynomials that you want to prove a statement about
+    /// These are the commitments to the polynomials that you want to prove a statement about.
     pub commitments_to_polynomials: Vec<Commitment>,
-    // This is the evaluated_point `z` that all of the polynomials are evaluated at
-    // pub evaluation_point: Scalar,
 }
 
 impl AggregateProof {
-    /// Creates an `AggregatedProof` with the commitment to the witness
+    /// Initialises an `AggregatedProof` with the commitment to the witness.
     pub fn with_witness(witness: Commitment) -> AggregateProof {
         AggregateProof {
             commitment_to_witness: witness,
@@ -45,8 +39,15 @@ impl AggregateProof {
             commitments_to_polynomials: Vec::new(),
         }
     }
-    // Flattens an aggregate proof into a `Proof`
-    // The challenge must be the same challenge that was used to aggregate the witness
+
+    /// Adds an evaluated point with the commitment to the polynomial which produced it.
+    pub fn add_part(&mut self, part: (Scalar, Commitment)) {
+        self.evaluated_points.push(part.0);
+        self.commitments_to_polynomials.push(part.1);
+    }
+
+    /// Flattens an `AggregateProof` into a `Proof`.
+    /// The transcript must have the same view as the transcript that was used to aggregate the witness in the proving stage.
     pub fn flatten(&self, transcript: &mut dyn TranscriptProtocol) -> Proof {
         let challenge = transcript.challenge_scalar(b"aggregate_witness");
         let powers = powers_of(&challenge, self.commitments_to_polynomials.len() - 1);
@@ -71,11 +72,6 @@ impl AggregateProof {
             evaluated_point: flattened_poly_evaluations,
             commitment_to_polynomial: Commitment::from_projective(flattened_poly_commitments),
         }
-    }
-    // Adds an evaluated point with the commitment to the polynomial which produced it
-    pub fn add_part(&mut self, part: (Scalar, Commitment)) {
-        self.evaluated_points.push(part.0);
-        self.commitments_to_polynomials.push(part.1);
     }
 }
 

--- a/src/commitment_scheme/kzg10/mod.rs
+++ b/src/commitment_scheme/kzg10/mod.rs
@@ -6,7 +6,7 @@ use crate::transcript::TranscriptProtocol;
 
 use crate::util::powers_of;
 pub use key::{ProverKey, VerifierKey};
-pub use srs::SRS;
+pub use srs::PublicParameters;
 #[derive(Copy, Clone, Debug)]
 /// Proof that a polynomial `p` was correctly evaluated at a point `z`
 /// producing the evaluated point p(z).

--- a/src/commitment_scheme/kzg10/srs.rs
+++ b/src/commitment_scheme/kzg10/srs.rs
@@ -1,48 +1,56 @@
-use super::errors::Error;
-use super::key::{ProverKey, VerifierKey};
-use crate::util::slow_multiscalar_mul_single_base;
-use bls12_381::{G1Affine, G1Projective, G2Affine, G2Prepared, G2Projective, Scalar};
+use super::{
+    errors::Error,
+    key::{ProverKey, VerifierKey},
+};
+use crate::util;
+use bls12_381::{G1Affine, G1Projective, G2Affine, G2Prepared};
 use rand_core::RngCore;
-/// Structured Reference String (SRS) is the main component in KZG10
-/// It is available to both the prover and verifier
-/// Allowing the verifier to efficiently verify claims about polynomials up to a configured degree
-pub struct SRS {
-    commit_key: ProverKey,
-    pub(crate) verifier_key: VerifierKey,
+
+/// The Public Parameters can also be referred to, as the Structured Reference String (SRS).
+/// It is available to both the prover and verifier and allows the verifier to
+/// efficiently verify claims about polynomials up to and including a configured degree.
+pub struct PublicParameters {
+    pub commit_key: ProverKey,
+    pub verifier_key: VerifierKey,
 }
 
-impl SRS {
-    /// Setup generates an SRS using a `RNG`
-    /// This method will in most cases be used for testing and exploration
-    /// In reality, a `trusted` party or an `MPC` is used to generate an SRS
-    pub fn setup<R: RngCore>(max_degree: usize, mut rng: &mut R) -> Result<SRS, Error> {
+impl PublicParameters {
+    /// Setup generates the public parameters using a random number generator.
+    /// This method will in most cases be used for testing and exploration.
+    /// In reality, a `Trusted party` or a `Multiparty Computation` will used to generate the SRS.
+    /// Returns an error if the configured degree is less than one.
+    pub fn setup<R: RngCore>(
+        max_degree: usize,
+        mut rng: &mut R,
+    ) -> Result<PublicParameters, Error> {
         // Cannot commit to constants
         if max_degree < 1 {
             return Err(Error::DegreeIsZero);
         }
 
         // Generate the secret scalar beta
-        // Seems `Scalar` does not have a method for this such as Scalar::random()
-        let beta = random_scalar(&mut rng);
-        // Compute powers of beta upto and including beta^max_degree
-        let powers_of_beta = powers_of(beta, max_degree);
+        let beta = util::random_scalar(&mut rng);
 
-        // powers of g will be used to commit to the polynomial
-        let g = random_g1_point(&mut rng);
-        let powers_of_g: Vec<G1Projective> = slow_multiscalar_mul_single_base(&powers_of_beta, g);
+        // Compute powers of beta up to and including beta^max_degree
+        let powers_of_beta = util::powers_of(&beta, max_degree);
+
+        // Powers of G1 that will be used to commit to a specified polynomial
+        let g = util::random_g1_point(&mut rng);
+        let powers_of_g: Vec<G1Projective> =
+            util::slow_multiscalar_mul_single_base(&powers_of_beta, g);
         assert_eq!(powers_of_g.len(), max_degree + 1);
 
         // Normalise all projective points
         let mut normalised_g = vec![G1Affine::identity(); max_degree + 1];
         G1Projective::batch_normalize(&powers_of_g, &mut normalised_g);
 
-        // Compute auxiliary elements to verify a proof
-        let h: G2Affine = random_g2_point(&mut rng).into();
+        // Compute beta*G2 element and stored cached elements for verifying multiple proofs.
+        let h: G2Affine = util::random_g2_point(&mut rng).into();
         let beta_h: G2Affine = (h * beta).into();
         let prepared_h: G2Prepared = G2Prepared::from(h);
         let prepared_beta_h = G2Prepared::from(beta_h);
 
-        Ok(SRS {
+        Ok(PublicParameters {
             commit_key: ProverKey {
                 powers_of_g: normalised_g,
             },
@@ -57,58 +65,35 @@ impl SRS {
     }
 
     /// Trim truncates the prover key to allow the prover to commit to polynomials up to the
-    /// and including the truncated degree
+    /// and including the truncated degree.
+    /// Returns an error if the truncated degree is larger than the public parameters configured degree.
     pub fn trim(&self, truncated_degree: usize) -> Result<(ProverKey, VerifierKey), Error> {
         let truncated_prover_key = self.commit_key.truncate(truncated_degree)?;
         let verifier_key = self.verifier_key.clone();
         Ok((truncated_prover_key, verifier_key))
     }
 
-    /// Max degree specifies the largest polynomial that a prover can commit to
+    /// Max degree specifies the largest polynomial that this prover key can commit to.
     pub fn max_degree(&self) -> usize {
         self.commit_key.max_degree()
     }
 }
-/// Returns a vector of Scalars of increasing powers of x from x^0 to x^d
-fn powers_of(mut x: Scalar, degree: usize) -> Vec<Scalar> {
-    let mut powers_of_x = vec![Scalar::one()];
-    for i in 1..=degree {
-        powers_of_x.push(x * powers_of_x[i - 1]);
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bls12_381::Scalar;
+    #[test]
+    fn test_powers_of() {
+        let x = Scalar::from(10u64);
+        let degree = 100u64;
+
+        let powers_of_x = util::powers_of(&x, degree as usize);
+
+        for (i, x_i) in powers_of_x.iter().enumerate() {
+            assert_eq!(*x_i, x.pow(&[i as u64, 0, 0, 0]))
+        }
+
+        let last_element = powers_of_x.last().unwrap();
+        assert_eq!(*last_element, x.pow(&[degree, 0, 0, 0]))
     }
-    powers_of_x
-}
-// bls_12-381 library does not provide a `random` method for Scalar
-// We wil use this helper function to compensate
-pub(crate) fn random_scalar<R: RngCore>(rng: &mut R) -> Scalar {
-    Scalar::from_raw([
-        rng.next_u64(),
-        rng.next_u64(),
-        rng.next_u64(),
-        rng.next_u64(),
-    ])
-}
-// bls_12-381 library does not provide a `random` method for G1
-// We wil use this helper function to compensate
-pub(crate) fn random_g1_point<R: RngCore>(rng: &mut R) -> G1Projective {
-    G1Affine::generator() * random_scalar(rng)
-}
-// bls_12-381 library does not provide a `random` method for G2
-// We wil use this helper function to compensate
-pub(crate) fn random_g2_point<R: RngCore>(rng: &mut R) -> G2Projective {
-    G2Affine::generator() * random_scalar(rng)
-}
-
-#[test]
-fn test_powers_of() {
-    let x = Scalar::from(10u64);
-    let degree = 100u64;
-
-    let powers_of_x = powers_of(x, degree as usize);
-
-    for (i, x_i) in powers_of_x.iter().enumerate() {
-        assert_eq!(*x_i, x.pow(&[i as u64, 0, 0, 0]))
-    }
-
-    let last_element = powers_of_x.last().unwrap();
-    assert_eq!(*last_element, x.pow(&[degree, 0, 0, 0]))
 }

--- a/src/constraint_system/standard/composer.rs
+++ b/src/constraint_system/standard/composer.rs
@@ -1069,7 +1069,7 @@ impl StandardComposer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commitment_scheme::kzg10::SRS;
+    use crate::commitment_scheme::kzg10::PublicParameters;
     use bls12_381::Scalar as Fr;
     use merlin::Transcript;
 
@@ -1330,7 +1330,7 @@ mod tests {
 
     fn test_gadget(gadget: fn(composer: &mut StandardComposer), n: usize) -> bool {
         // Common View
-        let public_parameters = SRS::setup(2 * n, &mut rand::thread_rng()).unwrap();
+        let public_parameters = PublicParameters::setup(2 * n, &mut rand::thread_rng()).unwrap();
         // Provers View
         let (proof, public_inputs) = {
             let mut composer: StandardComposer = add_dummy_composer(7);

--- a/src/fft/polynomial.rs
+++ b/src/fft/polynomial.rs
@@ -1,11 +1,12 @@
 use super::{EvaluationDomain, Evaluations};
-use crate::util::powers_of;
+use crate::util;
 use bls12_381::Scalar;
 use rand::Rng;
 use rayon::iter::{
     IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
 };
-use std::ops::{Add, AddAssign, Deref, DerefMut, Div, Mul, Neg, Sub, SubAssign};
+
+use std::ops::{Add, AddAssign, Deref, DerefMut, Mul, Neg, Sub, SubAssign};
 // This library will solely implement Dense Polynomials
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct Polynomial {
@@ -82,7 +83,7 @@ impl Polynomial {
         }
 
         // Compute powers of points
-        let powers = powers_of(point, self.len());
+        let powers = util::powers_of(point, self.len());
 
         let p_evals: Vec<_> = self
             .par_iter()
@@ -101,7 +102,7 @@ impl Polynomial {
     pub fn rand<R: Rng>(d: usize, mut rng: &mut R) -> Self {
         let mut random_coeffs = Vec::with_capacity(d + 1);
         for _ in 0..=d {
-            random_coeffs.push(random_scalar(&mut rng));
+            random_coeffs.push(util::random_scalar(&mut rng));
         }
         Self::from_coefficients_vec(random_coeffs)
     }
@@ -122,18 +123,6 @@ impl Sum for Polynomial {
     }
 }
 
-// bls_12-381 library does not provide a `random` method for Scalar
-// We wil use this helper function to compensate
-pub(crate) fn random_scalar<R: Rng>(rng: &mut R) -> Scalar {
-    Scalar::from_raw([
-        rng.next_u64(),
-        rng.next_u64(),
-        rng.next_u64(),
-        rng.next_u64(),
-    ])
-}
-
-///////////
 impl<'a, 'b> Add<&'a Polynomial> for &'b Polynomial {
     type Output = Polynomial;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,14 +1,34 @@
-use bls12_381::{G1Projective, Scalar};
+use bls12_381::{G1Affine, G1Projective, G2Affine, G2Projective, Scalar};
+use rand_core::RngCore;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
-// Computes 1,v, v^2, v^3,..v^max_degree
-pub fn powers_of(scalar: &Scalar, max_degree: usize) -> Vec<Scalar> {
+/// Returns a vector of Scalars of increasing powers of x from x^0 to x^d.
+pub(crate) fn powers_of(scalar: &Scalar, max_degree: usize) -> Vec<Scalar> {
     let mut powers = Vec::with_capacity(max_degree + 1);
     powers.push(Scalar::one());
     for i in 1..=max_degree {
         powers.push(powers[i - 1] * scalar);
     }
     powers
+}
+
+/// Generates a random Scalar using a RNG seed.
+pub(crate) fn random_scalar<R: RngCore>(rng: &mut R) -> Scalar {
+    Scalar::from_raw([
+        rng.next_u64(),
+        rng.next_u64(),
+        rng.next_u64(),
+        rng.next_u64(),
+    ])
+}
+
+/// Generates a random G1 Point using an RNG seed.
+pub(crate) fn random_g1_point<R: RngCore>(rng: &mut R) -> G1Projective {
+    G1Affine::generator() * random_scalar(rng)
+}
+/// Generates a random G2 point using an RNG seed.
+pub(crate) fn random_g2_point<R: RngCore>(rng: &mut R) -> G2Projective {
+    G2Affine::generator() * random_scalar(rng)
 }
 
 /// This function is only used to generate the SRS.


### PR DESCRIPTION
- Removes any inaccuracies in the documentation and cleans up all comments.
- Completes all TODOs and XXXs
     -  Uses one pairing when checking the opening proof for a single polynomial
- Cleans up all test functions to be more readable with helper functions

A step towards #121 