### PR TITLE
Export curve crates in plonk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 documentation = "https://dusk-network.github.io/plonk"
 repository = "https://github.com/dusk-network/plonk"
 keywords = ["cryptography", "plonk", "zk-snarks", "zero-knowledge", "crypto"]
-categories =["Algorithms", "Cryptography", "Development tools"]
+categories =["algorithms", "cryptography", "development tools"]
 description = "A pure-Rust implementation of the PLONK ZK-Proof algorithm"
 exclude = [
     "**/.gitignore",
@@ -34,6 +34,7 @@ rand_chacha = "0.2"
 rayon = "1.3.0"
 failure = "0.1.7"
 dusk-jubjub = "0.3.1"
+
 [dev-dependencies]
 rand = "0.7.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,3 +81,9 @@ pub mod notes {
     #[doc(include = "../docs/notes-KZG10.md")]
     pub mod kzg10_docs {}
 }
+
+/// Re-exported dusk-bls12_381 fork.
+pub use dusk_bls12_381 as bls12_381;
+
+/// Re-exported dusk-jubjub fork.
+pub use dusk_jubjub as jubjub;


### PR DESCRIPTION
Is a way easier to work with bls and jubjub libraries if they
are exported by plonk instead of importing and managing the versions
on our app where we have plonk as dep.

Closes #256