### PR TITLE
Update `add_witness_to_circuit_description` fn sig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - `failure` for error support since has been deprecated.
 
+### Changed
+- `add_witness_to_circuit_description` requires now just to send
+a `Scalar` and returns a constant & constrained witness `Variable`.
+
 
 ## [0.2.6] - 03-08-20
 

--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -98,23 +98,10 @@ impl StandardComposer {
     }
 
     /// Fixes a variable in the witness to be a part of the circuit description.
-    /// This method is (currently) only used in the following context:
-    /// We have gates which only require 3/4 wires,
-    /// We must assign the fourth value to another value, we then fix this value to be zero.
-    /// However, the verifier needs to be able to verify that this value is also zero.
-    /// We therefore must make this zero value a part of the circuit description of every circuit.
-    pub fn add_witness_to_circuit_description(&mut self, var: Variable, value: Scalar) {
-        self.poly_gate(
-            var,
-            var,
-            var,
-            Scalar::zero(),
-            Scalar::one(),
-            Scalar::zero(),
-            Scalar::zero(),
-            -value,
-            Scalar::zero(),
-        );
+    pub fn add_witness_to_circuit_description(&mut self, value: Scalar) -> Variable {
+        let var = self.add_input(value);
+        self.constrain_to_constant(var, value, Scalar::zero());
+        var
     }
 
     /// Creates a new circuit with an expected circuit size.
@@ -150,9 +137,7 @@ impl StandardComposer {
         };
 
         // Reserve the first variable to be zero
-        let zero_var = composer.add_input(Scalar::zero());
-        composer.add_witness_to_circuit_description(zero_var, Scalar::zero());
-        composer.zero_var = zero_var;
+        composer.zero_var = composer.add_witness_to_circuit_description(Scalar::zero());
 
         // Add dummy constraints
         composer.add_dummy_constraints();


### PR DESCRIPTION
Previously this required to send both, a `Scalar` and
a `Variable` with the same shared value.

By modifying the function signature, this will generate
a witness `Variable` constrained to be equal to
a constant `Scalar` which is sent to the function.

Closes #282