### PR TITLE
Update travis to allow nightly doc builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,23 @@ os:
   - linux
 
 matrix:
-  fast_finish: false
   include:
   - rust: stable
+  - rust: beta
+  - rust: nightly
 
-
-before_install:
-  - sudo apt-get update
+jobs:
+  allow_failures:
+    - rust: stable
+    - rust: beta
+  fast_finish: true
 
 # Main build
 script:
   - cargo check
   - cargo build --release --verbose --all
   - cargo test --release --verbose --all
+  - cargo doc --no-deps
 
 
 # Send a notification to the Dusk build Status Telegram channel once the CI build completes


### PR DESCRIPTION
Allow builds with `#![feature(external_doc)]` to fail for `stable` and `beta` channels