### PR TITLE
Bump to v0.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+## [0.2.10] - 23-09-20
+
+### Added
+- Added `CircuitBuilder` trait and a example for it. 
+
 ## [0.2.9] - 11-09-20
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-plonk"
-version = "0.2.9"
+version = "0.2.10"
 authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>",
            "Luke Pearson <luke@dusk.network>", 
            "CPerezz <carlos@dusk.network>"] 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,6 +7,7 @@
 //! with the principal data structures of the plonk library.
 //!
 
+pub use crate::circuit_builder::{Circuit, CircuitInputs, PublicInput};
 pub use crate::commitment_scheme::kzg10::{
     key::{CommitKey, OpeningKey},
     PublicParameters,


### PR DESCRIPTION
- This PR also adds `CircuitBuilder` traits inside of `prelude` so they're exported with the new version.

Bumps this crate to `0.2.10`