### PR TITLE
Add prelude file to plonk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Prover and Verifier abstraction @kevaundray
 - Error handling and custom errors @CPerezz
+- Add prelude file @CPerezz
+- Add identity separation challenge to each identity. @kevaundray
 ## 
 
 

--- a/examples/1_compose_prove_verify.rs
+++ b/examples/1_compose_prove_verify.rs
@@ -46,9 +46,7 @@ extern crate bincode;
 extern crate dusk_plonk;
 extern crate merlin;
 
-use dusk_bls12_381::Scalar;
-use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
-use dusk_plonk::proof_system::{Prover, Verifier};
+use dusk_plonk::prelude::*;
 use failure::Error;
 use std::fs;
 

--- a/examples/2_gadget_orientation.rs
+++ b/examples/2_gadget_orientation.rs
@@ -15,10 +15,7 @@ extern crate bincode;
 extern crate dusk_plonk;
 extern crate merlin;
 
-use dusk_bls12_381::Scalar;
-use dusk_plonk::commitment_scheme::kzg10::{OpeningKey, PublicParameters};
-use dusk_plonk::constraint_system::StandardComposer;
-use dusk_plonk::proof_system::{Proof, Prover, Verifier};
+use dusk_plonk::prelude::*;
 use failure::Error;
 use std::fs;
 

--- a/examples/3_0_setup_for_gadgets.rs
+++ b/examples/3_0_setup_for_gadgets.rs
@@ -11,10 +11,7 @@ extern crate bincode;
 extern crate dusk_plonk;
 extern crate merlin;
 
-use dusk_bls12_381::Scalar;
-use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
-use dusk_plonk::constraint_system::StandardComposer;
-use dusk_plonk::proof_system::{PreProcessedCircuit, Proof, Prover};
+use dusk_plonk::prelude::*;
 use failure::Error;
 use merlin::Transcript;
 use std::fs;

--- a/examples/3_1_final_gadget_orientation.rs
+++ b/examples/3_1_final_gadget_orientation.rs
@@ -6,10 +6,7 @@ extern crate lazy_static;
 extern crate dusk_plonk;
 extern crate merlin;
 
-use dusk_bls12_381::Scalar;
-use dusk_plonk::commitment_scheme::kzg10::{CommitKey, OpeningKey, PublicParameters};
-use dusk_plonk::constraint_system::StandardComposer;
-use dusk_plonk::proof_system::{PreProcessedCircuit, Proof, Prover};
+use dusk_plonk::prelude::*;
 use failure::Error;
 use merlin::Transcript;
 use std::fs;

--- a/src/constraint_system/mod.rs
+++ b/src/constraint_system/mod.rs
@@ -2,9 +2,9 @@
 //! of the PLONK Standard Composer, as well as the circuit
 //! tools and abstractions, used by the Composer to generate,
 //! build, preprocess & prove constructed circuits.
-pub mod variable;
-pub use variable::{Variable, WireData};
-pub mod composer;
-mod cs_errors;
+pub(crate) mod composer;
+pub(crate) mod cs_errors;
+pub(crate) mod variable;
 
 pub use composer::StandardComposer;
+pub use variable::{Variable, WireData};

--- a/src/fft/fft_errors.rs
+++ b/src/fft/fft_errors.rs
@@ -14,7 +14,9 @@ pub enum FFTErrors {
         log_size_of_group, adacity
     )]
     InvalidEvalDomainSize {
+        /// Log size of the group
         log_size_of_group: u32,
+        /// Two adacity generated
         adacity: u32,
     },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub mod commitment_scheme;
 pub mod constraint_system;
 pub mod fft;
 mod permutation;
+pub mod prelude;
 pub mod proof_system;
 pub mod transcript;
 mod util;

--- a/src/permutation/mod.rs
+++ b/src/permutation/mod.rs
@@ -1,4 +1,4 @@
 pub(crate) mod constants;
 #[allow(clippy::module_inception)]
-pub mod permutation;
+pub(crate) mod permutation;
 pub use permutation::Permutation;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,22 @@
+//! Collection of functions needed to use plonk library.
+//!
+//! Use this as the only import that you need to interact
+//! with the principal data structures of the plonk library.
+//!
+
+pub use crate::commitment_scheme::kzg10::{
+    key::{CommitKey, OpeningKey},
+    PublicParameters,
+};
+pub use crate::constraint_system::{StandardComposer, Variable};
+pub use crate::proof_system::{PreProcessedCircuit, Proof, Prover, Verifier};
+// Re-export dusk-bls12_381 Scalar type
+pub use dusk_bls12_381::Scalar;
+
+/// Collection of errors that the library exposes/uses.
+pub mod plonk_errors {
+    pub use crate::commitment_scheme::kzg10::errors::{KZG10Errors, PolyCommitSchemeError};
+    pub use crate::constraint_system::cs_errors::{PreProcessingError, ProvingError};
+    pub use crate::fft::fft_errors::{FFTError, FFTErrors};
+    pub use crate::proof_system::proof_system_errors::{ProofError, ProofErrors};
+}


### PR DESCRIPTION
- Re-exports `dusk-bls12_38::Scalar`.
- Exports the needed data structures needed to work with plonk as well as the plonk errors inside of a module.

Closes #227 and one of the points of the tracking issue: #237 