### PR TITLE
Implement propper Error handling for the plonk library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ after_success:
         sudo make install &&
         cd ../.. &&
         rm -rf kcov-master &&
-        for file in target/debug/plonk-*[^\.d]; do mkdir -p "target/cov/$(basename $file)"; kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
+        for file in target/debug/dusk_plonk-*[^\.d]; do mkdir -p "target/cov/$(basename $file)"; kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
         bash <(curl -s https://codecov.io/bash) &&
         echo "Uploaded code coverage"
       fi
@@ -85,7 +85,7 @@ after_success:
   - |
       if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "nightly" && "$TRAVIS_PULL_REQUEST" = "false" && "$TRAVIS_BRANCH" == "master" ]]; then
         cargo doc --no-deps --features nightly &&
-        echo "<meta http-equiv=refresh content=0;url=plonk/index.html>" > target/doc/index.html &&
+        echo "<meta http-equiv=refresh content=0;url=dusk_plonk/index.html>" > target/doc/index.html &&
         git clone https://github.com/davisp/ghp-import.git &&
         ./ghp-import/ghp_import.py -n -p -f -m "Documentation upload" -r https://"$GH_TOKEN"@github.com/"$TRAVIS_REPO_SLUG.git" target/doc &&
         echo "Uploaded documentation"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-## [0.1.0] - 23-04-20
+## [0.1.0] - 25-04-20
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ dusk-bls12_381 = "0.1.0"
 itertools = "0.8.2"
 rand_chacha = "0.2"
 rayon = "1.3.0"
-failure = { version = "0.1", default-features = false, features = ["derive"] }
+failure = "0.1.7"
 serde = {version = "1.0.106", features = ["derive"], optional = true} 
 
 [dev-dependencies]

--- a/benchmarks/plonk_benchmarks.rs
+++ b/benchmarks/plonk_benchmarks.rs
@@ -5,38 +5,32 @@ extern crate merlin;
 use bincode;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
-use dusk_plonk::constraint_system::StandardComposer;
-use dusk_plonk::fft::EvaluationDomain;
 use dusk_plonk::proof_system::Proof;
