### PR TITLE
Fix logic_constraint assertion bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ merlin = "2.0.0"
 rand = "0.7.2"
 rand_core = { version = "0.5", default-features = false }
 # Built by default with "std", "alloc", "pairing", "groups" and "endo" features.
-dusk-bls12_381 = {git = "https://github.com/dusk-network/bls12_381", tag = "0.1.2"}
+dusk-bls12_381 = "0.1.2"
 itertools = "0.8.2"
 rand_chacha = "0.2"
 rayon = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,12 @@ exclude = [
 license = "MPL-2.0"
 edition = "2018"
 
-
 [dependencies]
 merlin = "2.0.0"
 rand = "0.7.2"
 rand_core = { version = "0.5", default-features = false }
 # Built by default with "std", "alloc", "pairing", "groups" and "endo" features.
-dusk-bls12_381 = "0.1.0"
+dusk-bls12_381 = {git = "https://github.com/dusk-network/bls12_381", tag = "0.1.2"}
 itertools = "0.8.2"
 rand_chacha = "0.2"
 rayon = "1.3.0"
@@ -37,8 +36,6 @@ failure = "0.1.7"
 
 [dev-dependencies]
 rand = "0.7.0"
-
-
 
 [package.metadata.docs.rs]
 rustdoc-args = [ "--html-in-header", "katex-header.html" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,3 +81,6 @@ pub mod notes {
     #[doc(include = "../docs/notes-KZG10.md")]
     pub mod kzg10_docs {}
 }
+
+/// Bls12_381 Scalar structure used by plonk.
+pub use dusk_bls12_381::Scalar;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,3 @@ pub mod notes {
     #[doc(include = "../docs/notes-KZG10.md")]
     pub mod kzg10_docs {}
 }
-
-/// Bls12_381 Scalar structure used by plonk.
-pub use dusk_bls12_381::Scalar;


### PR DESCRIPTION
As mentioned in #251 there was a problem with the `assert`
statements used in the "front-end" check of the PLONK program
memmory.

This was caused by a bit_num parameter set to less bits than the
actual number bit-size.
Therefore, the assert was checking the final value of the resulting
wire agains the original number provided on each input wire instead
of the value clamped to the correct ammount of bits.

Closes #251 

We also now use `dusk-bls12_381 v0.1.2`, the new version of bls is published in crates.io