### PR TITLE
Migrate from `failure` to `anyhow + thiserror` for error support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `Anyhow` & `thiserror` for error handling support.
+
+### Removed
+- `failure` for error support since has been deprecated.
+
 ## [0.2.6] - 03-08-20
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,9 @@ dusk-bls12_381 = "0.1.2"
 itertools = "0.8.2"
 rand_chacha = "0.2"
 rayon = "1.3.0"
-failure = "0.1.7"
+anyhow = "1.0.32"
 dusk-jubjub = "0.3.5"
+thiserror = "1.0"
 
 [dev-dependencies]
 rand = "0.7.0"

--- a/src/commitment_scheme/kzg10/errors.rs
+++ b/src/commitment_scheme/kzg10/errors.rs
@@ -1,36 +1,30 @@
 //! Errors related to KZG10
 
-use failure::Error;
+use thiserror::Error;
 
 /// Represents an error in the PublicParameters creation and or modification.
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 pub enum KZG10Errors {
     /// This error occurs when the user tries to create PublicParameters
     /// and supplies the max degree as zero.
-    #[fail(display = "cannot create PublicParameters with max degree as 0")]
+    #[error("cannot create PublicParameters with max degree as 0")]
     DegreeIsZero,
     /// This error occurs when the user tries to trim PublicParameters
     /// to a degree that is larger than the maximum degree.
-    #[fail(display = "cannot trim more than the maximum degree")]
+    #[error("cannot trim more than the maximum degree")]
     TruncatedDegreeTooLarge,
     /// This error occurs when the user tries to trim PublicParameters
     /// down to a degree that is zero.
-    #[fail(display = "cannot trim PublicParameters to a maximum size of zero")]
+    #[error("cannot trim PublicParameters to a maximum size of zero")]
     TruncatedDegreeIsZero,
     /// This error occurs when the user tries to commit to a polynomial whose degree is larger than
     /// the supported degree for that proving key.
-    #[fail(display = "proving key is not large enough to commit to said polynomial")]
+    #[error("proving key is not large enough to commit to said polynomial")]
     PolynomialDegreeTooLarge,
     /// This error occurs when the user tries to commit to a polynomial whose degree is zero.
-    #[fail(display = "cannot commit to polynomial of zero degree")]
+    #[error("cannot commit to polynomial of zero degree")]
     PolynomialDegreeIsZero,
     /// This error occurs when the pairing check fails at being equal to the Identity point.
-    #[fail(display = "pairing check failed")]
+    #[error("pairing check failed")]
     PairingCheckFailure,
 }
