### PR TITLE
ECC Point should have its attributes exposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [0.2.5] - 31-07-20
+
+### Changed
+- ECC Point from `ecc:scalar_mul` should have its attributes exposed.
+
 ## [0.2.4] - 29-07-20
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-plonk"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>",
            "Luke Pearson <luke@dusk.network>", 
            "CPerezz <carlos@dusk.network>"] 

--- a/src/constraint_system/ecc/mod.rs
+++ b/src/constraint_system/ecc/mod.rs
@@ -12,11 +12,36 @@ pub struct Point {
     x: Variable,
     y: Variable,
 }
+
+impl Point {
+    /// Return the X coordinate of the point
+    pub fn x(&self) -> &Variable {
+        &self.x
+    }
+
+    /// Return the Y coordinate of the point
+    pub fn y(&self) -> &Variable {
+        &self.y
+    }
+}
+
 /// The result of a scalar multiplication
 #[derive(Debug, Clone, Copy)]
 pub struct PointScalar {
     point: Point,
     scalar: Variable,
+}
+
+impl PointScalar {
+    /// Return the generated point
+    pub fn point(&self) -> &Point {
+        &self.point
+    }
+
+    /// Return the internal scalar
+    pub fn scalar(&self) -> &Variable {
+        &self.scalar
+    }
 }
 
 impl From<PointScalar> for Point {


### PR DESCRIPTION
Some key expansion strategy may depend on the coordinates of the point,
like the case in Poseidon Cipher.

This way, the user need to have the ability to read the generated
coordinates.