### PR TITLE
Add serde support for crate's data structures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ itertools = "0.8.2"
 rand_chacha = "0.2"
 rayon = "1.3.0"
 failure = { version = "0.1", default-features = false, features = ["derive"] }
+serde = {version = "1.0.106", features = ["derive"], optional = true} 
+
+[dev-dependencies]
+bincode = "1"
 
 [package.metadata.docs.rs]
 rustdoc-args = [
@@ -29,3 +33,4 @@ rustdoc-args = [
 
 [features]
 nightly = []
+default = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,15 @@ failure = { version = "0.1", default-features = false, features = ["derive"] }
 serde = {version = "1.0.106", features = ["derive"], optional = true} 
 
 [dev-dependencies]
+criterion = "0.3.0"
+rand = "0.7.0"
 bincode = "1"
+
+# Criterion benchmarks
+[[bench]]
+path = "./benchmarks/plonk_benchmarks.rs"
+name = "plonk_benchmarks"
+harness = false
 
 [package.metadata.docs.rs]
 rustdoc-args = [

--- a/benchmarks/plonk_benchmarks.rs
+++ b/benchmarks/plonk_benchmarks.rs
@@ -1,25 +1,57 @@
-#![allow(non_snake_case)]
-
-#[macro_use]
 extern crate criterion;
+extern crate merlin;
 extern crate plonk;
 
-use bls12_381::{G1Projective, Scalar};
+use bincode;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use plonk::commitment_scheme::kzg10::SRS;
-use rand::thread_rng;
+use merlin::Transcript;
+use plonk::commitment_scheme::kzg10::PublicParameters;
+use plonk::constraint_system::standard::{proof::Proof, Composer, StandardComposer};
+use plonk::fft::EvaluationDomain;
 
-mod poly_commit_benches {
-
+mod serde_benches {
     use super::*;
-    pub fn bench_polynomial_commitment(c: &mut Criterion) {
-        // Generate the powers with size = 1_000_000
-        let srs = SRS::setup(1_000_000, &mut thread_rng());
-        let (ck, vk) = srs.trim(1_000_000usize);
-        let random_poly = (0..1000000)
-            .iter()
-            .map(|| Scalar::rand(&mut thread_rng()))
-            .collect();
-        let mut group = c.benchmark_group("Poly commit");
+
+    pub fn proof_serde(c: &mut Criterion) {
+        let public_parameters = PublicParameters::setup(1 << 18, &mut rand::thread_rng()).unwrap();
+        let mut composer: StandardComposer = StandardComposer::new();
+        // Fill the composer with dummy constraints until it has a
+        // size near to DuskNetworks' circuit (2^16 constraints).
+        //
+        // `add_dummy_constraints` adds 7 constraints to the circuit/call
+        // so we need 2^16 / 7 calls to the method ~ 9361
+        for _ in 0..9361 {
+            composer.add_dummy_constraints();
+        }
+
+        let (ck, _) = public_parameters
+            .trim(2 * composer.circuit_size().next_power_of_two())
+            .unwrap();
+        let domain = EvaluationDomain::new(composer.circuit_size()).unwrap();
+        let mut transcript = Transcript::new(b"12381");
+
+        // Preprocess circuit
+        let preprocessed_circuit = composer.preprocess(&ck, &mut transcript, &domain);
+
+        let proof = composer.prove(&ck, &preprocessed_circuit, &mut transcript);
+        let proof_ser_data = bincode::serialize(&proof).unwrap();
+
+        c.bench_with_input(
+            BenchmarkId::new("Proof Serde", "Deserialization"),
+            &proof_ser_data,
+            |b, proof_ser_data| {
+                b.iter(|| bincode::deserialize::<Proof>(&proof_ser_data.clone()));
+            },
+        );
+
+        c.bench_with_input(
+            BenchmarkId::new("Proof Serde", "Serialization"),
+            &proof,
+            |b, proof| {
+                b.iter(|| bincode::serialize(&proof.clone()));
+            },
+        );
     }
 }
+criterion_group!(benchmarks, serde_benches::proof_serde,);
+criterion_main!(benchmarks,);

--- a/src/commitment_scheme/kzg10/mod.rs
+++ b/src/commitment_scheme/kzg10/mod.rs
@@ -79,7 +79,7 @@ impl AggregateProof {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 /// Holds a commitment to a polynomial in a form of a `G1Affine` Bls12_381 point.
 pub struct Commitment(
     /// The commitment is a group element.

--- a/src/commitment_scheme/kzg10/mod.rs
+++ b/src/commitment_scheme/kzg10/mod.rs
@@ -7,10 +7,7 @@ use crate::transcript::TranscriptProtocol;
 use crate::util::powers_of;
 pub use key::{ProverKey, VerifierKey};
 #[cfg(feature = "serde")]
-use serde::{
-    de::Visitor, ser::SerializeSeq, ser::SerializeStruct, Deserialize, Deserializer, Serialize,
-    Serializer,
-};
+use serde::{de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 pub use srs::PublicParameters;
 
 #[derive(Copy, Clone, Debug)]
@@ -162,36 +159,9 @@ impl<'de> Deserialize<'de> for Commitment {
                     .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
                 Ok(Commitment(g1_affine))
             }
-
-            /*fn visit_map<V>(self, mut map: V) -> Result<Commitment, V::Error>
-            where
-                V: MapAccess<'de>,
-            {
-                let mut secs = None;
-                let mut nanos = None;
-                while let Some(key) = map.next_key()? {
-                    match key {
-                        Field::Secs => {
-                            if secs.is_some() {
-                                return Err(de::Error::duplicate_field("secs"));
-                            }
-                            secs = Some(map.next_value()?);
-                        }
-                        Field::Nanos => {
-                            if nanos.is_some() {
-                                return Err(de::Error::duplicate_field("nanos"));
-                            }
-                            nanos = Some(map.next_value()?);
-                        }
-                    }
-                }
-                let secs = secs.ok_or_else(|| de::Error::missing_field("secs"))?;
-                let nanos = nanos.ok_or_else(|| de::Error::missing_field("nanos"))?;
-                Ok(Commitment::new(secs, nanos))
-            }*/
         }
 
-        const FIELDS: &'static [&'static str] = &["g1affine"];
+        const FIELDS: &[&str] = &["g1affine"];
         deserializer.deserialize_struct("Commitment", FIELDS, CommitmentVisitor)
     }
 }
@@ -213,8 +183,8 @@ impl Commitment {
 }
 
 mod tests {
+    #[allow(unused_imports)]
     use super::*;
-
     #[cfg(feature = "serde")]
     #[test]
     fn commitment_serde_roundtrip() {

--- a/src/commitment_scheme/kzg10/srs.rs
+++ b/src/commitment_scheme/kzg10/srs.rs
@@ -18,6 +18,100 @@ pub struct PublicParameters {
     pub verifier_key: VerifierKey,
 }
 
+#[cfg(feature = "serde")]
+use serde::{
+    self, de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer,
+};
+
+#[cfg(feature = "serde")]
+impl Serialize for PublicParameters {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut verif_key = serializer.serialize_struct("struct PublicParameters", 2)?;
+        verif_key.serialize_field("ck", &self.commit_key)?;
+        verif_key.serialize_field("vk", &self.verifier_key)?;
+        verif_key.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for PublicParameters {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            Ck,
+            Vk,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut ::core::fmt::Formatter,
+                    ) -> ::core::fmt::Result {
+                        formatter.write_str("struct PublicParameters")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "ck" => Ok(Field::Ck),
+                            "vk" => Ok(Field::Vk),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct PublicParametersVisitor;
+
+        impl<'de> Visitor<'de> for PublicParametersVisitor {
+            type Value = PublicParameters;
+
+            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                formatter.write_str("struct PublicParameters")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<PublicParameters, V::Error>
+            where
+                V: serde::de::SeqAccess<'de>,
+            {
+                let commit_key = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let verifier_key = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+
+                Ok(PublicParameters {
+                    commit_key,
+                    verifier_key,
+                })
+            }
+        }
+
+        const FIELDS: &[&str] = &["ck", "vk"];
+        deserializer.deserialize_struct("PublicParameters", FIELDS, PublicParametersVisitor)
+    }
+}
+
 impl PublicParameters {
     /// Setup generates the public parameters using a random number generator.
     /// This method will in most cases be used for testing and exploration.
@@ -99,5 +193,22 @@ mod test {
 
         let last_element = powers_of_x.last().unwrap();
         assert_eq!(*last_element, x.pow(&[degree, 0, 0, 0]))
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn srs_serde_roundtrip() {
+        use bincode;
+        let srs = PublicParameters::setup(1 << 12, &mut rand::thread_rng()).unwrap();
+
+        let ser = bincode::serialize(&srs).unwrap();
+        let deser: PublicParameters = bincode::deserialize(&ser).unwrap();
+
+        assert!(&srs.commit_key.powers_of_g[..] == &deser.commit_key.powers_of_g[..]);
+        assert!(srs.verifier_key.g == deser.verifier_key.g);
+        assert!(srs.verifier_key.h == deser.verifier_key.h);
+        assert!(srs.verifier_key.beta_h == deser.verifier_key.beta_h);
+        // XXX: Missing prepared_beta & prepared_beta_h for VerifierKey
+        // since G2Prepared does not implement PartialEq.
     }
 }

--- a/src/constraint_system/standard/linearisation_poly.rs
+++ b/src/constraint_system/standard/linearisation_poly.rs
@@ -1,6 +1,8 @@
 use crate::constraint_system::standard::PreProcessedCircuit;
 use crate::fft::{EvaluationDomain, Polynomial};
 use bls12_381::Scalar;
+#[cfg(feature = "serde")]
+use serde::{de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 
 /// Evaluations at points `z` or and `z * root of unity`
 pub struct Evaluations {
@@ -8,8 +10,9 @@ pub struct Evaluations {
     // Evaluation of the linearisation sigma polynomial at `z`
     pub quot_eval: Scalar,
 }
-// Proof Evaluations is a subset of all of the evaluations. These evaluations will be added to the proof
-#[derive(Debug)]
+
+/// Proof Evaluations is a subset of all of the evaluations. These evaluations will be added to the proof
+#[derive(Debug, Eq, PartialEq)]
 pub struct ProofEvaluations {
     // Evaluation of the witness polynomial for the left wire at `z`
     pub a_eval: Scalar,
@@ -41,6 +44,192 @@ pub struct ProofEvaluations {
 
     // (Shifted) Evaluation of the permutation polynomial at `z * root of unity`
     pub perm_eval: Scalar,
+}
+#[cfg(feature = "serde")]
+impl Serialize for ProofEvaluations {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut proof_evals = serializer.serialize_struct("struct ProofEvaluations", 14)?;
+        proof_evals.serialize_field("a_eval", &self.a_eval)?;
+        proof_evals.serialize_field("b_eval", &self.b_eval)?;
+        proof_evals.serialize_field("c_eval", &self.c_eval)?;
+        proof_evals.serialize_field("d_eval", &self.d_eval)?;
+        proof_evals.serialize_field("a_next_eval", &self.a_next_eval)?;
+        proof_evals.serialize_field("b_next_eval", &self.b_next_eval)?;
+        proof_evals.serialize_field("d_next_eval", &self.d_next_eval)?;
+        proof_evals.serialize_field("q_arith_eval", &self.q_arith_eval)?;
+        proof_evals.serialize_field("q_c_eval", &self.q_c_eval)?;
+        proof_evals.serialize_field("left_sig_eval", &self.left_sigma_eval)?;
+        proof_evals.serialize_field("right_sig_eval", &self.right_sigma_eval)?;
+        proof_evals.serialize_field("out_sig_eval", &self.out_sigma_eval)?;
+        proof_evals.serialize_field("lin_poly_eval", &self.lin_poly_eval)?;
+        proof_evals.serialize_field("perm_eval", &self.perm_eval)?;
+        proof_evals.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for ProofEvaluations {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            Aeval,
+            Beval,
+            Ceval,
+            Deval,
+            ANextEval,
+            BNextEval,
+            DNextEval,
+            QArithEval,
+            QCEval,
+            LeftSigEval,
+            RightSigEval,
+            OutSigEval,
+            LinPolyEval,
+            PermEval,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut ::core::fmt::Formatter,
+                    ) -> ::core::fmt::Result {
+                        formatter.write_str("struct ProofEvaluations")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "a_eval" => Ok(Field::Aeval),
+                            "b_eval" => Ok(Field::Beval),
+                            "c_eval" => Ok(Field::Ceval),
+                            "d_eval" => Ok(Field::Deval),
+                            "a_next_eval" => Ok(Field::ANextEval),
+                            "b_next_eval" => Ok(Field::BNextEval),
+                            "d_next_eval" => Ok(Field::DNextEval),
+                            "q_arith_eval" => Ok(Field::QArithEval),
+                            "q_c_eval" => Ok(Field::QCEval),
+                            "left_sig_eval" => Ok(Field::LeftSigEval),
+                            "right_sig_eval" => Ok(Field::RightSigEval),
+                            "out_sig_eval" => Ok(Field::OutSigEval),
+                            "lin_poly_eval" => Ok(Field::LinPolyEval),
+                            "perm_eval" => Ok(Field::PermEval),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct ProofEvaluationsVisitor;
+
+        impl<'de> Visitor<'de> for ProofEvaluationsVisitor {
+            type Value = ProofEvaluations;
+
+            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                formatter.write_str("struct ProofEvaluations")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<ProofEvaluations, V::Error>
+            where
+                V: serde::de::SeqAccess<'de>,
+            {
+                let a_eval = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let b_eval = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let c_eval = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let d_eval = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let a_next_eval = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let b_next_eval = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let d_next_eval = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let q_arith_eval = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let q_c_eval = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let left_sigma_eval = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let right_sigma_eval = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let out_sigma_eval = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let lin_poly_eval = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let perm_eval = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                Ok(ProofEvaluations {
+                    a_eval,
+                    b_eval,
+                    c_eval,
+                    d_eval,
+                    a_next_eval,
+                    b_next_eval,
+                    d_next_eval,
+                    q_arith_eval,
+                    q_c_eval,
+                    left_sigma_eval,
+                    right_sigma_eval,
+                    out_sigma_eval,
+                    lin_poly_eval,
+                    perm_eval,
+                })
+            }
+        }
+
+        const FIELDS: &[&str] = &[
+            "a_eval",
+            "b_eval",
+            "c_eval",
+            "d_eval",
+            "a_next_eval",
+            "b_next_eval",
+            "d_next_eval",
+            "q_arith_eval",
+            "q_c_eval",
+            "left_sig_eval",
+            "right_sig_eval",
+            "out_sig_eval",
+            "lin_poly_eval",
+            "perm_eval",
+        ];
+        deserializer.deserialize_struct("ProofEvaluations", FIELDS, ProofEvaluationsVisitor)
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -183,4 +372,40 @@ fn compute_circuit_satisfiability(
         q_c_eval,
     );
     &(&a + &b) + &c
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn proof_evaluations_serde_roundtrip() {
+        use bincode;
+        let one = -Scalar::one();
+
+        // Build directly the widget since there's not any `new()` impl
+        // dor any other check and correctness methodology for the inputs.
+        let proof_evals = ProofEvaluations {
+            a_eval: one,
+            b_eval: one,
+            c_eval: one,
+            d_eval: one,
+            a_next_eval: one,
+            b_next_eval: one,
+            d_next_eval: one,
+            q_arith_eval: one,
+            q_c_eval: one,
+            left_sigma_eval: one,
+            right_sigma_eval: one,
+            out_sigma_eval: one,
+            lin_poly_eval: one,
+            perm_eval: one,
+        };
+
+        // Roundtrip with evals
+        let ser = bincode::serialize(&proof_evals).unwrap();
+        let deser: ProofEvaluations = bincode::deserialize(&ser).unwrap();
+        assert_eq!(proof_evals, deser);
+    }
 }

--- a/src/constraint_system/standard/linearisation_poly.rs
+++ b/src/constraint_system/standard/linearisation_poly.rs
@@ -45,6 +45,7 @@ pub struct ProofEvaluations {
     // (Shifted) Evaluation of the permutation polynomial at `z * root of unity`
     pub perm_eval: Scalar,
 }
+
 #[cfg(feature = "serde")]
 impl Serialize for ProofEvaluations {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/constraint_system/standard/preprocessed_circuit.rs
+++ b/src/constraint_system/standard/preprocessed_circuit.rs
@@ -2,6 +2,8 @@ use crate::constraint_system::widget::{
     ArithmeticWidget, LogicWidget, PermutationWidget, RangeWidget,
 };
 use crate::fft::Evaluations;
+#[cfg(feature = "serde")]
+use serde::{de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 
 /// `PreProcessedCircuit` is a data structure that holds the commitments to
 /// the selector and sigma polynomials.
@@ -9,7 +11,7 @@ use crate::fft::Evaluations;
 /// By doing this, we can see the `PreProcessedCircuit` as a "circuit-shape descriptor"
 /// since it only stores the commitments that describe the operations that we will perform
 /// innside the circuit.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct PreProcessedCircuit {
     /// The number of gates in the circuit
     pub n: usize,
@@ -33,8 +35,231 @@ pub struct PreProcessedCircuit {
     // divide by the quotient polynomial without having to IFFT
     pub(crate) v_h_coset_4n: Evaluations,
 }
+
+#[cfg(feature = "serde")]
+impl Serialize for PreProcessedCircuit {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut prep_circ = serializer.serialize_struct("struct PreProcessedCircuit", 6)?;
+        prep_circ.serialize_field("n", &self.n)?;
+        prep_circ.serialize_field("arith_widg", &self.arithmetic)?;
+        prep_circ.serialize_field("logic_widg", &self.logic)?;
+        prep_circ.serialize_field("range_widg", &self.range)?;
+        prep_circ.serialize_field("perm_widg", &self.permutation)?;
+        prep_circ.serialize_field("v_h_coset_4n", &self.v_h_coset_4n)?;
+        prep_circ.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for PreProcessedCircuit {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            N,
+            ArithWidget,
+            LogicWidget,
+            RangeWidget,
+            PermWidget,
+            VhCoset4n,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut ::core::fmt::Formatter,
+                    ) -> ::core::fmt::Result {
+                        formatter.write_str("struct PreProcessedCircuit")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "n" => Ok(Field::N),
+                            "arith_widg" => Ok(Field::ArithWidget),
+                            "logic_widg" => Ok(Field::LogicWidget),
+                            "range_widg" => Ok(Field::RangeWidget),
+                            "perm_widg" => Ok(Field::PermWidget),
+                            "v_h_coset_4n" => Ok(Field::VhCoset4n),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct PreProcessedCircuitVisitor;
+
+        impl<'de> Visitor<'de> for PreProcessedCircuitVisitor {
+            type Value = PreProcessedCircuit;
+
+            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                formatter.write_str("struct PreProcessedCircuit")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<PreProcessedCircuit, V::Error>
+            where
+                V: serde::de::SeqAccess<'de>,
+            {
+                let n = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let arith_widg = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let logic_widg = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let range_widg = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let perm_widg = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let v_h_coset_4n = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                Ok(PreProcessedCircuit {
+                    n,
+                    arithmetic: arith_widg,
+                    logic: logic_widg,
+                    range: range_widg,
+                    permutation: perm_widg,
+                    v_h_coset_4n,
+                })
+            }
+        }
+
+        const FIELDS: &[&str] = &[
+            "n",
+            "arith_widg",
+            "logic_widg",
+            "range_widg",
+            "perm_widg",
+            "v_h_coset_4n",
+            "q_arith",
+        ];
+        deserializer.deserialize_struct("PreProcessedCircuit", FIELDS, PreProcessedCircuitVisitor)
+    }
+}
+
 impl PreProcessedCircuit {
     pub(crate) fn v_h_coset_4n(&self) -> &Evaluations {
         &self.v_h_coset_4n
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constraint_system::widget::PreProcessedPolynomial;
+    use crate::fft::{EvaluationDomain, Polynomial};
+    use bls12_381::{G1Affine, Scalar};
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn prep_circuit_serde_roundtrip() {
+        use bincode;
+        let n = 24562352usize;
+        let coeffs = vec![
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+        ];
+        let dom = EvaluationDomain::new(coeffs.len()).unwrap();
+        let evals = Evaluations::from_vec_and_domain(coeffs.clone(), dom);
+        let poly = Polynomial::from_coefficients_vec(coeffs);
+        let comm = crate::commitment_scheme::kzg10::Commitment::from_affine(G1Affine::generator());
+
+        // Build directly the widget since the `new()` impl doesn't check any
+        // correctness on the inputs.
+        let prep_poly_w_evals = PreProcessedPolynomial {
+            polynomial: poly.clone(),
+            commitment: comm,
+            evaluations: Some(evals.clone()),
+        };
+
+        // Build directly the widget since the `new()` impl doesn't check any
+        // correctness on the inputs.
+        let prep_poly_without_evals = PreProcessedPolynomial {
+            polynomial: poly,
+            commitment: comm,
+            evaluations: None,
+        };
+
+        // Build directly the widget since the `new()` impl doesn't check any
+        // correctness on the inputs.
+        let arith_widget = ArithmeticWidget {
+            q_m: prep_poly_w_evals.clone(),
+            q_l: prep_poly_without_evals.clone(),
+            q_r: prep_poly_without_evals.clone(),
+            q_o: prep_poly_w_evals.clone(),
+            q_c: prep_poly_w_evals.clone(),
+            q_4: prep_poly_w_evals.clone(),
+            q_arith: prep_poly_without_evals.clone(),
+        };
+
+        // Build directly the widget since the `new()` impl doesn't check any
+        // correctness on the inputs.
+        let logic_widget = LogicWidget {
+            q_c: prep_poly_w_evals.clone(),
+            q_logic: prep_poly_without_evals.clone(),
+        };
+
+        // Build directly the widget since the `new()` impl doesn't check any
+        // correctness on the inputs.
+        let perm_widget = PermutationWidget {
+            left_sigma: prep_poly_w_evals.clone(),
+            right_sigma: prep_poly_without_evals.clone(),
+            out_sigma: prep_poly_without_evals.clone(),
+            fourth_sigma: prep_poly_w_evals.clone(),
+            linear_evaluations: evals.clone(),
+        };
+
+        // Build directly the widget since the `new()` impl doesn't check any
+        // correctness on the inputs.
+        let range_widget = RangeWidget {
+            q_range: prep_poly_w_evals,
+        };
+
+        // Build directly the widget since the `new()` impl doesn't check any
+        // correctness on the inputs.
+        let v_h_coset_4n = evals;
+
+        let prep_circ = PreProcessedCircuit {
+            n,
+            arithmetic: arith_widget,
+            logic: logic_widget,
+            range: range_widget,
+            permutation: perm_widget,
+            v_h_coset_4n,
+        };
+
+        // Roundtrip with evals
+        let ser = bincode::serialize(&prep_circ).unwrap();
+        let deser: PreProcessedCircuit = bincode::deserialize(&ser).unwrap();
+        assert_eq!(prep_circ, deser);
     }
 }

--- a/src/constraint_system/standard/proof.rs
+++ b/src/constraint_system/standard/proof.rs
@@ -10,8 +10,10 @@ use crate::commitment_scheme::kzg10::{Commitment, VerifierKey};
 use crate::fft::{EvaluationDomain, Polynomial};
 use crate::transcript::TranscriptProtocol;
 use bls12_381::{multiscalar_mul::msm_variable_base, G1Affine, Scalar};
+#[cfg(feature = "serde")]
+use serde::{de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 /// A Proof is a composition of `Commitments` to the witness, permutation,
 /// quotient, shifted and opening polynomials as well as the
 /// `ProofEvaluations`.
@@ -48,6 +50,177 @@ pub struct Proof {
     pub w_zw_comm: Commitment,
     /// Subset of all of the evaluations added to the proof.
     pub evaluations: ProofEvaluations,
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for Proof {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut proof = serializer.serialize_struct("struct Proof", 12)?;
+        proof.serialize_field("a_comm", &self.a_comm)?;
+        proof.serialize_field("b_comm", &self.b_comm)?;
+        proof.serialize_field("c_comm", &self.c_comm)?;
+        proof.serialize_field("d_comm", &self.d_comm)?;
+        proof.serialize_field("z_comm", &self.z_comm)?;
+        proof.serialize_field("t_1_comm", &self.t_1_comm)?;
+        proof.serialize_field("t_2_comm", &self.t_2_comm)?;
+        proof.serialize_field("t_3_comm", &self.t_3_comm)?;
+        proof.serialize_field("t_4_comm", &self.t_4_comm)?;
+        proof.serialize_field("w_z_comm", &self.w_z_comm)?;
+        proof.serialize_field("w_zw_comm", &self.w_zw_comm)?;
+        proof.serialize_field("evaluations", &self.evaluations)?;
+        proof.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for Proof {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            Acomm,
+            Bcomm,
+            Ccomm,
+            Dcomm,
+            Zcomm,
+            T1comm,
+            T2comm,
+            T3comm,
+            T4comm,
+            WZcomm,
+            WZWcomm,
+            Evals,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut ::core::fmt::Formatter,
+                    ) -> ::core::fmt::Result {
+                        formatter.write_str("struct Proof")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "a_comm" => Ok(Field::Acomm),
+                            "b_comm" => Ok(Field::Bcomm),
+                            "c_comm" => Ok(Field::Ccomm),
+                            "d_comm" => Ok(Field::Dcomm),
+                            "z_comm" => Ok(Field::Zcomm),
+                            "t_1_comm" => Ok(Field::T1comm),
+                            "t_2_comm" => Ok(Field::T2comm),
+                            "t_3_comm" => Ok(Field::T3comm),
+                            "t_4_comm" => Ok(Field::T4comm),
+                            "w_z_comm" => Ok(Field::WZcomm),
+                            "w_zw_comm" => Ok(Field::WZWcomm),
+                            "evaluations" => Ok(Field::Evals),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct ProofVisitor;
+
+        impl<'de> Visitor<'de> for ProofVisitor {
+            type Value = Proof;
+
+            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                formatter.write_str("struct Proof")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<Proof, V::Error>
+            where
+                V: serde::de::SeqAccess<'de>,
+            {
+                let a_comm = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let b_comm = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let c_comm = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let d_comm = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let z_comm = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let t_1_comm = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let t_2_comm = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let t_3_comm = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let t_4_comm = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let w_z_comm = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let w_zw_comm = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let evaluations = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                Ok(Proof {
+                    a_comm,
+                    b_comm,
+                    c_comm,
+                    d_comm,
+                    z_comm,
+                    t_1_comm,
+                    t_2_comm,
+                    t_3_comm,
+                    t_4_comm,
+                    w_z_comm,
+                    w_zw_comm,
+                    evaluations,
+                })
+            }
+        }
+
+        const FIELDS: &[&str] = &[
+            "a_comm",
+            "b_comm",
+            "c_comm",
+            "d_comm",
+            "z_comm",
+            "t_1_comm",
+            "t_2_comm",
+            "t_3_comm",
+            "t_4_comm",
+            "w_z_comm",
+            "w_zw_comm",
+            "evaluations",
+        ];
+        deserializer.deserialize_struct("Proof", FIELDS, ProofVisitor)
+    }
 }
 
 impl Proof {
@@ -342,5 +515,59 @@ impl Proof {
             );
 
         Commitment::from_projective(msm_variable_base(&points, &scalars))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn proof_serde_roundtrip() {
+        use bincode;
+        let comm = Commitment::empty();
+        let one = Scalar::one();
+
+        // Build directly the widget since there's not any `new()` impl
+        // dor any other check and correctness methodology for the inputs.
+        let proof_evals = ProofEvaluations {
+            a_eval: one,
+            b_eval: one,
+            c_eval: one,
+            d_eval: one,
+            a_next_eval: one,
+            b_next_eval: one,
+            d_next_eval: one,
+            q_arith_eval: one,
+            q_c_eval: one,
+            left_sigma_eval: one,
+            right_sigma_eval: one,
+            out_sigma_eval: one,
+            lin_poly_eval: one,
+            perm_eval: one,
+        };
+
+        // Build directly the widget since there's not any `new()` impl
+        // dor any other check and correctness methodology for the inputs.
+        let proof = Proof {
+            a_comm: comm,
+            b_comm: comm,
+            c_comm: comm,
+            d_comm: comm,
+            z_comm: comm,
+            t_1_comm: comm,
+            t_2_comm: comm,
+            t_3_comm: comm,
+            t_4_comm: comm,
+            w_z_comm: comm,
+            w_zw_comm: comm,
+            evaluations: proof_evals,
+        };
+
+        // Roundtrip with evals
+        let ser = bincode::serialize(&proof).unwrap();
+        let deser: Proof = bincode::deserialize(&ser).unwrap();
+        assert_eq!(proof, deser);
     }
 }

--- a/src/constraint_system/widget/arithmetic.rs
+++ b/src/constraint_system/widget/arithmetic.rs
@@ -23,15 +23,15 @@ impl Serialize for ArithmeticWidget {
     where
         S: Serializer,
     {
-        let mut eval_dom = serializer.serialize_struct("struct ArithmeticWidget", 7)?;
-        eval_dom.serialize_field("q_m", &self.q_m)?;
-        eval_dom.serialize_field("q_l", &self.q_l)?;
-        eval_dom.serialize_field("q_r", &self.q_r)?;
-        eval_dom.serialize_field("q_o", &self.q_o)?;
-        eval_dom.serialize_field("q_c", &self.q_c)?;
-        eval_dom.serialize_field("q_4", &self.q_4)?;
-        eval_dom.serialize_field("q_arith", &self.q_arith)?;
-        eval_dom.end()
+        let mut arith_widget = serializer.serialize_struct("struct ArithmeticWidget", 7)?;
+        arith_widget.serialize_field("q_m", &self.q_m)?;
+        arith_widget.serialize_field("q_l", &self.q_l)?;
+        arith_widget.serialize_field("q_r", &self.q_r)?;
+        arith_widget.serialize_field("q_o", &self.q_o)?;
+        arith_widget.serialize_field("q_c", &self.q_c)?;
+        arith_widget.serialize_field("q_4", &self.q_4)?;
+        arith_widget.serialize_field("q_arith", &self.q_arith)?;
+        arith_widget.end()
     }
 }
 

--- a/src/constraint_system/widget/arithmetic.rs
+++ b/src/constraint_system/widget/arithmetic.rs
@@ -3,8 +3,10 @@ use crate::commitment_scheme::kzg10::Commitment;
 use crate::constraint_system::standard::linearisation_poly::ProofEvaluations;
 use crate::fft::{Evaluations, Polynomial};
 use bls12_381::{G1Affine, Scalar};
+#[cfg(feature = "serde")]
+use serde::{de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ArithmeticWidget {
     pub q_m: PreProcessedPolynomial,
     pub q_l: PreProcessedPolynomial,
@@ -13,6 +15,129 @@ pub struct ArithmeticWidget {
     pub q_c: PreProcessedPolynomial,
     pub q_4: PreProcessedPolynomial,
     pub q_arith: PreProcessedPolynomial,
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for ArithmeticWidget {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut eval_dom = serializer.serialize_struct("struct ArithmeticWidget", 7)?;
+        eval_dom.serialize_field("q_m", &self.q_m)?;
+        eval_dom.serialize_field("q_l", &self.q_l)?;
+        eval_dom.serialize_field("q_r", &self.q_r)?;
+        eval_dom.serialize_field("q_o", &self.q_o)?;
+        eval_dom.serialize_field("q_c", &self.q_c)?;
+        eval_dom.serialize_field("q_4", &self.q_4)?;
+        eval_dom.serialize_field("q_arith", &self.q_arith)?;
+        eval_dom.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for ArithmeticWidget {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            Qm,
+            Ql,
+            Qr,
+            Qo,
+            Qc,
+            Q4,
+            Qarith,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut ::core::fmt::Formatter,
+                    ) -> ::core::fmt::Result {
+                        formatter.write_str("struct ArithmeticWidget")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "q_m" => Ok(Field::Qm),
+                            "q_l" => Ok(Field::Ql),
+                            "q_r" => Ok(Field::Qr),
+                            "q_o" => Ok(Field::Qo),
+                            "q_c" => Ok(Field::Qc),
+                            "q_4" => Ok(Field::Q4),
+                            "q_arith" => Ok(Field::Qarith),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct ArithmeticWidgetVisitor;
+
+        impl<'de> Visitor<'de> for ArithmeticWidgetVisitor {
+            type Value = ArithmeticWidget;
+
+            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                formatter.write_str("struct ArithmeticWidget")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<ArithmeticWidget, V::Error>
+            where
+                V: serde::de::SeqAccess<'de>,
+            {
+                let q_m = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let q_l = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let q_r = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let q_o = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let q_c = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let q_4 = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let q_arith = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                Ok(ArithmeticWidget {
+                    q_m,
+                    q_l,
+                    q_r,
+                    q_o,
+                    q_c,
+                    q_4,
+                    q_arith,
+                })
+            }
+        }
+
+        const FIELDS: &[&str] = &["q_m", "q_l", "q_r", "q_o", "q_c", "q_4", "q_arith"];
+        deserializer.deserialize_struct("ArithmeticWidget", FIELDS, ArithmeticWidgetVisitor)
+    }
 }
 
 impl ArithmeticWidget {
@@ -132,5 +257,57 @@ impl ArithmeticWidget {
 
         scalars.push(q_arith_eval);
         points.push(self.q_c.commitment.0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fft::EvaluationDomain;
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn q_arith_serde_roundtrip() {
+        use bincode;
+        let coeffs = vec![
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+        ];
+        let dom = EvaluationDomain::new(coeffs.len()).unwrap();
+        let evals = Evaluations::from_vec_and_domain(coeffs.clone(), dom);
+        let poly = Polynomial::from_coefficients_vec(coeffs);
+        let comm = crate::commitment_scheme::kzg10::Commitment::from_affine(G1Affine::generator());
+
+        let prep_poly_w_evals = PreProcessedPolynomial {
+            polynomial: poly.clone(),
+            commitment: comm,
+            evaluations: Some(evals),
+        };
+        let prep_poly_without_evals = PreProcessedPolynomial {
+            polynomial: poly,
+            commitment: comm,
+            evaluations: None,
+        };
+
+        let arith_widget = ArithmeticWidget {
+            q_m: prep_poly_w_evals.clone(),
+            q_l: prep_poly_without_evals.clone(),
+            q_r: prep_poly_without_evals.clone(),
+            q_o: prep_poly_w_evals.clone(),
+            q_c: prep_poly_w_evals.clone(),
+            q_4: prep_poly_w_evals,
+            q_arith: prep_poly_without_evals,
+        };
+
+        // Roundtrip with evals
+        let ser = bincode::serialize(&arith_widget).unwrap();
+        let deser: ArithmeticWidget = bincode::deserialize(&ser).unwrap();
+        assert_eq!(arith_widget, deser);
     }
 }

--- a/src/constraint_system/widget/arithmetic.rs
+++ b/src/constraint_system/widget/arithmetic.rs
@@ -267,7 +267,7 @@ mod tests {
 
     #[cfg(feature = "serde")]
     #[test]
-    fn q_arith_serde_roundtrip() {
+    fn arith_widget_serde_roundtrip() {
         use bincode;
         let coeffs = vec![
             Scalar::one(),

--- a/src/constraint_system/widget/arithmetic.rs
+++ b/src/constraint_system/widget/arithmetic.rs
@@ -284,17 +284,24 @@ mod tests {
         let poly = Polynomial::from_coefficients_vec(coeffs);
         let comm = crate::commitment_scheme::kzg10::Commitment::from_affine(G1Affine::generator());
 
+        // Build directly the widget since the `new()` impl doesn't check any
+        // correctness on the inputs.
         let prep_poly_w_evals = PreProcessedPolynomial {
             polynomial: poly.clone(),
             commitment: comm,
             evaluations: Some(evals),
         };
+
+        // Build directly the widget since the `new()` impl doesn't check any
+        // correctness on the inputs.
         let prep_poly_without_evals = PreProcessedPolynomial {
             polynomial: poly,
             commitment: comm,
             evaluations: None,
         };
 
+        // Build directly the widget since the `new()` impl doesn't check any
+        // correctness on the inputs.
         let arith_widget = ArithmeticWidget {
             q_m: prep_poly_w_evals.clone(),
             q_l: prep_poly_without_evals.clone(),

--- a/src/constraint_system/widget/logic.rs
+++ b/src/constraint_system/widget/logic.rs
@@ -242,7 +242,7 @@ mod tests {
 
     #[cfg(feature = "serde")]
     #[test]
-    fn q_logic_serde_roundtrip() {
+    fn logic_widget_serde_roundtrip() {
         use bincode;
         let coeffs = vec![
             Scalar::one(),

--- a/src/constraint_system/widget/logic.rs
+++ b/src/constraint_system/widget/logic.rs
@@ -259,17 +259,24 @@ mod tests {
         let poly = Polynomial::from_coefficients_vec(coeffs);
         let comm = crate::commitment_scheme::kzg10::Commitment::from_affine(G1Affine::generator());
 
+        // Build directly the widget since the `new()` impl doesn't check any
+        // correctness on the inputs.
         let prep_poly_w_evals = PreProcessedPolynomial {
             polynomial: poly.clone(),
             commitment: comm,
             evaluations: Some(evals),
         };
+
+        // Build directly the widget since the `new()` impl doesn't check any
+        // correctness on the inputs.
         let prep_poly_without_evals = PreProcessedPolynomial {
             polynomial: poly,
             commitment: comm,
             evaluations: None,
         };
 
+        // Build directly the widget since the `new()` impl doesn't check any
+        // correctness on the inputs.
         let logic_widget = LogicWidget {
             q_c: prep_poly_w_evals.clone(),
             q_logic: prep_poly_without_evals.clone(),

--- a/src/constraint_system/widget/logic.rs
+++ b/src/constraint_system/widget/logic.rs
@@ -19,10 +19,10 @@ impl Serialize for LogicWidget {
     where
         S: Serializer,
     {
-        let mut eval_dom = serializer.serialize_struct("struct LogicWidget", 2)?;
-        eval_dom.serialize_field("q_c", &self.q_c)?;
-        eval_dom.serialize_field("q_logic", &self.q_logic)?;
-        eval_dom.end()
+        let mut logic_widget = serializer.serialize_struct("struct LogicWidget", 2)?;
+        logic_widget.serialize_field("q_c", &self.q_c)?;
+        logic_widget.serialize_field("q_logic", &self.q_logic)?;
+        logic_widget.end()
     }
 }
 

--- a/src/constraint_system/widget/logic.rs
+++ b/src/constraint_system/widget/logic.rs
@@ -3,13 +3,99 @@ use super::PreProcessedPolynomial;
 use crate::commitment_scheme::kzg10::Commitment;
 use crate::constraint_system::standard::linearisation_poly::ProofEvaluations;
 use crate::fft::{Evaluations, Polynomial};
-use bls12_381::G1Affine;
-use bls12_381::Scalar;
+use bls12_381::{G1Affine, Scalar};
+#[cfg(feature = "serde")]
+use serde::{de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct LogicWidget {
     pub q_c: PreProcessedPolynomial,
     pub q_logic: PreProcessedPolynomial,
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for LogicWidget {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut eval_dom = serializer.serialize_struct("struct LogicWidget", 2)?;
+        eval_dom.serialize_field("q_c", &self.q_c)?;
+        eval_dom.serialize_field("q_logic", &self.q_logic)?;
+        eval_dom.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for LogicWidget {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            Qc,
+            Qlogic,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut ::core::fmt::Formatter,
+                    ) -> ::core::fmt::Result {
+                        formatter.write_str("struct LogicWidget")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "q_c" => Ok(Field::Qc),
+                            "q_logic" => Ok(Field::Qlogic),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct LogicWidgetVisitor;
+
+        impl<'de> Visitor<'de> for LogicWidgetVisitor {
+            type Value = LogicWidget;
+
+            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                formatter.write_str("struct LogicWidget")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<LogicWidget, V::Error>
+            where
+                V: serde::de::SeqAccess<'de>,
+            {
+                let q_c = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let q_logic = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                Ok(LogicWidget { q_c, q_logic })
+            }
+        }
+
+        const FIELDS: &[&str] = &["q_c", "q_logic"];
+        deserializer.deserialize_struct("LogicWidget", FIELDS, LogicWidgetVisitor)
+    }
 }
 
 impl LogicWidget {
@@ -147,4 +233,51 @@ fn delta_xor_and(a: &Scalar, b: &Scalar, w: &Scalar, c: &Scalar, q_c: &Scalar) -
     let E = three * (a + b + c) - (two * F);
     let B = q_c * ((nine * c) - three * (a + b));
     B + E
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fft::EvaluationDomain;
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn q_logic_serde_roundtrip() {
+        use bincode;
+        let coeffs = vec![
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+        ];
+        let dom = EvaluationDomain::new(coeffs.len()).unwrap();
+        let evals = Evaluations::from_vec_and_domain(coeffs.clone(), dom);
+        let poly = Polynomial::from_coefficients_vec(coeffs);
+        let comm = crate::commitment_scheme::kzg10::Commitment::from_affine(G1Affine::generator());
+
+        let prep_poly_w_evals = PreProcessedPolynomial {
+            polynomial: poly.clone(),
+            commitment: comm,
+            evaluations: Some(evals),
+        };
+        let prep_poly_without_evals = PreProcessedPolynomial {
+            polynomial: poly,
+            commitment: comm,
+            evaluations: None,
+        };
+
+        let logic_widget = LogicWidget {
+            q_c: prep_poly_w_evals.clone(),
+            q_logic: prep_poly_without_evals.clone(),
+        };
+
+        // Roundtrip with evals
+        let ser = bincode::serialize(&logic_widget).unwrap();
+        let deser: LogicWidget = bincode::deserialize(&ser).unwrap();
+        assert_eq!(logic_widget, deser);
+    }
 }

--- a/src/constraint_system/widget/mod.rs
+++ b/src/constraint_system/widget/mod.rs
@@ -13,7 +13,7 @@ pub use range::RangeWidget;
 #[cfg(feature = "serde")]
 use serde::{de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct PreProcessedPolynomial {
     pub(crate) polynomial: Polynomial,
     pub(crate) commitment: Commitment,

--- a/src/constraint_system/widget/mod.rs
+++ b/src/constraint_system/widget/mod.rs
@@ -10,12 +10,113 @@ pub use arithmetic::ArithmeticWidget;
 pub use logic::LogicWidget;
 pub use permutation::PermutationWidget;
 pub use range::RangeWidget;
+#[cfg(feature = "serde")]
+use serde::{de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct PreProcessedPolynomial {
     pub(crate) polynomial: Polynomial,
     pub(crate) commitment: Commitment,
     pub(crate) evaluations: Option<Evaluations>,
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for PreProcessedPolynomial {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut eval_dom = serializer.serialize_struct("struct PreProcessedPolynomial", 3)?;
+        eval_dom.serialize_field("poly", &self.polynomial)?;
+        eval_dom.serialize_field("comm", &self.commitment)?;
+        eval_dom.serialize_field("evals", &self.evaluations)?;
+        eval_dom.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for PreProcessedPolynomial {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            Poly,
+            Comm,
+            Evals,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut ::core::fmt::Formatter,
+                    ) -> ::core::fmt::Result {
+                        formatter.write_str("struct PreProcessedPolynomial")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "poly" => Ok(Field::Poly),
+                            "comm" => Ok(Field::Comm),
+                            "evals" => Ok(Field::Evals),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct PreProcessedPolynomialVisitor;
+
+        impl<'de> Visitor<'de> for PreProcessedPolynomialVisitor {
+            type Value = PreProcessedPolynomial;
+
+            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                formatter.write_str("struct PreProcessedPolynomial")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<PreProcessedPolynomial, V::Error>
+            where
+                V: serde::de::SeqAccess<'de>,
+            {
+                let polynomial = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let commitment = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let evaluations = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                Ok(PreProcessedPolynomial {
+                    polynomial,
+                    commitment,
+                    evaluations,
+                })
+            }
+        }
+
+        const FIELDS: &[&str] = &["poly", "comm", "evals"];
+        deserializer.deserialize_struct(
+            "PreProcessedPolynomial",
+            FIELDS,
+            PreProcessedPolynomialVisitor,
+        )
+    }
 }
 
 impl PreProcessedPolynomial {
@@ -25,5 +126,53 @@ impl PreProcessedPolynomial {
             commitment: t.1,
             evaluations: t.2,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fft::EvaluationDomain;
+    use bls12_381::{G1Affine, Scalar};
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn prep_poly_serde_roundtrip() {
+        use bincode;
+        let coeffs = vec![
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+        ];
+        let dom = EvaluationDomain::new(coeffs.len()).unwrap();
+        let evals = Evaluations::from_vec_and_domain(coeffs.clone(), dom);
+        let poly = Polynomial::from_coefficients_vec(coeffs);
+        let comm = crate::commitment_scheme::kzg10::Commitment::from_affine(G1Affine::generator());
+
+        let prep_poly_w_evals = PreProcessedPolynomial {
+            polynomial: poly.clone(),
+            commitment: comm,
+            evaluations: Some(evals),
+        };
+        let prep_poly_without_evals = PreProcessedPolynomial {
+            polynomial: poly,
+            commitment: comm,
+            evaluations: None,
+        };
+
+        // Roundtrip with evals
+        let ser = bincode::serialize(&prep_poly_w_evals).unwrap();
+        let deser: PreProcessedPolynomial = bincode::deserialize(&ser).unwrap();
+        assert_eq!(prep_poly_w_evals, deser);
+
+        // Roundtrip without evals
+        let ser = bincode::serialize(&prep_poly_without_evals).unwrap();
+        let deser: PreProcessedPolynomial = bincode::deserialize(&ser).unwrap();
+        assert_eq!(prep_poly_without_evals, deser);
     }
 }

--- a/src/constraint_system/widget/permutation.rs
+++ b/src/constraint_system/widget/permutation.rs
@@ -448,11 +448,16 @@ mod tests {
         let poly = Polynomial::from_coefficients_vec(coeffs);
         let comm = crate::commitment_scheme::kzg10::Commitment::from_affine(G1Affine::generator());
 
+        // Build directly the widget since the `new()` impl doesn't check any
+        // correctness on the inputs.
         let prep_poly_w_evals = PreProcessedPolynomial {
             polynomial: poly.clone(),
             commitment: comm,
             evaluations: Some(evals.clone()),
         };
+
+        // Build directly the widget since the `new()` impl doesn't check any
+        // correctness on the inputs.
         let prep_poly_without_evals = PreProcessedPolynomial {
             polynomial: poly,
             commitment: comm,

--- a/src/constraint_system/widget/permutation.rs
+++ b/src/constraint_system/widget/permutation.rs
@@ -8,14 +8,131 @@ use crate::fft::{EvaluationDomain, Evaluations, Polynomial};
 use crate::permutation::constants::{K1, K2, K3};
 use bls12_381::{G1Affine, Scalar};
 use rayon::prelude::*;
+#[cfg(feature = "serde")]
+use serde::{de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct PermutationWidget {
     pub left_sigma: PreProcessedPolynomial,
     pub right_sigma: PreProcessedPolynomial,
     pub out_sigma: PreProcessedPolynomial,
     pub fourth_sigma: PreProcessedPolynomial,
     pub linear_evaluations: Evaluations, // Evaluations of f(x) = X
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for PermutationWidget {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut perm_widget = serializer.serialize_struct("struct PermutationWidget", 7)?;
+        perm_widget.serialize_field("left_sig", &self.left_sigma)?;
+        perm_widget.serialize_field("right_sig", &self.right_sigma)?;
+        perm_widget.serialize_field("out_sig", &self.out_sigma)?;
+        perm_widget.serialize_field("fourth_sig", &self.fourth_sigma)?;
+        perm_widget.serialize_field("lin_evals", &self.linear_evaluations)?;
+        perm_widget.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for PermutationWidget {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            LeftSigma,
+            RightSigma,
+            OutSigma,
+            FourthSigma,
+            LinEvals,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut ::core::fmt::Formatter,
+                    ) -> ::core::fmt::Result {
+                        formatter.write_str("struct PermutationWidget")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "left_sig" => Ok(Field::LeftSigma),
+                            "right_sig" => Ok(Field::RightSigma),
+                            "out_sig" => Ok(Field::OutSigma),
+                            "fourth_sig" => Ok(Field::FourthSigma),
+                            "lin_evals" => Ok(Field::LinEvals),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct PermutationWidgetVisitor;
+
+        impl<'de> Visitor<'de> for PermutationWidgetVisitor {
+            type Value = PermutationWidget;
+
+            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                formatter.write_str("struct PermutationWidget")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<PermutationWidget, V::Error>
+            where
+                V: serde::de::SeqAccess<'de>,
+            {
+                let left_sigma = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let right_sigma = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let out_sigma = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let fourth_sigma = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let linear_evaluations = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                Ok(PermutationWidget {
+                    left_sigma,
+                    right_sigma,
+                    out_sigma,
+                    fourth_sigma,
+                    linear_evaluations,
+                })
+            }
+        }
+
+        const FIELDS: &[&str] = &[
+            "left_sig",
+            "right_sig",
+            "out_sig",
+            "fourth_sig",
+            "lin_evals",
+        ];
+        deserializer.deserialize_struct("PermutationWidget", FIELDS, PermutationWidgetVisitor)
+    }
 }
 
 impl PermutationWidget {
@@ -305,4 +422,56 @@ pub fn compute_is_one_polynomial(
         .map(|i| alpha_sq_l1_evals[i] * (z_eval_4n[i] - Scalar::one()))
         .collect();
     Evaluations::from_vec_and_domain(t_4, domain_4n)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fft::EvaluationDomain;
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn perm_widget_serde_roundtrip() {
+        use bincode;
+        let coeffs = vec![
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+        ];
+        let dom = EvaluationDomain::new(coeffs.len()).unwrap();
+        let evals = Evaluations::from_vec_and_domain(coeffs.clone(), dom);
+        let poly = Polynomial::from_coefficients_vec(coeffs);
+        let comm = crate::commitment_scheme::kzg10::Commitment::from_affine(G1Affine::generator());
+
+        let prep_poly_w_evals = PreProcessedPolynomial {
+            polynomial: poly.clone(),
+            commitment: comm,
+            evaluations: Some(evals.clone()),
+        };
+        let prep_poly_without_evals = PreProcessedPolynomial {
+            polynomial: poly,
+            commitment: comm,
+            evaluations: None,
+        };
+
+        // Build directly the widget since the `new()` impl doesn't check any
+        // correctness on the inputs.
+        let perm_widget = PermutationWidget {
+            left_sigma: prep_poly_w_evals.clone(),
+            right_sigma: prep_poly_without_evals.clone(),
+            out_sigma: prep_poly_without_evals.clone(),
+            fourth_sigma: prep_poly_w_evals.clone(),
+            linear_evaluations: evals,
+        };
+
+        // Roundtrip with evals
+        let ser = bincode::serialize(&perm_widget).unwrap();
+        let deser: PermutationWidget = bincode::deserialize(&ser).unwrap();
+        assert_eq!(perm_widget, deser);
+    }
 }

--- a/src/constraint_system/widget/permutation.rs
+++ b/src/constraint_system/widget/permutation.rs
@@ -26,7 +26,7 @@ impl Serialize for PermutationWidget {
     where
         S: Serializer,
     {
-        let mut perm_widget = serializer.serialize_struct("struct PermutationWidget", 7)?;
+        let mut perm_widget = serializer.serialize_struct("struct PermutationWidget", 5)?;
         perm_widget.serialize_field("left_sig", &self.left_sigma)?;
         perm_widget.serialize_field("right_sig", &self.right_sigma)?;
         perm_widget.serialize_field("out_sig", &self.out_sigma)?;

--- a/src/constraint_system/widget/range.rs
+++ b/src/constraint_system/widget/range.rs
@@ -189,12 +189,16 @@ mod tests {
         let poly = Polynomial::from_coefficients_vec(coeffs);
         let comm = crate::commitment_scheme::kzg10::Commitment::from_affine(G1Affine::generator());
 
+        // Build directly the widget since the `new()` impl doesn't check any
+        // correctness on the inputs.
         let prep_poly_w_evals = PreProcessedPolynomial {
             polynomial: poly.clone(),
             commitment: comm,
             evaluations: Some(evals),
         };
 
+        // Build directly the widget since the `new()` impl doesn't check any
+        // correctness on the inputs.
         let range_widget = RangeWidget {
             q_range: prep_poly_w_evals,
         };

--- a/src/fft/domain.rs
+++ b/src/fft/domain.rs
@@ -152,6 +152,8 @@ impl<'de> Deserialize<'de> for EvaluationDomain {
                 let generator_inv = seq
                     .next_element()?
                     .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                // Deserialization will fail if the log_size_of_group > TWO_ADACITY
+                // according to the `new()` fn implemented for `EvaluationDomain`.
                 match log_size_of_group < TWO_ADACITY {
                     true => Ok(EvaluationDomain {
                         size,

--- a/src/fft/domain.rs
+++ b/src/fft/domain.rs
@@ -14,6 +14,8 @@ use super::Evaluations;
 use bls12_381::{Scalar, GENERATOR, ROOT_OF_UNITY, TWO_ADACITY};
 use core::fmt;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
+#[cfg(feature = "serde")]
+use serde::{de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 use std::ops::MulAssign;
 
 /// Defines a domain over which finite field (I)FFTs can be performed. Works
@@ -40,6 +42,143 @@ pub struct EvaluationDomain {
 impl fmt::Debug for EvaluationDomain {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Multiplicative subgroup of size {}", self.size)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for EvaluationDomain {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut eval_dom = serializer.serialize_struct("struct EvaluationDomain", 7)?;
+        eval_dom.serialize_field("size", &self.size)?;
+        eval_dom.serialize_field("log_size_of_group", &self.log_size_of_group)?;
+        eval_dom.serialize_field("size_as_field_element", &self.size_as_field_element)?;
+        eval_dom.serialize_field("size_inv", &self.size_inv)?;
+        eval_dom.serialize_field("group_gen", &self.group_gen)?;
+        eval_dom.serialize_field("group_gen_inv", &self.group_gen_inv)?;
+        eval_dom.serialize_field("generator_inv", &self.generator_inv)?;
+
+        eval_dom.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for EvaluationDomain {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            Size,
+            LogSizeOfGroup,
+            SizeAsFieldElement,
+            SizeInv,
+            GroupGen,
+            GroupGenInv,
+            GenInv,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut ::core::fmt::Formatter,
+                    ) -> ::core::fmt::Result {
+                        formatter.write_str("struct EvaluationDomain")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "size" => Ok(Field::Size),
+                            "log_size_of_group" => Ok(Field::LogSizeOfGroup),
+                            "size_as_field_element" => Ok(Field::SizeAsFieldElement),
+                            "size_inv" => Ok(Field::SizeInv),
+                            "group_gen" => Ok(Field::GroupGen),
+                            "group_gen_inv" => Ok(Field::GroupGenInv),
+                            "generator_inv" => Ok(Field::GenInv),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct EvaluationDomainVisitor;
+
+        impl<'de> Visitor<'de> for EvaluationDomainVisitor {
+            type Value = EvaluationDomain;
+
+            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                formatter.write_str("struct EvaluationDomain")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<EvaluationDomain, V::Error>
+            where
+                V: serde::de::SeqAccess<'de>,
+            {
+                let size = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let log_size_of_group = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let size_as_field_element = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let size_inv = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let group_gen = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let group_gen_inv = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let generator_inv = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                match log_size_of_group < TWO_ADACITY {
+                    true => Ok(EvaluationDomain {
+                        size,
+                        log_size_of_group,
+                        size_as_field_element,
+                        size_inv,
+                        group_gen,
+                        group_gen_inv,
+                        generator_inv,
+                    }),
+                    false => Err(serde::de::Error::custom(
+                        "log_size_of_group is greater than Bls12_381 two_adacity",
+                    )),
+                }
+            }
+        }
+
+        const FIELDS: &'static [&'static str] = &[
+            "size",
+            "log_size_of_group",
+            "size_as_field_element",
+            "size_inv",
+            "group_gen",
+            "group_gen_inv",
+            "generator_inv",
+        ];
+        deserializer.deserialize_struct("EvaluationDomain", FIELDS, EvaluationDomainVisitor)
     }
 }
 
@@ -446,5 +585,16 @@ mod tests {
                 assert_eq!(element, domain.group_gen.pow(&[i as u64, 0, 0, 0]));
             }
         }
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn eval_domain_serde_roundtrip() {
+        use bincode;
+        let eval_dom = EvaluationDomain::new(((1 << 13) - 233) as usize).unwrap();
+        let ser = bincode::serialize(&eval_dom).unwrap();
+        let deser: EvaluationDomain = bincode::deserialize(&ser).unwrap();
+
+        assert_eq!(eval_dom, deser);
     }
 }

--- a/src/fft/domain.rs
+++ b/src/fft/domain.rs
@@ -169,7 +169,7 @@ impl<'de> Deserialize<'de> for EvaluationDomain {
             }
         }
 
-        const FIELDS: &'static [&'static str] = &[
+        const FIELDS: &[&str] = &[
             "size",
             "log_size_of_group",
             "size_as_field_element",

--- a/src/fft/evaluations.rs
+++ b/src/fft/evaluations.rs
@@ -4,6 +4,8 @@ use super::domain::EvaluationDomain;
 use super::polynomial::Polynomial;
 use bls12_381::Scalar;
 use core::ops::{Add, AddAssign, DivAssign, Index, Mul, MulAssign, Sub, SubAssign};
+#[cfg(feature = "serde")]
+use serde::{de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 /// Stores a polynomial in evaluation form.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Evaluations {
@@ -13,6 +15,90 @@ pub struct Evaluations {
     domain: EvaluationDomain,
 }
 
+#[cfg(feature = "serde")]
+impl Serialize for Evaluations {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut eval_dom = serializer.serialize_struct("struct Evaluations", 2)?;
+        eval_dom.serialize_field("evals", &self.evals)?;
+        eval_dom.serialize_field("domain", &self.domain)?;
+        eval_dom.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for Evaluations {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            Evals,
+            EvalDomain,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut ::core::fmt::Formatter,
+                    ) -> ::core::fmt::Result {
+                        formatter.write_str("struct Evaluations")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "evals" => Ok(Field::Evals),
+                            "domain" => Ok(Field::EvalDomain),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct EvaluationsVisitor;
+
+        impl<'de> Visitor<'de> for EvaluationsVisitor {
+            type Value = Evaluations;
+
+            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                formatter.write_str("struct Evaluations")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<Evaluations, V::Error>
+            where
+                V: serde::de::SeqAccess<'de>,
+            {
+                let evals = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let domain = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                Ok(Evaluations { evals, domain })
+            }
+        }
+
+        const FIELDS: &[&str] = &["evals", "domain"];
+        deserializer.deserialize_struct("Evaluations", FIELDS, EvaluationsVisitor)
+    }
+}
 impl Evaluations {
     /// Construct `Self` from evaluations and a domain.
     pub fn from_vec_and_domain(evals: Vec<Scalar>, domain: EvaluationDomain) -> Self {
@@ -114,5 +200,32 @@ impl<'a> DivAssign<&'a Evaluations> for Evaluations {
             .iter_mut()
             .zip(&other.evals)
             .for_each(|(a, b)| *a *= b.invert().unwrap());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn evals_serde_roundtrip() {
+        use bincode;
+        let coeffs = vec![
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+        ];
+        let dom = EvaluationDomain::new(coeffs.len()).unwrap();
+        let evals = Evaluations::from_vec_and_domain(coeffs, dom);
+        let ser = bincode::serialize(&evals).unwrap();
+        let deser: Evaluations = bincode::deserialize(&ser).unwrap();
+
+        assert_eq!(evals, deser);
     }
 }

--- a/src/fft/polynomial.rs
+++ b/src/fft/polynomial.rs
@@ -30,6 +30,58 @@ impl DerefMut for Polynomial {
     }
 }
 
+#[cfg(feature = "serde")]
+use serde::de::Visitor;
+#[cfg(feature = "serde")]
+use serde::{self, ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
+
+#[cfg(feature = "serde")]
+impl Serialize for Polynomial {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut tup = serializer.serialize_seq(Some(self.len()))?;
+        for coeff in &self.coeffs {
+            tup.serialize_element(&coeff)?;
+        }
+        tup.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for Polynomial {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct PolynomialVisitor;
+
+        impl<'de> Visitor<'de> for PolynomialVisitor {
+            type Value = Polynomial;
+
+            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                formatter.write_str("a polynomial with valid scalars")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Polynomial, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut scalar_vec = Vec::new();
+                // Visit each element in the inner array and push it onto
+                // the existing vector.
+                while let Some(elem) = seq.next_element()? {
+                    scalar_vec.push(elem)
+                }
+                Ok(Polynomial::from_coefficients_vec(scalar_vec))
+            }
+        }
+
+        deserializer.deserialize_seq(PolynomialVisitor)
+    }
+}
+
 impl Polynomial {
     /// Returns the zero polynomial.
     pub fn zero() -> Self {
@@ -439,5 +491,23 @@ mod test {
         let expected_quotient =
             Polynomial::from_coefficients_vec(vec![Scalar::one(), Scalar::one()]);
         assert_eq!(quotient, expected_quotient);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn poly_serialisation_roundtrip() {
+        use bincode;
+        let poly = Polynomial::from_coefficients_slice(&[
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+            Scalar::one(),
+        ]);
+        let ser = bincode::serialize(&poly).unwrap();
+        let deser: Polynomial = bincode::deserialize(&ser).unwrap();
+
+        assert!(&poly.coeffs[..] == &deser.coeffs[..]);
     }
 }

--- a/src/fft/polynomial.rs
+++ b/src/fft/polynomial.rs
@@ -31,9 +31,9 @@ impl DerefMut for Polynomial {
 }
 
 #[cfg(feature = "serde")]
-use serde::de::Visitor;
-#[cfg(feature = "serde")]
-use serde::{self, ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{
+    self, de::Visitor, ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer,
+};
 
 #[cfg(feature = "serde")]
 impl Serialize for Polynomial {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,11 @@ mod util;
 #[macro_use]
 extern crate failure;
 
+#[cfg(all(test, feature = "serde"))]
+extern crate bincode;
+#[cfg(feature = "serde")]
+extern crate serde;
+
 #[cfg(feature = "nightly")]
 #[doc(include = "../docs/notes-intro.md")]
 pub mod notes {


### PR DESCRIPTION
- Adds serde impl for `PreProcessedCircuit` and it's components. Closes #170
- Adds serde impl for `Proof` and it's components. Closes #171
- Adds serde impl for `SRS` and it's components. Closes #127 

The serde implementations are behind a `serde` feature which comes enabled by default in `default-features`. See `Cargo.toml`. On this way, the `serde` implementations are optional to be or not used by the end-user.

This Pr also adds `PartialEq` & `Eq` derivations for almost all of  the structs of the crate since those were needed in order to do the serde impl testing.

# Proof Serde final results:
- Memory -> `SerializedProof` with `bincode` = 972bytes.
- Performance ->
```
Proof Serde/Deserialization                                                                             
                        time:   [6.5842 ms 6.6738 ms 6.7583 ms]
Proof Serde/Serialization                                                                             
                        time:   [7.5748 us 7.7101 us 7.8419 us]
```

Included flamegraph of the `Proof` deserialization:
![](https://user-images.githubusercontent.com/37264926/79556801-da5f7380-80a1-11ea-9bd1-711ac34e2a27.png)

