### PR TITLE
Version 0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Serialisation methods for the crate public structures &
 `serde` support.
 - dusk-jubjub version updated to 0.3.6
+- Update `add_witness_to_circuit_description` fn sig (#282, #284)
 
 ### Removed
 - `failure` for error support since has been deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.2.7] - 13-08-20
+
 ### Added
 - `Anyhow` & `thiserror` for error handling support.
 - Serialisation methods for the crate public structures &
 `serde` support.
+- dusk-jubjub version updated to 0.3.6
 
 ### Removed
 - `failure` for error support since has been deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Anyhow` & `thiserror` for error handling support.
 - Serialisation methods for the crate public structures &
 `serde` support.
-- dusk-jubjub version updated to 0.3.6
-- Update `add_witness_to_circuit_description` fn sig (#282, #284)
 
 ### Removed
 - `failure` for error support since has been deprecated.
@@ -25,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `add_witness_to_circuit_description` requires now just to send
 a `Scalar` and returns a constant & constrained witness `Variable`.
-
+- Update `add_witness_to_circuit_description` fn sig (#282, #284)
+- dusk-jubjub version updated to 0.3.6
 
 ## [0.2.6] - 03-08-20
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-plonk"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>",
            "Luke Pearson <luke@dusk.network>", 
            "CPerezz <carlos@dusk.network>"] 
@@ -31,7 +31,7 @@ itertools = "0.8.2"
 rand_chacha = "0.2"
 rayon = "1.3.0"
 anyhow = "1.0.32"
-dusk-jubjub = "0.3.5"
+dusk-jubjub = "0.3.6"
 thiserror = "1.0"
 serde = "1.0"
 


### PR DESCRIPTION
### Added
- `Anyhow` & `thiserror` for error handling support.
- Serialisation methods for the crate public structures &
`serde` support.
- dusk-jubjub version updated to 0.3.6

### Removed
- `failure` for error support since has been deprecated.