### PR TITLE
Pad witness in Prover

### DIFF
--- a/src/constraint_system/standard/composer.rs
+++ b/src/constraint_system/standard/composer.rs
@@ -272,11 +272,11 @@ impl Composer for StandardComposer {
         let mut w_4_scalar = self.to_scalars(&self.w_4);
 
         // Pad witness
-        let pad = vec![Scalar::zero(); domain.size() - w_l.len()].iter();
-        w_l_scalar.extend(pad);
-        w_r_scalar.extend(pad);
-        w_o_scalar.extend(pad);
-        w_4_scalar.extend(pad);
+        let pad = vec![Scalar::zero(); domain.size() - w_l_scalar.len()];
+        w_l_scalar.extend(pad.iter());
+        w_r_scalar.extend(pad.iter());
+        w_o_scalar.extend(pad.iter());
+        w_4_scalar.extend(pad.iter());
 
         // Witnesses are now in evaluation form, convert them to coefficients
         // So that we may commit to them

--- a/src/constraint_system/standard/composer.rs
+++ b/src/constraint_system/standard/composer.rs
@@ -265,25 +265,20 @@ impl Composer for StandardComposer {
 
         //1. Compute witness Polynomials
         //
-        // Convert Variables to Scalars
-        let mut w_l_scalar = self.to_scalars(&self.w_l);
-        let mut w_r_scalar = self.to_scalars(&self.w_r);
-        let mut w_o_scalar = self.to_scalars(&self.w_o);
-        let mut w_4_scalar = self.to_scalars(&self.w_4);
-
-        // Pad witness
-        let pad = vec![Scalar::zero(); domain.size() - w_l_scalar.len()];
-        w_l_scalar.extend(pad.iter());
-        w_r_scalar.extend(pad.iter());
-        w_o_scalar.extend(pad.iter());
-        w_4_scalar.extend(pad.iter());
+        // Convert Variables to Scalars padding them to the
+        // correct domain size.
+        let pad = vec![Scalar::zero(); domain.size() - self.w_l.len()];
+        let w_l_scalar = &[&self.to_scalars(&self.w_l)[..], &pad].concat();
+        let w_r_scalar = &[&self.to_scalars(&self.w_r)[..], &pad].concat();
+        let w_o_scalar = &[&self.to_scalars(&self.w_o)[..], &pad].concat();
+        let w_4_scalar = &[&self.to_scalars(&self.w_4)[..], &pad].concat();
 
         // Witnesses are now in evaluation form, convert them to coefficients
         // So that we may commit to them
-        let w_l_poly = Polynomial::from_coefficients_vec(domain.ifft(&w_l_scalar));
-        let w_r_poly = Polynomial::from_coefficients_vec(domain.ifft(&w_r_scalar));
-        let w_o_poly = Polynomial::from_coefficients_vec(domain.ifft(&w_o_scalar));
-        let w_4_poly = Polynomial::from_coefficients_vec(domain.ifft(&w_4_scalar));
+        let w_l_poly = Polynomial::from_coefficients_vec(domain.ifft(w_l_scalar));
+        let w_r_poly = Polynomial::from_coefficients_vec(domain.ifft(w_r_scalar));
+        let w_o_poly = Polynomial::from_coefficients_vec(domain.ifft(w_o_scalar));
+        let w_4_poly = Polynomial::from_coefficients_vec(domain.ifft(w_4_scalar));
 
         // Commit to witness polynomials
         let w_l_poly_commit = commit_key.commit(&w_l_poly).unwrap();

--- a/src/constraint_system/standard/composer.rs
+++ b/src/constraint_system/standard/composer.rs
@@ -266,11 +266,17 @@ impl Composer for StandardComposer {
         //1. Compute witness Polynomials
         //
         // Convert Variables to Scalars
-        // XXX: Maybe there's no need to allocate `to_scalars` returning &[Scalar].
-        let w_l_scalar = self.to_scalars(&self.w_l);
-        let w_r_scalar = self.to_scalars(&self.w_r);
-        let w_o_scalar = self.to_scalars(&self.w_o);
-        let w_4_scalar = self.to_scalars(&self.w_4);
+        let mut w_l_scalar = self.to_scalars(&self.w_l);
+        let mut w_r_scalar = self.to_scalars(&self.w_r);
+        let mut w_o_scalar = self.to_scalars(&self.w_o);
+        let mut w_4_scalar = self.to_scalars(&self.w_4);
+
+        // Pad witness
+        let pad = vec![Scalar::zero(); domain.size() - w_l.len()].iter();
+        w_l_scalar.extend(pad);
+        w_r_scalar.extend(pad);
+        w_o_scalar.extend(pad);
+        w_4_scalar.extend(pad);
 
         // Witnesses are now in evaluation form, convert them to coefficients
         // So that we may commit to them

--- a/src/permutation/permutation.rs
+++ b/src/permutation/permutation.rs
@@ -200,13 +200,12 @@ impl Permutation {
             &Polynomial,
         ),
     ) -> Polynomial {
-        let pad = vec![Scalar::zero(); domain.size() - w_l.len()];
         let z_evaluations = self.compute_fast_permutation_poly(
             domain,
-            &[w_l, &pad].concat(),
-            &[w_r, &pad].concat(),
-            &[w_o, &pad].concat(),
-            &[w_4, &pad].concat(),
+            w_l,
+            w_r,
+            w_o,
+            w_4,
             beta,
             gamma,
             (


### PR DESCRIPTION
This removes the responsibility of padding from the permutation module, to the prover. 

Was merged in #192 from #193 