### PR TITLE
Circuit trait refactoring to make it usable & efficient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Changed
+- Now `Circuit` inputs are set in the circuit structure as `Option<T>`.
+- Make `PublicInput::value()` fn public.
+- Make pi_builder return `Result<T>`
+- Refactored examples for the `Circuit` trait impl
+according to the new changes.
+### Removed
+- Removed `CircuitInputs` from the crate.
+
 
 
 ## [0.2.10] - 23-09-20

--- a/src/circuit_builder.rs
+++ b/src/circuit_builder.rs
@@ -10,9 +10,12 @@ use dusk_jubjub::{AffinePoint as JubJubAffine, Scalar as JubJubScalar};
 /// Circuit inputs
 #[derive(Debug, Clone, Copy)]
 pub struct CircuitInputs<'a> {
-    bls_scalars: &'a [BlsScalar],
-    jubjub_scalars: &'a [JubJubScalar],
-    jubjub_affines: &'a [JubJubAffine],
+    /// BlsScalar inputs.
+    pub bls_scalars: &'a [BlsScalar],
+    /// JubJubScalar inputs.
+    pub jubjub_scalars: &'a [JubJubScalar],
+    /// JubJubAffine inputs.
+    pub jubjub_affines: &'a [JubJubAffine],
 }
 
 /// Public Input

--- a/src/circuit_builder.rs
+++ b/src/circuit_builder.rs
@@ -76,9 +76,9 @@ pub enum CircuitErrors {
     #[error("missing inputs for the circuit")]
     CircuitInputsNotFound,
     /// This error occurs when we want to verify a Proof but the pi_constructor
-    /// attribute is unninitialized.
-    #[error("PI constructor attribute is unninitialized")]
-    UnninitializedPIGenerator,
+    /// attribute is uninitialized.
+    #[error("PI constructor attribute is uninitialized")]
+    UninitializedPIGenerator,
 }
 
 #[cfg(test)]

--- a/src/circuit_builder.rs
+++ b/src/circuit_builder.rs
@@ -3,20 +3,10 @@
 use crate::commitment_scheme::kzg10::PublicParameters;
 use crate::constraint_system::StandardComposer;
 use crate::proof_system::{Proof, ProverKey, VerifierKey};
-use anyhow::{Error, Result};
+use anyhow::Result;
 use dusk_bls12_381::Scalar as BlsScalar;
 use dusk_jubjub::{AffinePoint as JubJubAffine, Scalar as JubJubScalar};
-
-/// Circuit inputs
-#[derive(Debug, Clone, Copy)]
-pub struct CircuitInputs<'a> {
-    /// BlsScalar inputs.
-    pub bls_scalars: &'a [BlsScalar],
-    /// JubJubScalar inputs.
-    pub jubjub_scalars: &'a [JubJubScalar],
-    /// JubJubAffine inputs.
-    pub jubjub_affines: &'a [JubJubAffine],
-}
+use thiserror::Error;
 
 /// Public Input
 #[derive(Debug, Copy, Clone)]
@@ -47,18 +37,11 @@ where
     Self: Sized + Default,
 {
     /// Gadget implementation used to fill the composer.
-    fn gadget(
-        &mut self,
-        composer: &mut StandardComposer,
-        inputs: CircuitInputs,
-    ) -> Result<Vec<PublicInput>, Error>;
+    fn gadget(&mut self, composer: &mut StandardComposer) -> Result<Vec<PublicInput>>;
     /// Compiles the circuit by using a function that returns a `Result`
     /// with the `ProverKey`, `VerifierKey` and the circuit size.
-    fn compile(
-        &mut self,
-        pub_params: &PublicParameters,
-        inputs: CircuitInputs,
-    ) -> Result<(ProverKey, VerifierKey, usize), Error>;
+    fn compile(&mut self, pub_params: &PublicParameters)
+        -> Result<(ProverKey, VerifierKey, usize)>;
 
     /// Build PI vector for Proof verifications.
     fn build_pi(&self, pub_inputs: &[PublicInput]) -> Vec<BlsScalar>;
@@ -71,9 +54,8 @@ where
         &mut self,
         pub_params: &PublicParameters,
         prover_key: &ProverKey,
-        inputs: CircuitInputs,
         transcript_initialisation: &'static [u8],
-    ) -> Result<Proof, Error>;
+    ) -> Result<Proof>;
 
     /// Verifies a proof using the provided `CircuitInputs` & `VerifierKey` instances.
     fn verify_proof(
@@ -83,7 +65,16 @@ where
         transcript_initialisation: &'static [u8],
         proof: &Proof,
         pub_inputs: &[PublicInput],
-    ) -> Result<(), Error>;
+    ) -> Result<()>;
+}
+
+/// Represents an error in the PublicParameters creation and or modification.
+#[derive(Error, Debug)]
+pub enum CircuitErrors {
+    /// This error occurs when the circuit is not provided with all of the
+    /// required inputs.
+    #[error("missing inputs for the circuit")]
+    CircuitInputsNotFound,
 }
 
 #[cfg(test)]
