### PR TITLE
Remove pub visibility of Proof::verify()

### DIFF
--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -54,7 +54,7 @@ pub struct Proof {
 
 impl Proof {
     /// Performs the verification of a `Proof` returning a boolean result.
-    pub fn verify(
+    pub(crate) fn verify(
         &self,
         verifier_key: &VerifierKey,
         transcript: &mut Transcript,


### PR DESCRIPTION
Since now the verification is done through the `Verifier` abstraction,
we no longer need to expose publicly the `verify()` method of the
`Proof` object. Indeed, we can simply change it to `pub(crate)` and
let the `Verifier` method call it.

Closes #263