-use merlin::Transcript;
+use dusk_plonk::proof_system::Prover;
 
 mod serde_benches {
     use super::*;
 
     pub fn proof_serde(c: &mut Criterion) {
         let public_parameters = PublicParameters::setup(1 << 18, &mut rand::thread_rng()).unwrap();
-        let mut composer: StandardComposer = StandardComposer::new();
+        let mut prover = Prover::default();
         // Fill the composer with dummy constraints until it has a
         // size near to DuskNetworks' circuit (2^16 constraints).
         //
         // `add_dummy_constraints` adds 7 constraints to the circuit/call
         // so we need 2^16 / 7 calls to the method ~ 9361
         for _ in 0..9361 {
-            composer.add_dummy_constraints();
+            prover.mut_cs().add_dummy_constraints();
         }
 
         let (ck, _) = public_parameters
-            .trim(2 * composer.circuit_size().next_power_of_two())
+            .trim(2 * prover.circuit_size().next_power_of_two())
             .unwrap();
-        let domain = EvaluationDomain::new(composer.circuit_size()).unwrap();
-        let mut transcript = Transcript::new(b"12381");
 
         // Preprocess circuit
-        let preprocessed_circuit = composer.preprocess(&ck, &mut transcript, &domain).unwrap();
+        prover.preprocess(&ck).unwrap();
 
-        let proof = composer
-            .prove(&ck, &preprocessed_circuit, &mut transcript)
-            .unwrap();
+        let proof = prover.prove(&ck).unwrap();
         let proof_ser_data = bincode::serialize(&proof).unwrap();
 
         c.bench_with_input(

--- a/benchmarks/plonk_benchmarks.rs
+++ b/benchmarks/plonk_benchmarks.rs
@@ -32,7 +32,7 @@ mod serde_benches {
         let mut transcript = Transcript::new(b"12381");
 
         // Preprocess circuit
-        let preprocessed_circuit = composer.preprocess(&ck, &mut transcript, &domain);
+        let preprocessed_circuit = composer.preprocess(&ck, &mut transcript, &domain).unwrap();
 
         let proof = composer.prove(&ck, &preprocessed_circuit, &mut transcript);
         let proof_ser_data = bincode::serialize(&proof).unwrap();

--- a/benchmarks/plonk_benchmarks.rs
+++ b/benchmarks/plonk_benchmarks.rs
@@ -34,7 +34,9 @@ mod serde_benches {
         // Preprocess circuit
         let preprocessed_circuit = composer.preprocess(&ck, &mut transcript, &domain).unwrap();
 
-        let proof = composer.prove(&ck, &preprocessed_circuit, &mut transcript);
+        let proof = composer
+            .prove(&ck, &preprocessed_circuit, &mut transcript)
+            .unwrap();
         let proof_ser_data = bincode::serialize(&proof).unwrap();
 
         c.bench_with_input(

--- a/examples/0_setup_srs.rs
+++ b/examples/0_setup_srs.rs
@@ -33,9 +33,10 @@ extern crate dusk_plonk;
 extern crate rand;
 
 use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
+use failure::Error;
 use std::fs;
 
-fn main() -> () {
+fn main() -> Result<(), Error> {
     // First of all we generate our `PublicParameters` data structure.
     // NOTE that we need to specify the `size` of them.
     //
@@ -49,7 +50,7 @@ fn main() -> () {
     // For this example we will assume that our circuit_size is between 2^10 & 2^11
     // gates, so we will basically use `max_size` as `2^11`.
 
-    let public_params = PublicParameters::setup(1 << 11, &mut rand::thread_rng()).unwrap();
+    let public_params = PublicParameters::setup(1 << 11, &mut rand::thread_rng())?;
 
     // Now that we have our `PublicParameters` generated, we will serialize them so that
     // they can be used for the next examples.
@@ -61,4 +62,5 @@ fn main() -> () {
     let ser_pub_params = bincode::serialize(&public_params).unwrap();
 
     fs::write("examples/.public_params.bin", &ser_pub_params).expect("Unable to write file");
+    Ok(())
 }

--- a/examples/1_compose_prove_verify.rs
+++ b/examples/1_compose_prove_verify.rs
@@ -303,17 +303,19 @@ fn main() -> Result<(), Error> {
         &prover_key,
         &pre_processed_circ,
         &mut prover_transcript.clone(),
-    );
+    )?;
 
     let zero = Scalar::zero();
     let one = Scalar::one();
     // On this example, since we are using the same composer, we just need to
-    assert!(proof.verify(
+    proof.verify(
         &pre_processed_circ,
         &mut prover_transcript,
         &verifier_key,
-        &vec![zero, zero, zero, zero, zero, zero, zero, zero, zero, zero, zero, zero, -one, -one],
-    ));
+        &vec![
+            zero, zero, zero, zero, zero, zero, zero, zero, zero, zero, zero, zero, -one, -one,
+        ],
+    )?;
     println!("Proof verified succesfully!");
     Ok(())
 }

--- a/examples/1_compose_prove_verify.rs
+++ b/examples/1_compose_prove_verify.rs
@@ -50,10 +50,11 @@ use dusk_bls12_381::Scalar;
 use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
 use dusk_plonk::constraint_system::StandardComposer;
 use dusk_plonk::fft::EvaluationDomain;
+use failure::Error;
 use merlin::Transcript;
 use std::fs;
 
-fn main() {
+fn main() -> Result<(), Error> {
     //
     //
     // Circuit construction stage
@@ -282,7 +283,8 @@ fn main() {
         .unwrap();
 
     // Now we can finally preprocess the circuit that we've built.
-    let pre_processed_circ = composer.preprocess(&prover_key, &mut prover_transcript, &eval_domain);
+    let pre_processed_circ =
+        composer.preprocess(&prover_key, &mut prover_transcript, &eval_domain)?;
 
     // We could now store our `PreProcessedCircuit` serialized with `bincode`.
     // let ser_prep_cir = bincode::serialize(&pre_processed_circ).unwrap();
@@ -313,4 +315,5 @@ fn main() {
         &vec![zero, zero, zero, zero, zero, zero, zero, zero, zero, zero, zero, zero, -one, -one],
     ));
     println!("Proof verified succesfully!");
+    Ok(())
 }

--- a/examples/3_0_setup_for_gadgets.rs
+++ b/examples/3_0_setup_for_gadgets.rs
@@ -59,28 +59,28 @@ fn build_prep_circ() -> Result<PreProcessedCircuit, Error> {
         Scalar::one(),
     );
     let circ_size = composer.circuit_size();
-    let eval_domain = EvaluationDomain::new(circ_size).unwrap();
+    let eval_domain = EvaluationDomain::new(circ_size)?;
     let ser_pub_params = fs::read(&"examples/.public_params.bin")
         .expect("File not found. Run example `0_setup_srs` first please");
-    let pub_params: PublicParameters = bincode::deserialize(&ser_pub_params).unwrap();
+    let pub_params: PublicParameters = bincode::deserialize(&ser_pub_params)?;
     // Derive the `ProverKey` from the `PublicParameters`.
-    let (prover_key, _) = pub_params
-        .trim(2 * composer.circuit_size().next_power_of_two())
-        .unwrap();
+    let (prover_key, _) = pub_params.trim(2 * composer.circuit_size().next_power_of_two())?;
     composer.preprocess(&prover_key, &mut transcript, &eval_domain)
 }
 
-fn build_proof(inputs: &[Scalar], final_result: Scalar, prep_circ: &PreProcessedCircuit) -> Proof {
+fn build_proof(
+    inputs: &[Scalar],
+    final_result: Scalar,
+    prep_circ: &PreProcessedCircuit,
+) -> Result<Proof, Error> {
     let mut composer = StandardComposer::new();
     let mut transcript = Transcript::new(b"Gadget-Orientation-Is-Cool");
     gadget_builder(&mut composer, inputs, final_result);
     let ser_pub_params = fs::read(&"examples/.public_params.bin")
         .expect("File not found. Run example `0_setup_srs` first please");
-    let pub_params: PublicParameters = bincode::deserialize(&ser_pub_params).unwrap();
+    let pub_params: PublicParameters = bincode::deserialize(&ser_pub_params)?;
     // Derive the `ProverKey` from the `PublicParameters`.
-    let (prover_key, _) = pub_params
-        .trim(2 * composer.circuit_size().next_power_of_two())
-        .unwrap();
+    let (prover_key, _) = pub_params.trim(2 * composer.circuit_size().next_power_of_two())?;
     composer.prove(&prover_key, &prep_circ, &mut transcript)
 }
 
@@ -106,7 +106,7 @@ fn main() -> Result<(), Error> {
         Scalar::from(3u64),
         Scalar::from(8u64),
     ];
-    let ok_proof = build_proof(&inputs, pub_input, &prep_circ);
+    let ok_proof = build_proof(&inputs, pub_input, &prep_circ)?;
     let ser_proof_ok = bincode::serialize(&ok_proof).unwrap();
     fs::write("examples/.proof_ok_2_3.bin", &ser_proof_ok).expect("Unable to write file");
 
@@ -118,7 +118,7 @@ fn main() -> Result<(), Error> {
         Scalar::from(9329u64),
     ];
 
-    let ko_proof = build_proof(&bad_inputs, pub_input, &prep_circ);
+    let ko_proof = build_proof(&bad_inputs, pub_input, &prep_circ)?;
     let ser_proof_ko = bincode::serialize(&ko_proof).unwrap();
     fs::write("examples/.proof_ko_2_3.bin", &ser_proof_ko).expect("Unable to write file");
 

--- a/examples/3_1_final_gadget_orientation.rs
+++ b/examples/3_1_final_gadget_orientation.rs
@@ -10,6 +10,7 @@ use dusk_bls12_381::Scalar;
 use dusk_plonk::commitment_scheme::kzg10::{CommitKey, OpeningKey, PublicParameters};
 use dusk_plonk::constraint_system::StandardComposer;
 use dusk_plonk::proof_system::{PreProcessedCircuit, Proof, Prover};
+use failure::Error;
 use merlin::Transcript;
 use std::fs;
 
@@ -68,7 +69,7 @@ fn gadget_builder(composer: &mut StandardComposer, inputs: &[Scalar], final_resu
     composer.add_dummy_constraints();
 }
 
-fn elaborate_proof(prover: &mut Prover) -> Proof {
+fn elaborate_proof(prover: &mut Prover) -> Result<Proof, Error> {
     prover.prove_with_preprocessed(&COMMIT_KEY, &PREPROCESSED_CIRCUIT)
 }
 
@@ -86,7 +87,7 @@ fn verify_proof(proof: &Proof, pub_input: Scalar) -> Result<(), Error> {
     )
 }
 
-fn start_proving(inputs: &[Scalar], final_result: Scalar) -> Proof {
+fn start_proving(inputs: &[Scalar], final_result: Scalar) -> Result<Proof, Error> {
     let mut prover = Prover::new(b"Gadget-Orientation-Is-Cool");
     gadget_builder(prover.mut_cs(), inputs, final_result);
     elaborate_proof(&mut prover)

--- a/examples/3_1_final_gadget_orientation.rs
+++ b/examples/3_1_final_gadget_orientation.rs
@@ -131,8 +131,7 @@ fn main() -> Result<(), Error> {
         Ok(()) => panic!("Incorrect proof has been verified successfully!"),
         Err(e) => {
             println!(
-            "KO Proof constructed before was succesfully verified unsuccessfully as we expected!
-            \n{:?}", e);
+            "KO Proof constructed before was succesfully verified unsuccessfully as we expected! with the following error: {:?}", e);
             Ok(())
         }
     }

--- a/examples/3_1_final_gadget_orientation.rs
+++ b/examples/3_1_final_gadget_orientation.rs
@@ -118,7 +118,6 @@ fn main() -> Result<(), Error> {
     // We just need to do call one function to build a proof
     let proof = start_proving(&inputs, pub_input)?;
 
-
     // Verification
     verify_proof(&proof, pub_input)?;
     println!("Proof constructed in the example was succesfully verified!");
@@ -138,10 +137,12 @@ fn main() -> Result<(), Error> {
     verify_proof(&ok_proof, pub_input)?;
     println!("OK Proof constructed before was succesfully verified!");
     match verify_proof(&ko_proof, pub_input) {
-        Ok(()) => {
-            println!("KO Proof constructed before was succesfully verified unsuccessfully as we expected!");
+        Ok(()) => panic!("Incorrect proof has been verified successfully!"),
+        Err(e) => {
+            println!(
+            "KO Proof constructed before was succesfully verified unsuccessfully as we expected!
+            \n{:?}", e);
             Ok(())
         }
-        Err(e) => Err(e),
     }
 }

--- a/examples/3_1_final_gadget_orientation.rs
+++ b/examples/3_1_final_gadget_orientation.rs
@@ -136,8 +136,11 @@ fn main() -> Result<(), Error> {
 
     verify_proof(&ok_proof, pub_input)?;
     println!("OK Proof constructed before was succesfully verified!");
-    verify_proof(&ko_proof, pub_input)?;
-    println!("KO Proof constructed before was succesfully verified unsuccessfully as we expected!");
-
-    Ok(())
+    match verify_proof(&ko_proof, pub_input) {
+        Ok(()) => {
+            println!("KO Proof constructed before was succesfully verified unsuccessfully as we expected!");
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
 }

--- a/src/commitment_scheme/kzg10/errors.rs
+++ b/src/commitment_scheme/kzg10/errors.rs
@@ -1,16 +1,21 @@
 //! Errors related to KZG10
 
-/// Represents an error in SRS creation and or modification.
+use failure::Error;
+
+/// Represents an error in the PublicParameters creation and or modification.
 #[derive(Fail, Debug)]
-pub enum Error {
-    /// This error occurs when the user tries to create an SRS and supplies the max degree as zero.
-    #[fail(display = "cannot create an srs with max degree as 0")]
+pub enum KZG10Errors {
+    /// This error occurs when the user tries to create PublicParameters
+    /// and supplies the max degree as zero.
+    #[fail(display = "cannot create PublicParameters with max degree as 0")]
     DegreeIsZero,
-    /// This error occurs when the user tries to trim an srs to a degree that is larger than the maximum degree.
+    /// This error occurs when the user tries to trim PublicParameters
+    /// to a degree that is larger than the maximum degree.
     #[fail(display = "cannot trim more than the maximum degree")]
     TruncatedDegreeTooLarge,
-    /// This error occurs when the user tries to trim an srs down to a degree that is zero.
-    #[fail(display = "cannot trim srs to a maximum size of zero")]
+    /// This error occurs when the user tries to trim PublicParameters
+    /// down to a degree that is zero.
+    #[fail(display = "cannot trim PublicParameters to a maximum size of zero")]
     TruncatedDegreeIsZero,
     /// This error occurs when the user tries to commit to a polynomial whose degree is larger than
     /// the supported degree for that proving key.
@@ -19,4 +24,13 @@ pub enum Error {
     /// This error occurs when the user tries to commit to a polynomial whose degree is zero.
     #[fail(display = "cannot commit to polynomial of zero degree")]
     PolynomialDegreeIsZero,
+    /// This error occurs when the pairing check fails at being equal to the Identity point.
+    #[fail(display = "pairing check failed")]
+    PairingCheckFailure,
 }
+
+#[derive(Debug, Fail)]
+#[fail(display = "polynomial commitment scheme module error")]
+/// Represents an error triggered on any of the Polynomial Commitment Scheme
+/// functions.
+pub struct PolyCommitSchemeError(#[fail(cause)] pub(crate) Error);

--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -329,7 +329,7 @@ impl CommitKey {
 impl OpeningKey {
     /// Checks that a polynomial `p` was evaluated at a point `z` and returned the value specified `v`.
     /// ie. v = p(z).
-    pub(crate) fn check(&self, point: Scalar, proof: Proof) -> bool {
+    pub fn check(&self, point: Scalar, proof: Proof) -> bool {
         let inner_a: G1Affine =
             (proof.commitment_to_polynomial.0 - (self.g * proof.evaluated_point)).into();
 

--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -327,9 +327,10 @@ impl ProverKey {
 }
 
 impl VerifierKey {
+    #[allow(dead_code)]
     /// Checks that a polynomial `p` was evaluated at a point `z` and returned the value specified `v`.
     /// ie. v = p(z).
-    fn check(&self, point: Scalar, proof: Proof) -> bool {
+    pub(crate) fn check(&self, point: Scalar, proof: Proof) -> bool {
         let inner_a: G1Affine =
             (proof.commitment_to_polynomial.0 - (self.g * proof.evaluated_point)).into();
 

--- a/src/commitment_scheme/kzg10/srs.rs
+++ b/src/commitment_scheme/kzg10/srs.rs
@@ -1,10 +1,11 @@
 //! The Public Parameters can also be referred to as the Structured Reference String (SRS).
 use super::{
-    errors::Error,
+    errors::{KZG10Errors, PolyCommitSchemeError},
     key::{ProverKey, VerifierKey},
 };
 use crate::util;
 use dusk_bls12_381::{G1Affine, G1Projective, G2Affine, G2Prepared};
+use failure::Error;
 use rand_core::RngCore;
 
 /// The Public Parameters can also be referred to as the Structured Reference String (SRS).
@@ -123,7 +124,7 @@ impl PublicParameters {
     ) -> Result<PublicParameters, Error> {
         // Cannot commit to constants
         if max_degree < 1 {
-            return Err(Error::DegreeIsZero);
+            return Err(PolyCommitSchemeError(KZG10Errors::DegreeIsZero.into()).into());
         }
 
         // Generate the secret scalar beta

--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -151,15 +151,15 @@ impl StandardComposer {
 
         // 4. Commit to polynomials
         //
-        let q_m_poly_commit = commit_key.commit(&q_m_poly)?;
-        let q_l_poly_commit = commit_key.commit(&q_l_poly)?;
-        let q_r_poly_commit = commit_key.commit(&q_r_poly)?;
-        let q_o_poly_commit = commit_key.commit(&q_o_poly)?;
-        let q_c_poly_commit = commit_key.commit(&q_c_poly)?;
-        let q_4_poly_commit = commit_key.commit(&q_4_poly)?;
-        let q_arith_poly_commit = commit_key.commit(&q_arith_poly)?;
-        let q_range_poly_commit = commit_key.commit(&q_range_poly)?;
-        let q_logic_poly_commit = commit_key.commit(&q_logic_poly)?;
+        let q_m_poly_commit = commit_key.commit(&q_m_poly).unwrap_or_default();
+        let q_l_poly_commit = commit_key.commit(&q_l_poly).unwrap_or_default();
+        let q_r_poly_commit = commit_key.commit(&q_r_poly).unwrap_or_default();
+        let q_o_poly_commit = commit_key.commit(&q_o_poly).unwrap_or_default();
+        let q_c_poly_commit = commit_key.commit(&q_c_poly).unwrap_or_default();
+        let q_4_poly_commit = commit_key.commit(&q_4_poly).unwrap_or_default();
+        let q_arith_poly_commit = commit_key.commit(&q_arith_poly).unwrap_or_default();
+        let q_range_poly_commit = commit_key.commit(&q_range_poly).unwrap_or_default();
+        let q_logic_poly_commit = commit_key.commit(&q_logic_poly).unwrap_or_default();
 
         let left_sigma_poly_commit = commit_key.commit(&left_sigma_poly)?;
         let right_sigma_poly_commit = commit_key.commit(&right_sigma_poly)?;

--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -84,20 +84,9 @@ impl StandardComposer {
         commit_key: &CommitKey,
         transcript: &mut Transcript,
     ) -> Result<PreProcessedCircuit, Error> {
-        let domain = EvaluationDomain::new(self.circuit_size()).unwrap();
-
-        let k = self.q_m.len();
-        assert!(self.q_o.len() == k);
-        assert!(self.q_l.len() == k);
-        assert!(self.q_r.len() == k);
-        assert!(self.q_c.len() == k);
-        assert!(self.q_4.len() == k);
-        assert!(self.q_arith.len() == k);
-        assert!(self.q_range.len() == k);
-        assert!(self.q_logic.len() == k);
-        assert!(self.w_l.len() == k);
-        assert!(self.w_r.len() == k);
-        assert!(self.w_o.len() == k);
+        let domain = EvaluationDomain::new(self.circuit_size())?;
+        // Check that the lenght of the wires is consistent.
+        self.check_poly_same_len()?;
 
         //1. Pad circuit to a power of two
         self.pad(domain.size as usize - self.n);
@@ -162,15 +151,15 @@ impl StandardComposer {
 
         // 4. Commit to polynomials
         //
-        let q_m_poly_commit = commit_key.commit(&q_m_poly).unwrap_or_default();
-        let q_l_poly_commit = commit_key.commit(&q_l_poly).unwrap_or_default();
-        let q_r_poly_commit = commit_key.commit(&q_r_poly).unwrap_or_default();
-        let q_o_poly_commit = commit_key.commit(&q_o_poly).unwrap_or_default();
-        let q_c_poly_commit = commit_key.commit(&q_c_poly).unwrap_or_default();
-        let q_4_poly_commit = commit_key.commit(&q_4_poly).unwrap_or_default();
-        let q_arith_poly_commit = commit_key.commit(&q_arith_poly).unwrap_or_default();
-        let q_range_poly_commit = commit_key.commit(&q_range_poly).unwrap_or_default();
-        let q_logic_poly_commit = commit_key.commit(&q_logic_poly).unwrap_or_default();
+        let q_m_poly_commit = commit_key.commit(&q_m_poly)?;
+        let q_l_poly_commit = commit_key.commit(&q_l_poly)?;
+        let q_r_poly_commit = commit_key.commit(&q_r_poly)?;
+        let q_o_poly_commit = commit_key.commit(&q_o_poly)?;
+        let q_c_poly_commit = commit_key.commit(&q_c_poly)?;
+        let q_4_poly_commit = commit_key.commit(&q_4_poly)?;
+        let q_arith_poly_commit = commit_key.commit(&q_arith_poly)?;
+        let q_range_poly_commit = commit_key.commit(&q_range_poly)?;
+        let q_logic_poly_commit = commit_key.commit(&q_logic_poly)?;
 
         let left_sigma_poly_commit = commit_key.commit(&left_sigma_poly)?;
         let right_sigma_poly_commit = commit_key.commit(&right_sigma_poly)?;
@@ -1711,7 +1700,7 @@ mod tests {
 
     fn test_gadget(gadget: fn(composer: &mut StandardComposer), n: usize) -> Result<(), Error> {
         // Common View
-        let public_parameters = PublicParameters::setup(2 * n, &mut rand::thread_rng()).unwrap();
+        let public_parameters = PublicParameters::setup(2 * n, &mut rand::thread_rng())?;
         // Provers View
         let (proof, public_inputs) = {
             // Create a prover struct

--- a/src/constraint_system/cs_errors.rs
+++ b/src/constraint_system/cs_errors.rs
@@ -1,22 +1,17 @@
 //! Errors related to the Constraint system
 
-/* I wanted to encapsulate all of the composer errors on a global one and then define
-sub types. But seems quite tricky.
-/// Represents an error in the Circuit composing process.
-#[derive(Fail, Debug)]
-pub enum ComposerError<E>
-where
-    E: Display + Debug + Sync + Send,
-{
-    #[fail(display = "Composer error caused by: {:?}", err)]
-    ComposerError { err: E },
-}
-*/
+use failure::Error;
 
 /// Represents an error on the Circuit preprocessing stage.
 #[derive(Fail, Debug)]
 pub enum PreProcessingError {
-    /// This error occurs when the .
+    /// This error occurs when an error triggers during the preprocessing
+    /// stage.
     #[fail(display = "the length of the wires it's not the same")]
     MissmatchedPolyLen,
 }
+
+#[derive(Debug, Fail)]
+#[fail(display = "Proving error")]
+/// Represents an error on the Proving stage.
+pub struct ProvingError(#[fail(cause)] Error);

--- a/src/constraint_system/cs_errors.rs
+++ b/src/constraint_system/cs_errors.rs
@@ -1,0 +1,22 @@
+//! Errors related to the Constraint system
+
+/* I wanted to encapsulate all of the composer errors on a global one and then define
+sub types. But seems quite tricky.
+/// Represents an error in the Circuit composing process.
+#[derive(Fail, Debug)]
+pub enum ComposerError<E>
+where
+    E: Display + Debug + Sync + Send,
+{
+    #[fail(display = "Composer error caused by: {:?}", err)]
+    ComposerError { err: E },
+}
+*/
+
+/// Represents an error on the Circuit preprocessing stage.
+#[derive(Fail, Debug)]
+pub enum PreProcessingError {
+    /// This error occurs when the .
+    #[fail(display = "the length of the wires it's not the same")]
+    MissmatchedPolyLen,
+}

--- a/src/constraint_system/mod.rs
+++ b/src/constraint_system/mod.rs
@@ -5,5 +5,6 @@
 pub mod variable;
 pub use variable::{Variable, WireData};
 pub mod composer;
+mod cs_errors;
 
 pub use composer::StandardComposer;

--- a/src/fft/domain.rs
+++ b/src/fft/domain.rs
@@ -6,6 +6,7 @@
 //! This allows us to perform polynomial operations in O(n)
 //! by performing an O(n log n) FFT over such a domain.
 
+use super::fft_errors::{FFTError, FFTErrors};
 use super::Evaluations;
 use core::fmt;
 use dusk_bls12_381::{Scalar, GENERATOR, ROOT_OF_UNITY, TWO_ADACITY};
@@ -183,13 +184,16 @@ impl<'de> Deserialize<'de> for EvaluationDomain {
 impl EvaluationDomain {
     /// Construct a domain that is large enough for evaluations of a polynomial
     /// having `num_coeffs` coefficients.
-    pub fn new(num_coeffs: usize) -> Option<Self> {
+    pub fn new(num_coeffs: usize) -> Result<Self, FFTError> {
         // Compute the size of our evaluation domain
         let size = num_coeffs.next_power_of_two() as u64;
         let log_size_of_group = size.trailing_zeros();
 
         if log_size_of_group >= TWO_ADACITY {
-            return None;
+            return Err(FFTError(FFTErrors::InvalidEvalDomainSize {
+                log_size_of_group,
+                adacity: TWO_ADACITY,
+            }));
         }
 
         // Compute the generator for the multiplicative subgroup.
@@ -202,7 +206,7 @@ impl EvaluationDomain {
         let size_as_field_element = Scalar::from(size);
         let size_inv = size_as_field_element.invert().unwrap();
 
-        Some(EvaluationDomain {
+        Ok(EvaluationDomain {
             size,
             log_size_of_group,
             size_as_field_element,
@@ -384,6 +388,9 @@ impl EvaluationDomain {
     /// Given an index which assumes the first elements of this domain are the
     /// elements of another (sub)domain with size size_s,
     /// this returns the actual index into this domain.
+    ///
+    /// # Panics
+    /// When the index of self is smaller than the other provided.
     pub fn reindex_by_subdomain(&self, other: Self, index: usize) -> usize {
         assert!(self.size() >= other.size());
         // Let this subgroup be G, and the subgroup we're re-indexing by be S.

--- a/src/fft/fft_errors.rs
+++ b/src/fft/fft_errors.rs
@@ -1,5 +1,7 @@
 //! Errors related to the fft module.
 
+use failure::Error;
+
 /// Defines all of the possible FFTError types that we could have when
 /// we are working with the `fft` module.
 #[derive(Fail, Debug)]
@@ -21,4 +23,4 @@ pub enum FFTErrors {
 #[fail(display = "FFT module error")]
 /// Represents an error triggered on any of the FFT module operations
 /// such as `Polynomial` or `EvaluationDomain`
-pub struct FFTError(#[fail(cause)] pub(crate) FFTErrors);
+pub struct FFTError(#[fail(cause)] pub(crate) Error);

--- a/src/fft/fft_errors.rs
+++ b/src/fft/fft_errors.rs
@@ -1,0 +1,24 @@
+//! Errors related to the fft module.
+
+/// Defines all of the possible FFTError types that we could have when
+/// we are working with the `fft` module.
+#[derive(Fail, Debug)]
+pub enum FFTErrors {
+    /// This error occurs when an error triggers on any of the fft module
+    /// functions.
+    #[fail(
+        display = "Log-size of the EvaluationDomain group > TWO_ADACITY\
+    Size: {:?} > TWO_ADACITY = {:?}",
+        log_size_of_group, adacity
+    )]
+    InvalidEvalDomainSize {
+        log_size_of_group: u32,
+        adacity: u32,
+    },
+}
+
+#[derive(Debug, Fail)]
+#[fail(display = "FFT module error")]
+/// Represents an error triggered on any of the FFT module operations
+/// such as `Polynomial` or `EvaluationDomain`
+pub struct FFTError(#[fail(cause)] pub(crate) FFTErrors);

--- a/src/fft/mod.rs
+++ b/src/fft/mod.rs
@@ -3,6 +3,7 @@
 //! the operations that the `Composer` needs to peform with them.
 pub(crate) mod domain;
 pub(crate) mod evaluations;
+pub(crate) mod fft_errors;
 pub(crate) mod polynomial;
 
 pub use domain::EvaluationDomain;

--- a/src/fft/polynomial.rs
+++ b/src/fft/polynomial.rs
@@ -100,6 +100,9 @@ impl Polynomial {
     }
 
     /// Constructs a new polynomial from a list of coefficients.
+    ///
+    /// # Panics
+    /// When the length of the coeffs is zero.
     pub fn from_coefficients_vec(coeffs: Vec<Scalar>) -> Self {
         let mut result = Self { coeffs };
         // While there are zeros at the end of the coefficient vector, pop them off.

--- a/src/proof_system/mod.rs
+++ b/src/proof_system/mod.rs
@@ -3,6 +3,7 @@
 pub(crate) mod linearisation_poly;
 pub(crate) mod preprocessed_circuit;
 pub(crate) mod proof;
+pub(crate) mod proof_system_errors;
 pub(crate) mod quotient_poly;
 pub(crate) mod widget;
 

--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -483,6 +483,7 @@ fn compute_first_lagrange_evaluation(
     let denom = n_fr * (z_challenge - Scalar::one());
     z_h_eval * denom.invert().unwrap()
 }
+
 #[warn(clippy::needless_range_loop)]
 fn compute_barycentric_eval(
     evaluations: &[Scalar],

--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -3,13 +3,16 @@
 //!
 //! This module contains the implementation of the `StandardComposer`s
 //! `Proof` structure and it's methods.
+
 use super::linearisation_poly::ProofEvaluations;
+use super::proof_system_errors::{ProofError, ProofErrors};
 use super::PreProcessedCircuit;
 use crate::commitment_scheme::kzg10::AggregateProof;
 use crate::commitment_scheme::kzg10::{Commitment, VerifierKey};
 use crate::fft::EvaluationDomain;
 use crate::transcript::TranscriptProtocol;
 use dusk_bls12_381::{multiscalar_mul::msm_variable_base, G1Affine, Scalar};
+use failure::Error;
 #[cfg(feature = "serde")]
 use serde::{de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 
@@ -230,10 +233,10 @@ impl Proof {
         transcript: &mut dyn TranscriptProtocol,
         verifier_key: &VerifierKey,
         pub_inputs: &[Scalar],
-    ) -> bool {
-        let domain = EvaluationDomain::new(preprocessed_circuit.n).unwrap();
+    ) -> Result<(), Error> {
+        let domain = EvaluationDomain::new(preprocessed_circuit.n)?;
 
-        // subgroup checks are done when the proof is deserialised.
+        // Subgroup checks are done when the proof is deserialised.
 
         // In order for the Verifier and Prover to have the same view in the non-interactive setting
         // Both parties must commit the same elements into the transcript
@@ -357,11 +360,17 @@ impl Proof {
         transcript.append_commitment(b"w_z_w", &self.w_zw_comm);
 
         // Batch check
-        verifier_key.batch_check(
-            &[z_challenge, (z_challenge * domain.group_gen)],
-            &[flattened_proof_a, flattened_proof_b],
-            transcript,
-        )
+        if verifier_key
+            .batch_check(
+                &[z_challenge, (z_challenge * domain.group_gen)],
+                &[flattened_proof_a, flattened_proof_b],
+                transcript,
+            )
+            .is_err()
+        {
+            return Err(ProofError(ProofErrors::ProofVerificationError.into()).into());
+        }
+        Ok(())
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/proof_system/proof_system_errors.rs
+++ b/src/proof_system/proof_system_errors.rs
@@ -1,0 +1,17 @@
+//! Errors related to the proof_system module.
+
+use failure::Error;
+/// Defines all of the possible ProofError types that we could have when
+/// we are working with the `proof_system` module.
+#[derive(Fail, Debug)]
+pub enum ProofErrors {
+    /// This error occurs when the verification of a `Proof` fails.
+    #[fail(display = "proof verification failed")]
+    ProofVerificationError,
+}
+
+#[derive(Debug, Fail)]
+#[fail(display = "proof_system module error")]
+/// Represents an error triggered on any of the proof_system
+/// module operations such as verification errors
+pub struct ProofError(#[fail(cause)] pub(crate) Error);

--- a/src/proof_system/quotient_poly.rs
+++ b/src/proof_system/quotient_poly.rs
@@ -42,7 +42,7 @@ pub(crate) fn compute(
     w4_eval_4n.push(w4_eval_4n[3]);
 
     let t_1 = compute_circuit_satisfiability_equation(
-        &domain_4n,
+        &domain,
         preprocessed_circuit,
         (&wl_eval_4n, &wr_eval_4n, &wo_eval_4n, &w4_eval_4n),
         public_inputs_poly,

--- a/src/proof_system/quotient_poly.rs
+++ b/src/proof_system/quotient_poly.rs
@@ -50,7 +50,6 @@ pub(crate) fn compute(
 
     let t_2 = compute_permutation_checks(
         domain,
-        &domain_4n,
         preprocessed_circuit,
         (&wl_eval_4n, &wr_eval_4n, &wo_eval_4n, &w4_eval_4n),
         &z_eval_4n,
@@ -73,11 +72,12 @@ pub(crate) fn compute(
 
 // Ensures that the circuit is satisfied
 fn compute_circuit_satisfiability_equation(
-    domain_4n: &EvaluationDomain,
+    domain: &EvaluationDomain,
     preprocessed_circuit: &PreProcessedCircuit,
     (wl_eval_4n, wr_eval_4n, wo_eval_4n, w4_eval_4n): (&[Scalar], &[Scalar], &[Scalar], &[Scalar]),
     pi_poly: &Polynomial,
 ) -> Vec<Scalar> {
+    let domain_4n = EvaluationDomain::new(4 * domain.size()).unwrap();
     let pi_eval_4n = domain_4n.coset_fft(pi_poly);
 
     let t: Vec<_> = (0..domain_4n.size())
@@ -112,12 +112,12 @@ fn compute_circuit_satisfiability_equation(
 
 fn compute_permutation_checks(
     domain: &EvaluationDomain,
-    domain_4n: &EvaluationDomain,
     preprocessed_circuit: &PreProcessedCircuit,
     (wl_eval_4n, wr_eval_4n, wo_eval_4n, w4_eval_4n): (&[Scalar], &[Scalar], &[Scalar], &[Scalar]),
     z_eval_4n: &[Scalar],
     (alpha, beta, gamma): (&Scalar, &Scalar, &Scalar),
 ) -> Vec<Scalar> {
+    let domain_4n = EvaluationDomain::new(4 * domain.size()).unwrap();
     let l1_poly_alpha = compute_first_lagrange_poly_scaled(domain, alpha.square());
     let l1_alpha_sq_evals = domain_4n.coset_fft(&l1_poly_alpha.coeffs);
 

--- a/src/proof_system/quotient_poly.rs
+++ b/src/proof_system/quotient_poly.rs
@@ -1,4 +1,3 @@
-use super::proof_system_errors::{ProofError, ProofErrors};
 use crate::fft::{EvaluationDomain, Polynomial};
 use crate::proof_system::PreProcessedCircuit;
 use dusk_bls12_381::Scalar;


### PR DESCRIPTION
- Custom errors for the following modules:
1. Composer
2. fft
3. proof_system
4. commitment_scheme (refactored)

- All of the errors are converted to `failure::Error` which makes easier to manage the error handling since we just have one General type of error with different implementations per module. 

- Having this general Error type allows us to propagate custom error types for each module across the library without any compatibility problem. 

- It also provides the user a way to dissect the error on it's lib when implements plonk as a dependency.


# Future work

- Create a prelude file that not only contains the important data structures but also the whole collection of errors that we provide with the lib.