@@ -91,41 +82,39 @@ mod tests {
     use super::*;
     use crate::constraint_system::StandardComposer;
     use crate::proof_system::{Prover, ProverKey, Verifier, VerifierKey};
-    use anyhow::{Error, Result};
+    use anyhow::Result;
 
     // Implements a circuit that checks:
     // 1) a + b = c where C is a PI
     // 2) a <= 2^6
     // 3) b <= 2^5
     // 4) a * b = d where D is a PI
-    pub struct TestCircuit {
+    pub struct TestCircuit<'a> {
+        inputs: Option<&'a [BlsScalar]>,
         circuit_size: usize,
         pi_constructor: Option<Vec<PublicInput>>,
     }
 
-    impl Default for TestCircuit {
+    impl<'a> Default for TestCircuit<'a> {
         fn default() -> Self {
             TestCircuit {
+                inputs: None,
                 circuit_size: 0,
                 pi_constructor: None,
             }
         }
     }
 
-    impl<'a> Circuit<'a> for TestCircuit {
-        fn gadget(
-            &mut self,
-            composer: &mut StandardComposer,
-            inputs: CircuitInputs,
-        ) -> Result<Vec<PublicInput>, Error> {
+    impl<'a> Circuit<'a> for TestCircuit<'a> {
+        fn gadget(&mut self, composer: &mut StandardComposer) -> Result<Vec<PublicInput>> {
+            let inputs = self
+                .inputs
+                .ok_or_else(|| CircuitErrors::CircuitInputsNotFound)?;
             let mut pi = Vec::new();
-            let a = composer.add_input(inputs.bls_scalars[0]);
-            let b = composer.add_input(inputs.bls_scalars[1]);
+            let a = composer.add_input(inputs[0]);
+            let b = composer.add_input(inputs[1]);
             // Make first constraint a + b = c
-            pi.push(PublicInput::BlsScalar(
-                -inputs.bls_scalars[2],
-                composer.circuit_size(),
-            ));
+            pi.push(PublicInput::BlsScalar(-inputs[2], composer.circuit_size()));
             composer.poly_gate(
                 a,
                 b,
@@ -135,17 +124,14 @@ mod tests {
                 BlsScalar::one(),
                 BlsScalar::zero(),
                 BlsScalar::zero(),
-                -inputs.bls_scalars[2],
+                -inputs[2],
             );
 
             // Check that a and b are in range
             composer.range_gate(a, 1 << 6);
             composer.range_gate(b, 1 << 5);
             // Make second constraint a * b = d
-            pi.push(PublicInput::BlsScalar(
-                -inputs.bls_scalars[3],
-                composer.circuit_size(),
-            ));
+            pi.push(PublicInput::BlsScalar(-inputs[3], composer.circuit_size()));
             composer.poly_gate(
                 a,
                 b,
@@ -155,7 +141,7 @@ mod tests {
                 BlsScalar::zero(),
                 BlsScalar::one(),
                 BlsScalar::zero(),
-                -inputs.bls_scalars[3],
+                -inputs[3],
             );
 
             self.circuit_size = composer.circuit_size();
@@ -164,19 +150,18 @@ mod tests {
         fn compile(
             &mut self,
             pub_params: &PublicParameters,
-            compile_inputs: CircuitInputs,
-        ) -> Result<(ProverKey, VerifierKey, usize), Error> {
+        ) -> Result<(ProverKey, VerifierKey, usize)> {
             // Setup PublicParams
             let (ck, _) = pub_params.trim(1 << 9)?;
             // Generate & save `ProverKey` with some random values.
             let mut prover = Prover::new(b"TestCircuit");
             // Set size & Pi builder
-            self.pi_constructor = Some(self.gadget(prover.mut_cs(), compile_inputs)?);
+            self.pi_constructor = Some(self.gadget(prover.mut_cs())?);
             prover.preprocess(&ck)?;
 
             // Generate & save `VerifierKey` with some random values.
             let mut verifier = Verifier::new(b"TestCircuit");
-            self.gadget(verifier.mut_cs(), compile_inputs)?;
+            self.gadget(verifier.mut_cs())?;
             verifier.preprocess(&ck).unwrap();
             Ok((
                 prover
@@ -220,14 +205,13 @@ mod tests {
             &mut self,
             pub_params: &PublicParameters,
             prover_key: &ProverKey,
-            inputs: CircuitInputs,
             transcript_initialisation: &'static [u8],
-        ) -> Result<Proof, Error> {
+        ) -> Result<Proof> {
             let (ck, _) = pub_params.trim(1 << 9)?;
             // New Prover instance
             let mut prover = Prover::new(transcript_initialisation);
             // Fill witnesses for Prover
-            self.gadget(prover.mut_cs(), inputs)?;
+            self.gadget(prover.mut_cs())?;
             // Add ProverKey to Prover
             prover.prover_key = Some(prover_key.clone());
             prover.prove(&ck)
@@ -240,7 +224,7 @@ mod tests {
             transcript_initialisation: &'static [u8],
             proof: &Proof,
             pub_inputs: &[PublicInput],
-        ) -> Result<(), Error> {
+        ) -> Result<()> {
             let (_, vk) = pub_params.trim(1 << 9)?;
             // New Verifier instance
             let mut verifier = Verifier::new(transcript_initialisation);
@@ -250,24 +234,23 @@ mod tests {
     }
 
     #[test]
-    fn test_full() -> Result<(), Error> {
+    fn test_full() -> Result<()> {
         // Generate CRS
         let pub_params = PublicParameters::setup(1 << 10, &mut rand::thread_rng())?;
         // Generate circuit compilation params
-        let a = BlsScalar::from(25u64);
-        let b = BlsScalar::from(5u64);
-        let c = BlsScalar::from(30u64);
-        let d = BlsScalar::from(125u64);
-        let inputs = CircuitInputs {
-            bls_scalars: &[a, b, c, d],
-            jubjub_scalars: &[],
-            jubjub_affines: &[],
-        };
+        let inputs = [
+            BlsScalar::from(25u64),
+            BlsScalar::from(5u64),
+            BlsScalar::from(30u64),
+            BlsScalar::from(125u64),
+        ];
+
         // Initialize the circuit
         let mut circuit = TestCircuit::default();
+        circuit.inputs = Some(&inputs);
         {
             // Compile the circuit
-            let (prover_key, verifier_key, _) = circuit.compile(&pub_params, inputs)?;
+            let (prover_key, verifier_key, _) = circuit.compile(&pub_params)?;
             // Write the keys
             use std::fs::File;
             use std::io::Write;
@@ -284,17 +267,20 @@ mod tests {
 
         // Generate new inputs
         // Generate circuit compilation params
-        let a = BlsScalar::from(20u64);
-        let b = BlsScalar::from(5u64);
-        let c = BlsScalar::from(25u64);
-        let d = BlsScalar::from(100u64);
-        let inputs2 = CircuitInputs {
-            bls_scalars: &[a, b, c, d],
-            jubjub_scalars: &[],
-            jubjub_affines: &[],
-        };
-        let public_inputs2 = vec![PublicInput::BlsScalar(-c, 0), PublicInput::BlsScalar(-d, 0)];
-        let proof = circuit.gen_proof(&pub_params, &prover_key, inputs2, b"TestCirc")?;
+        let inputs2 = [
+            BlsScalar::from(20u64),
+            BlsScalar::from(5u64),
+            BlsScalar::from(25u64),
+            BlsScalar::from(100u64),
+        ];
+        // Replace previous used inputs by the new ones.
+        circuit.inputs = Some(&inputs2);
+
+        let public_inputs2 = vec![
+            PublicInput::BlsScalar(-BlsScalar::from(25u64), 0),
+            PublicInput::BlsScalar(-BlsScalar::from(100u64), 0),
+        ];
+        let proof = circuit.gen_proof(&pub_params, &prover_key, b"TestCirc")?;
         circuit.verify_proof(
             &pub_params,
             &verifier_key,

--- a/src/circuit_builder.rs
+++ b/src/circuit_builder.rs
@@ -183,7 +183,7 @@ mod tests {
             let mut pi = vec![BlsScalar::zero(); self.circuit_size];
             self.pi_constructor
                 .as_ref()
-                .ok_or_else(|| CircuitErrors::UnninitializedPIGenerator)?
+                .ok_or_else(|| CircuitErrors::UninitializedPIGenerator)?
                 .iter()
                 .enumerate()
                 .for_each(|(idx, pi_constr)| {

--- a/src/circuit_builder.rs
+++ b/src/circuit_builder.rs
@@ -20,8 +20,8 @@ pub enum PublicInput {
 }
 
 impl PublicInput {
-    #[allow(dead_code)]
-    fn value(&self) -> Vec<BlsScalar> {
+    /// Returns the value of a PublicInput struct
+    pub fn value(&self) -> Vec<BlsScalar> {
         match self {
             PublicInput::BlsScalar(scalar, _) => vec![*scalar],
             PublicInput::JubJubScalar(scalar, _) => vec![BlsScalar::from(*scalar)],
@@ -59,7 +59,7 @@ where
 
     /// Verifies a proof using the provided `CircuitInputs` & `VerifierKey` instances.
     fn verify_proof(
-        &self,
+        &mut self,
         pub_params: &PublicParameters,
         verifier_key: &VerifierKey,
         transcript_initialisation: &'static [u8],
@@ -166,7 +166,7 @@ mod tests {
             // Generate & save `VerifierKey` with some random values.
             let mut verifier = Verifier::new(b"TestCircuit");
             self.gadget(verifier.mut_cs())?;
-            verifier.preprocess(&ck).unwrap();
+            verifier.preprocess(&ck)?;
             Ok((
                 prover
                     .prover_key
@@ -222,7 +222,7 @@ mod tests {
         }
 
         fn verify_proof(
-            &self,
+            &mut self,
             pub_params: &PublicParameters,
             verifier_key: &VerifierKey,
             transcript_initialisation: &'static [u8],
@@ -232,6 +232,8 @@ mod tests {
             let (_, vk) = pub_params.trim(1 << 9)?;
             // New Verifier instance
             let mut verifier = Verifier::new(transcript_initialisation);
+            // Fill witnesses for Verifier
+            self.gadget(verifier.mut_cs())?;
             verifier.verifier_key = Some(*verifier_key);
             verifier.verify(proof, &vk, &self.build_pi(pub_inputs)?)
         }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,7 +7,7 @@
 //! with the principal data structures of the plonk library.
 //!
 
-pub use crate::circuit_builder::{Circuit, CircuitInputs, PublicInput};
+pub use crate::circuit_builder::{Circuit, CircuitErrors, PublicInput};
 pub use crate::commitment_scheme::kzg10::{
     key::{CommitKey, OpeningKey},
     PublicParameters,


### PR DESCRIPTION
The `Circuit` trait was not flexible enough for some of the circuits that we were implementing in issues like https://github.com/dusk-network/dusk-blindbid/issues/65.

Therefore, we needed more flexibility from the `CircuitInputs` perspective as well as a way to set the `PublicInputs` value correctly.

This PR introduces the following changes:
- Removed `CircuitInputs` structure and use the struct that implements `Circuit` as the container to store the inputs.
- Use `gadget()` fn in the verification definition to avoid bugs that deal to short Opening Keys.
- Make `build_pi()` return a `Result<T>` since now the inputs might not be charged inside the structure.

This leads to make possible the implementation of more complex circuits such as the BlindBid Circuit, so at least we know that the approach is better than before.