### PR TITLE
Implement padding on perm poly computation

### DIFF
--- a/src/permutation/permutation.rs
+++ b/src/permutation/permutation.rs
@@ -194,12 +194,16 @@ impl Permutation {
             &Polynomial,
         ),
     ) -> Polynomial {
+        // We need to pad the witness coeffs to match the `EvaluationDomain`
+        // size which is usually the next power of two respectively to the
+        // domain.size
+        let padding = vec![Scalar::zero(); domain.size() - w_l.len()];
         let z_evaluations = self.compute_fast_permutation_poly(
             domain,
-            w_l,
-            w_r,
-            w_o,
-            w_4,
+            &[w_l, &padding].concat(),
+            &[w_r, &padding].concat(),
+            &[w_o, &padding].concat(),
+            &[w_4, &padding].concat(),
             beta,
             gamma,
             (


### PR DESCRIPTION
This fixes the problems found in issues like #198 & #186 

We need to pad the witness values since otherways, the len
of them is lower than the evaluation domain size that it's
used.

To put an example:
We preprocess a circuit of size 21 but we pad it to the next
pow of two = 32.

When we try to build proofs with it later, so using the same
prep_circ, it's domain size = 32 but the length of the witnesses
keeps being the same as the circuit size = 21.

This causes the permutation_poly computation function to try to
access indexes of the witness vectors that do not have any
value inside of them.

The solution passes by padding with `Scalar::zero` these vecs.