### PR TITLE
Add identity separation challenge to each identity

### DIFF
--- a/src/proof_system/linearisation_poly.rs
+++ b/src/proof_system/linearisation_poly.rs
@@ -238,7 +238,14 @@ impl<'de> Deserialize<'de> for ProofEvaluations {
 pub fn compute(
     domain: &EvaluationDomain,
     preprocessed_circuit: &PreProcessedCircuit,
-    (alpha, beta, gamma, z_challenge): &(Scalar, Scalar, Scalar, Scalar),
+    (alpha, beta, gamma, range_separation_challenge, logic_separation_challenge, z_challenge): &(
+        Scalar,
+        Scalar,
+        Scalar,
+        Scalar,
+        Scalar,
+        Scalar,
+    ),
     w_l_poly: &Polynomial,
     w_r_poly: &Polynomial,
     w_o_poly: &Polynomial,
@@ -284,6 +291,7 @@ pub fn compute(
     let perm_eval = z_poly.evaluate(&(z_challenge * domain.group_gen));
 
     let f_1 = compute_circuit_satisfiability(
+        (range_separation_challenge, logic_separation_challenge),
         &a_eval,
         &b_eval,
         &c_eval,
@@ -336,6 +344,7 @@ pub fn compute(
 
 #[allow(clippy::too_many_arguments)]
 fn compute_circuit_satisfiability(
+    (range_separation_challenge, logic_separation_challenge): (&Scalar, &Scalar),
     a_eval: &Scalar,
     b_eval: &Scalar,
     c_eval: &Scalar,
@@ -356,13 +365,16 @@ fn compute_circuit_satisfiability(
     );
 
     let b = preprocessed_circuit.range.compute_linearisation(
+        range_separation_challenge,
         a_eval,
         b_eval,
         c_eval,
         d_eval,
         &d_next_eval,
     );
+
     let c = preprocessed_circuit.logic.compute_linearisation(
+        logic_separation_challenge,
         a_eval,
         a_next_eval,
         b_eval,
@@ -372,6 +384,7 @@ fn compute_circuit_satisfiability(
         d_next_eval,
         q_c_eval,
     );
+
     &(&a + &b) + &c
 }
 

--- a/src/proof_system/prover.rs
+++ b/src/proof_system/prover.rs
@@ -199,6 +199,8 @@ impl Prover {
         //
         // Compute quotient challenge; `alpha`
         let alpha = transcript.challenge_scalar(b"alpha");
+        let range_sep_challenge = transcript.challenge_scalar(b"range separation challenge");
+        let logic_sep_challenge = transcript.challenge_scalar(b"logic separation challenge");
 
         let t_poly = quotient_poly::compute(
             &domain,
@@ -206,7 +208,7 @@ impl Prover {
             &z_poly,
             (&w_l_poly, &w_r_poly, &w_o_poly, &w_4_poly),
             &pi_poly,
-            &(alpha, beta, gamma),
+            &(alpha, beta, gamma, range_sep_challenge, logic_sep_challenge),
         )?;
 
         // Split quotient polynomial into 4 degree `n` polynomials
@@ -232,7 +234,14 @@ impl Prover {
         let (lin_poly, evaluations) = linearisation_poly::compute(
             &domain,
             &preprocessed_circuit,
-            &(alpha, beta, gamma, z_challenge),
+            &(
+                alpha,
+                beta,
+                gamma,
+                range_sep_challenge,
+                logic_sep_challenge,
+                z_challenge,
+            ),
             &w_l_poly,
             &w_r_poly,
             &w_o_poly,

--- a/src/proof_system/widget/arithmetic.rs
+++ b/src/proof_system/widget/arithmetic.rs
@@ -240,6 +240,7 @@ impl ArithmeticWidget {
         evaluations: &ProofEvaluations,
     ) {
         let q_arith_eval = evaluations.q_arith_eval;
+
         scalars.push(evaluations.a_eval * evaluations.b_eval * q_arith_eval);
         points.push(self.q_m.commitment.0);
 

--- a/src/proof_system/widget/range.rs
+++ b/src/proof_system/widget/range.rs
@@ -97,10 +97,11 @@ impl RangeWidget {
             q_range: PreProcessedPolynomial::new(selector),
         }
     }
-
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn compute_quotient_i(
         &self,
         index: usize,
+        range_separation_challenge: &Scalar,
         w_l_i: &Scalar,
         w_r_i: &Scalar,
         w_o_i: &Scalar,
@@ -108,20 +109,24 @@ impl RangeWidget {
         w_4_i_next: &Scalar,
     ) -> Scalar {
         let four = Scalar::from(4);
-
         let q_range_i = &self.q_range.evaluations.as_ref().unwrap()[index];
+
+        let kappa = range_separation_challenge.square();
+        let kappa_sq = kappa.square();
+        let kappa_cu = kappa_sq * kappa;
 
         // Delta([c(X) - 4 * d(X)]) + Delta([b(X) - 4 * c(X)]) + Delta([a(X) - 4 * b(X)]) + Delta([d(Xg) - 4 * a(X)]) * Q_Range(X)
         //
         let b_1 = delta(w_o_i - four * w_4_i);
-        let b_2 = delta(w_r_i - four * w_o_i);
-        let b_3 = delta(w_l_i - four * w_r_i);
-        let b_4 = delta(w_4_i_next - four * w_l_i);
-        (b_1 + b_2 + b_3 + b_4) * q_range_i
+        let b_2 = delta(w_r_i - four * w_o_i) * kappa;
+        let b_3 = delta(w_l_i - four * w_r_i) * kappa_sq;
+        let b_4 = delta(w_4_i_next - four * w_l_i) * kappa_cu;
+        (b_1 + b_2 + b_3 + b_4) * q_range_i * range_separation_challenge
     }
 
     pub(crate) fn compute_linearisation(
         &self,
+        range_separation_challenge: &Scalar,
         a_eval: &Scalar,
         b_eval: &Scalar,
         c_eval: &Scalar,
@@ -129,31 +134,42 @@ impl RangeWidget {
         d_next_eval: &Scalar,
     ) -> Polynomial {
         let four = Scalar::from(4);
-
         let q_range_poly = &self.q_range.polynomial;
+
+        let kappa = range_separation_challenge.square();
+        let kappa_sq = kappa.square();
+        let kappa_cu = kappa_sq * kappa;
 
         // Delta([c_eval - 4 * d_eval]) + Delta([b_eval - 4 * c_eval]) + Delta([a_eval - 4 * b_eval]) + Delta([d_next_eval - 4 * a_eval]) * Q_Range(X)
         let b_1 = delta(c_eval - four * d_eval);
-        let b_2 = delta(b_eval - four * c_eval);
-        let b_3 = delta(a_eval - four * b_eval);
-        let b_4 = delta(d_next_eval - four * a_eval);
-        q_range_poly * &(b_1 + b_2 + b_3 + b_4)
+        let b_2 = delta(b_eval - four * c_eval) * kappa;
+        let b_3 = delta(a_eval - four * b_eval) * kappa_sq;
+        let b_4 = delta(d_next_eval - four * a_eval) * kappa_cu;
+
+        let t = (b_1 + b_2 + b_3 + b_4) * range_separation_challenge;
+
+        q_range_poly * &t
     }
 
     pub(crate) fn compute_linearisation_commitment(
         &self,
+        range_separation_challenge: &Scalar,
         scalars: &mut Vec<Scalar>,
         points: &mut Vec<G1Affine>,
         evaluations: &ProofEvaluations,
     ) {
         let four = Scalar::from(4);
 
-        let b_1 = delta(evaluations.c_eval - (four * evaluations.d_eval));
-        let b_2 = delta(evaluations.b_eval - four * evaluations.c_eval);
-        let b_3 = delta(evaluations.a_eval - four * evaluations.b_eval);
-        let b_4 = delta(evaluations.d_next_eval - (four * evaluations.a_eval));
+        let kappa = range_separation_challenge.square();
+        let kappa_sq = kappa.square();
+        let kappa_cu = kappa_sq * kappa;
 
-        scalars.push(b_1 + b_2 + b_3 + b_4);
+        let b_1 = delta(evaluations.c_eval - (four * evaluations.d_eval));
+        let b_2 = delta(evaluations.b_eval - four * evaluations.c_eval) * kappa;
+        let b_3 = delta(evaluations.a_eval - four * evaluations.b_eval) * kappa_sq;
+        let b_4 = delta(evaluations.d_next_eval - (four * evaluations.a_eval)) * kappa_cu;
+
+        scalars.push((b_1 + b_2 + b_3 + b_4) * range_separation_challenge);
         points.push(self.q_range.commitment.0);
     }
 }


### PR DESCRIPTION
This PR diverges from the reference implementation.

Each identity has it's own challenge, to which we can take powers of, to separate sub identities.

I believe this way is safer  and ensures that no identity contains a power of alpha that was used in previous identity. Additionally, it means that alpha challenge has one purposes, while the separation challenges also have one purpose. This should increase code readability. 

Closes #148 