-
-#[derive(Debug, Fail)]
-#[fail(display = "polynomial commitment scheme module error")]
-/// Represents an error triggered on any of the Polynomial Commitment Scheme
-/// functions.
-pub struct PolyCommitSchemeError(#[fail(cause)] pub(crate) Error);

--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -1,15 +1,12 @@
 //! Key module contains the utilities and data structures
 //! that support the generation and usage of Commit and
 //! Opening keys.
-use super::{
-    errors::{KZG10Errors, PolyCommitSchemeError},
-    AggregateProof, Commitment, Proof,
-};
+use super::{errors::KZG10Errors, AggregateProof, Commitment, Proof};
 use crate::{fft::Polynomial, transcript::TranscriptProtocol, util};
+use anyhow::{Context, Error, Result};
 use dusk_bls12_381::{
     multiscalar_mul::msm_variable_base, G1Affine, G1Projective, G2Affine, G2Prepared, Scalar,
 };
-use failure::Error;
 use merlin::Transcript;
 
 /// Opening Key is used to verify opening proofs made about a committed polynomial.
@@ -49,12 +46,12 @@ impl CommitKey {
         }
         // Check that the truncated degree is not zero
         if truncated_degree == 0 {
-            return Err(PolyCommitSchemeError(KZG10Errors::TruncatedDegreeIsZero.into()).into());
+            return Err(KZG10Errors::TruncatedDegreeIsZero.into());
         }
 
         // Check that max degree is less than truncated degree
         if truncated_degree > self.max_degree() {
-            return Err(PolyCommitSchemeError(KZG10Errors::TruncatedDegreeTooLarge.into()).into());
+            return Err(KZG10Errors::TruncatedDegreeTooLarge.into());
         }
 
         let truncated_powers = Self {
@@ -217,7 +214,7 @@ impl OpeningKey {
         .final_exponentiation();
 
         if pairing != dusk_bls12_381::Gt::identity() {
-            return Err(PolyCommitSchemeError(KZG10Errors::PairingCheckFailure.into()).into());
+            return Err(KZG10Errors::PairingCheckFailure.into());
         };
         Ok(())
     }
@@ -231,10 +228,10 @@ impl OpeningKey {
 /// Returns an error if any of the above conditions are true.
 fn check_degree_is_within_bounds(max_degree: usize, poly_degree: usize) -> Result<(), Error> {
     if poly_degree == 0 {
-        return Err(PolyCommitSchemeError(KZG10Errors::PolynomialDegreeIsZero.into()).into());
+        return Err(KZG10Errors::PolynomialDegreeIsZero.into());
     }
     if poly_degree > max_degree {
-        return Err(PolyCommitSchemeError(KZG10Errors::PolynomialDegreeTooLarge.into()).into());
+        return Err(KZG10Errors::PolynomialDegreeTooLarge.into());
     }
     Ok(())
 }

--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -3,7 +3,7 @@
 //! Opening keys.
 use super::{errors::KZG10Errors, AggregateProof, Commitment, Proof};
 use crate::{fft::Polynomial, transcript::TranscriptProtocol, util};
-use anyhow::{Context, Error, Result};
+use anyhow::{Error, Result};
 use dusk_bls12_381::{
     multiscalar_mul::msm_variable_base, G1Affine, G1Projective, G2Affine, G2Prepared, Scalar,
 };

--- a/src/commitment_scheme/kzg10/srs.rs
+++ b/src/commitment_scheme/kzg10/srs.rs
@@ -1,11 +1,11 @@
 //! The Public Parameters can also be referred to as the Structured Reference String (SRS).
 use super::{
-    errors::{KZG10Errors, PolyCommitSchemeError},
+    errors::KZG10Errors,
     key::{CommitKey, OpeningKey},
 };
 use crate::util;
+use anyhow::{Error, Result};
 use dusk_bls12_381::{G1Affine, G1Projective, G2Affine, G2Prepared};
-use failure::Error;
 use rand_core::RngCore;
 
 /// The Public Parameters can also be referred to as the Structured Reference String (SRS).
@@ -30,7 +30,7 @@ impl PublicParameters {
     ) -> Result<PublicParameters, Error> {
         // Cannot commit to constants
         if max_degree < 1 {
-            return Err(PolyCommitSchemeError(KZG10Errors::DegreeIsZero.into()).into());
+            return Err(KZG10Errors::DegreeIsZero.into());
         }
 
         // Generate the secret scalar beta

--- a/src/constraint_system/cs_errors.rs
+++ b/src/constraint_system/cs_errors.rs
@@ -1,17 +1,12 @@
 //! Errors related to the Constraint system
 
-use failure::Error;
+use thiserror::Error;
 
 /// Represents an error on the Circuit preprocessing stage.
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 pub enum PreProcessingError {
     /// This error occurs when an error triggers during the preprocessing
     /// stage.
-    #[fail(display = "the length of the wires it's not the same")]
+    #[error("the length of the wires it's not the same")]
     MissmatchedPolyLen,
 }
-
-#[derive(Debug, Fail)]
-#[fail(display = "Proving error")]
-/// Represents an error on the Proving stage.
-pub struct ProvingError(#[fail(cause)] Error);

--- a/src/constraint_system/cs_errors.rs
+++ b/src/constraint_system/cs_errors.rs
@@ -8,5 +8,5 @@ pub enum PreProcessingError {
     /// This error occurs when an error triggers during the preprocessing
     /// stage.
     #[error("the length of the wires it's not the same")]
-    MissmatchedPolyLen,
+    MismatchedPolyLen,
 }

--- a/src/constraint_system/helper.rs
+++ b/src/constraint_system/helper.rs
@@ -1,8 +1,8 @@
 use super::StandardComposer;
 use crate::commitment_scheme::kzg10::PublicParameters;
 use crate::proof_system::{Prover, Verifier};
+use anyhow::{Error, Result};
 use dusk_bls12_381::Scalar;
-use failure::Error;
 
 /// Adds dummy constraints using arithmetic gates
 pub(crate) fn dummy_gadget(n: usize, composer: &mut StandardComposer) {

--- a/src/fft/domain.rs
+++ b/src/fft/domain.rs
@@ -6,13 +6,10 @@
 //! This allows us to perform polynomial operations in O(n)
 //! by performing an O(n log n) FFT over such a domain.
 
-use super::{
-    fft_errors::{FFTError, FFTErrors},
-    Evaluations,
-};
+use super::{fft_errors::FFTErrors, Evaluations};
+use anyhow::{Error, Result};
 use core::fmt;
 use dusk_bls12_381::{Scalar, GENERATOR, ROOT_OF_UNITY, TWO_ADACITY};
-use failure::Error;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 use std::ops::MulAssign;
 
@@ -52,13 +49,10 @@ impl EvaluationDomain {
         let log_size_of_group = size.trailing_zeros();
 
         if log_size_of_group >= TWO_ADACITY {
-            return Err(FFTError(
-                FFTErrors::InvalidEvalDomainSize {
-                    log_size_of_group,
-                    adacity: TWO_ADACITY,
-                }
-                .into(),
-            )
+            return Err(FFTErrors::InvalidEvalDomainSize {
+                log_size_of_group,
+                adacity: TWO_ADACITY,
+            }
             .into());
         }
 

--- a/src/fft/fft_errors.rs
+++ b/src/fft/fft_errors.rs
@@ -1,17 +1,18 @@
 //! Errors related to the fft module.
 
-use failure::Error;
+use thiserror::Error;
 
 /// Defines all of the possible FFTError types that we could have when
 /// we are working with the `fft` module.
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 pub enum FFTErrors {
     /// This error occurs when an error triggers on any of the fft module
     /// functions.
-    #[fail(
-        display = "Log-size of the EvaluationDomain group > TWO_ADACITY\
+    #[error(
+        "Log-size of the EvaluationDomain group > TWO_ADACITY\
     Size: {:?} > TWO_ADACITY = {:?}",
-        log_size_of_group, adacity
+        log_size_of_group,
+        adacity
     )]
     InvalidEvalDomainSize {
         /// Log size of the group
@@ -20,9 +21,3 @@ pub enum FFTErrors {
         adacity: u32,
     },
 }
-
-#[derive(Debug, Fail)]
-#[fail(display = "FFT module error")]
-/// Represents an error triggered on any of the FFT module operations
-/// such as `Polynomial` or `EvaluationDomain`
-pub struct FFTError(#[fail(cause)] pub(crate) Error);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,9 +56,6 @@ pub mod proof_system;
 pub mod transcript;
 mod util;
 
-#[macro_use]
-extern crate failure;
-
 #[cfg(feature = "nightly")]
 #[doc(include = "../docs/notes-intro.md")]
 pub mod notes {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -22,8 +22,8 @@ pub use dusk_jubjub::Fr as JubJubScalar;
 
 /// Collection of errors that the library exposes/uses.
 pub mod plonk_errors {
-    pub use crate::commitment_scheme::kzg10::errors::{KZG10Errors, PolyCommitSchemeError};
-    pub use crate::constraint_system::cs_errors::{PreProcessingError, ProvingError};
-    pub use crate::fft::fft_errors::{FFTError, FFTErrors};
-    pub use crate::proof_system::proof_system_errors::{ProofError, ProofErrors};
+    pub use crate::commitment_scheme::kzg10::errors::KZG10Errors;
+    pub use crate::constraint_system::cs_errors::PreProcessingError;
+    pub use crate::fft::fft_errors::FFTErrors;
+    pub use crate::proof_system::proof_system_errors::ProofErrors;
 }

--- a/src/proof_system/preprocess.rs
+++ b/src/proof_system/preprocess.rs
@@ -6,8 +6,8 @@ use crate::constraint_system::StandardComposer;
 
 use crate::fft::{EvaluationDomain, Evaluations, Polynomial};
 use crate::proof_system::widget;
+use anyhow::{Error, Result};
 use dusk_bls12_381::Scalar;
-use failure::Error;
 use merlin::Transcript;
 
 /// Struct that contains all of the selector and permutation polynomials in PLONK
@@ -78,7 +78,7 @@ impl StandardComposer {
         {
             Ok(())
         } else {
-            Err(PreProcessingError::MissmatchedPolyLen)
+            Err(PreProcessingError::MissmatchedPolyLen.into())
         }
     }
     /// These are the parts of preprocessing that the prover must compute

--- a/src/proof_system/preprocess.rs
+++ b/src/proof_system/preprocess.rs
@@ -78,7 +78,7 @@ impl StandardComposer {
         {
             Ok(())
         } else {
-            Err(PreProcessingError::MissmatchedPolyLen.into())
+            Err(PreProcessingError::MismatchedPolyLen.into())
         }
     }
     /// These are the parts of preprocessing that the prover must compute

--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -5,13 +5,13 @@
 //! `Proof` structure and it's methods.
 
 use super::linearisation_poly::ProofEvaluations;
-use super::proof_system_errors::{ProofError, ProofErrors};
+use super::proof_system_errors::ProofErrors;
 use crate::commitment_scheme::kzg10::{AggregateProof, Commitment, OpeningKey};
 use crate::fft::EvaluationDomain;
 use crate::proof_system::widget::VerifierKey;
 use crate::transcript::TranscriptProtocol;
+use anyhow::{Error, Result};
 use dusk_bls12_381::{multiscalar_mul::msm_variable_base, G1Affine, Scalar};
-use failure::Error;
 use merlin::Transcript;
 
 /// A Proof is a composition of `Commitments` to the witness, permutation,
@@ -205,7 +205,7 @@ impl Proof {
             )
             .is_err()
         {
-            return Err(ProofError(ProofErrors::ProofVerificationError.into()).into());
+            return Err(ProofErrors::ProofVerificationError.into());
         }
         Ok(())
     }

--- a/src/proof_system/proof_system_errors.rs
+++ b/src/proof_system/proof_system_errors.rs
@@ -1,21 +1,16 @@
 //! Errors related to the proof_system module.
 
-use failure::Error;
+use thiserror::Error;
+
 /// Defines all of the possible ProofError types that we could have when
 /// we are working with the `proof_system` module.
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 pub enum ProofErrors {
     /// This error occurs when the verification of a `Proof` fails.
-    #[fail(display = "proof verification failed")]
+    #[error("proof verification failed")]
     ProofVerificationError,
     /// This error occurrs when the Prover structure already contains a
     /// preprocessed circuit inside, but you call preprocess again.
-    #[fail(display = "circuit already preprocessed")]
+    #[error("circuit already preprocessed")]
     CircuitAlreadyPreprocessed,
 }
-
-#[derive(Debug, Fail)]
-#[fail(display = "proof_system module error")]
-/// Represents an error triggered on any of the proof_system
-/// module operations such as verification errors
-pub struct ProofError(#[fail(cause)] pub(crate) Error);

--- a/src/proof_system/prover.rs
+++ b/src/proof_system/prover.rs
@@ -1,12 +1,12 @@
-use super::proof_system_errors::{ProofError, ProofErrors};
+use super::proof_system_errors::ProofErrors;
 use crate::commitment_scheme::kzg10::CommitKey;
 use crate::constraint_system::{StandardComposer, Variable};
 use crate::fft::{EvaluationDomain, Polynomial};
 use crate::proof_system::widget::ProverKey;
 use crate::proof_system::{linearisation_poly, proof::Proof, quotient_poly};
 use crate::transcript::TranscriptProtocol;
+use anyhow::{Error, Result};
 use dusk_bls12_381::Scalar;
-use failure::Error;
 use merlin::Transcript;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
@@ -30,7 +30,7 @@ impl Prover {
     /// Preprocesses the underlying constraint system
     pub fn preprocess(&mut self, commit_key: &CommitKey) -> Result<(), Error> {
         if self.prover_key.is_some() {
-            return Err(ProofError(ProofErrors::CircuitAlreadyPreprocessed.into()).into());
+            return Err(ProofErrors::CircuitAlreadyPreprocessed.into());
         }
         let pk = self
             .cs

--- a/src/proof_system/quotient_poly.rs
+++ b/src/proof_system/quotient_poly.rs
@@ -1,7 +1,7 @@
 use crate::fft::{EvaluationDomain, Polynomial};
 use crate::proof_system::widget::ProverKey;
+use anyhow::{Error, Result};
 use dusk_bls12_381::Scalar;
-use failure::Error;
 use rayon::prelude::*;
 
 /// This quotient polynomial can only be used for the standard composer

--- a/src/proof_system/verifier.rs
+++ b/src/proof_system/verifier.rs
@@ -2,8 +2,8 @@ use crate::commitment_scheme::kzg10::{CommitKey, OpeningKey};
 use crate::constraint_system::StandardComposer;
 use crate::proof_system::widget::VerifierKey;
 use crate::proof_system::Proof;
+use anyhow::{Error, Result};
 use dusk_bls12_381::Scalar;
-use failure::Error;
 use merlin::Transcript;
 /// Verifier verifies a proof
 #[allow(missing_debug_implementations)]


### PR DESCRIPTION
Replaced the types & macro invocations used previously by
failure crate by the ones required by `anyhow` & `thiserror`.

- Refactored the `XXXErrors` enum to use `thiserror` as the
`derive` macro provider.
- Use `anyhow::{Result, Error}; as main types returned by plonk.