### PR TITLE
Implement a method for constraint-to-const witnes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Method to create constrained witness values. @CPerezz
+
+### Changed
+- Visibility of the `Proof::verify()` fn to `pub(crate)`. @CPerezz
  
 
 ## [0.2.0] - 20-07-20

--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -172,6 +172,21 @@ impl StandardComposer {
         var
     }
 
+    /// Adds the passed `BlsScalar` to the Constraint System as a
+    /// witness value and constraints it to be equal to the value that
+    /// was sent.
+    ///
+    /// This makes easier to work with Public Inputs, since they can just be
+    /// used as witnesses constrained to a fixed value.
+    pub fn add_constant_witness(&mut self, s: Scalar) -> Variable {
+        // Allocate and link the Variable and the Scalar values in the
+        // `Permutation` struct.
+        let var = self.add_input(s);
+        // We constraint the witness to be equal to a certain constant value.
+        self.constrain_to_constant(var, s, Scalar::zero());
+        var
+    }
+
     /// Adds a width-3 poly gate.
     /// This gate gives total freedom to the end user to implement the corresponding
     /// circuits in the most optimized way possible because the under has access to the


### PR DESCRIPTION
We needed before to create a witness and then constrain it to a
constant on every circuit we had.
This was time consuming and makes the code less readable since these
kind of constraints should already be performed by the Composer.

- Added the `add_constant_witness` method to the `StandardComposer`
impl block.

Adds the passed `BlsScalar` to the Constraint System as a
witness value and constraints it to be equal to the value that
was sent.

This makes easier to work with Public Inputs, since they can just be
used as witnesses constrained to a fixed value.

Closes #264