### PR TITLE
Improve Circuit trait API and usability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
-## [0.2.11] - 29-09-20
+## [0.3.0] - 05-10-20
+### Changed
+- `Circuit` trait API & usability improvements (#313)
 
+## [0.2.11] - 29-09-20
 ### Changed
 - Now `Circuit` inputs are set in the circuit structure as `Option<T>`.
 - Make `PublicInput::value()` fn public.
@@ -23,12 +26,10 @@ according to the new changes.
 - Removed `CircuitInputs` from the crate.
 
 ## [0.2.10] - 23-09-20
-
 ### Added
 - Added `CircuitBuilder` trait and a example for it. 
 
 ## [0.2.9] - 11-09-20
-
 ### Added
 - Added `ProverKey` & `Verifierkey` to the public API as exported types.
 
@@ -37,7 +38,6 @@ according to the new changes.
 - Use `dusk-jubjub v0.3.8`. 
 
 ## [0.2.8] - 25-08-20
-
 ### Added
 - Add a `variable_base_scalar_mul` method using a variable base curve add gate.
 
@@ -46,7 +46,6 @@ according to the new changes.
 
 
 ## [0.2.7] - 13-08-20
-
 ### Added
 - `Anyhow` & `thiserror` for error handling support.
 - Serialisation methods for the crate public structures &
@@ -63,27 +62,22 @@ a `Scalar` and returns a constant & constrained witness `Variable`.
 - `ecc::scalar_mul` now named fixed_base_scalar_mul
 
 ## [0.2.6] - 03-08-20
-
 ### Changed
 - Make public inputs vector publicly accessible.
 
 ## [0.2.5] - 31-07-20
-
 ### Changed
 - ECC Point from `ecc:scalar_mul` should have its attributes exposed.
 
 ## [0.2.4] - 29-07-20
-
 ### Changed
 - Changed `dusk-jubjub` version to `v0.3.5` to fix Fr random gen.
 
 ## [0.2.3] - 28-07-20
-
 ### Changed
 - Changed `dusk-jubjub` version to `v0.3.4` to update dhke generation.
 
 ## [0.2.2] - 25-07-20
-
 ### Added
 - Method to create constrained witness values. @CPerezz
 
@@ -92,7 +86,6 @@ a `Scalar` and returns a constant & constrained witness `Variable`.
 - Changed `dusk-jubjub` version to `v0.3.3` since `v0.3.2` was yanked.
 
 ## [0.2.1] - 24-07-20 [yanked]
-
 ### Added
 - Method to create constrained witness values. @CPerezz
 
@@ -101,7 +94,6 @@ a `Scalar` and returns a constant & constrained witness `Variable`.
  
 
 ## [0.2.0] - 20-07-20
-
 ### Added
 - Prover and Verifier abstraction @kevaundray
 - Error handling and custom errors @CPerezz
@@ -125,7 +117,6 @@ a `Scalar` and returns a constant & constrained witness `Variable`.
 
 
 ## [0.1.0] - 25-04-20
-
 ### Added
 
 - PLONK algorithm implementation.
@@ -134,9 +125,3 @@ a `Scalar` and returns a constant & constrained witness `Variable`.
 - KZG10 polynomial commitment scheme implementation.
 - fft module with Polynomial ops implemented.
 - Proof system module.
-
-### Changed
-
-### Fixed
-
-### Removed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-plonk"
-version = "0.2.11"
+version = "0.3.0"
 authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>",
            "Luke Pearson <luke@dusk.network>", 
            "CPerezz <carlos@dusk.network>"] 
@@ -27,7 +27,7 @@ rand = "0.7.2"
 rand_core = { version = "0.5", default-features = false }
 # Built by default with "std", "alloc", "pairing", "groups" and "endo" features.
 dusk-bls12_381 = "0.1.4"
-itertools = "0.8.2"
+itertools = "0.9.0"
 rand_chacha = "0.2"
 rayon = "1.3.0"
 anyhow = "1.0.32"

--- a/src/circuit_builder.rs
+++ b/src/circuit_builder.rs
@@ -60,18 +60,18 @@ where
         // Setup PublicParams
         let (ck, _) = pub_params.trim(self.trim_size())?;
         // Generate & save `ProverKey` with some random values.
-        let mut prover = Prover::new(b"TestCircuit");
+        let mut prover = Prover::new(b"CircuitCompilation");
         self.gadget(prover.mut_cs())?;
         prover.preprocess(&ck)?;
 
         // Generate & save `VerifierKey` with some random values.
-        let mut verifier = Verifier::new(b"TestCircuit");
+        let mut verifier = Verifier::new(b"CircuitCompilation");
         self.gadget(verifier.mut_cs())?;
         verifier.preprocess(&ck)?;
         Ok((
             prover
                 .prover_key
-                .expect("Unexpected error. Missing VerifierKey in compilation")
+                .expect("Unexpected error. Missing ProverKey in compilation")
                 .clone(),
             verifier
                 .verifier_key
@@ -289,7 +289,7 @@ mod tests {
         let proof = {
             let mut circuit = TestCircuit::default();
             circuit.inputs = Some(&inputs2);
-            circuit.gen_proof(&pub_params, &prover_key, b"TestCirc")
+            circuit.gen_proof(&pub_params, &prover_key, b"Test")
         }?;
 
         // Verifier POV
@@ -299,12 +299,6 @@ mod tests {
             PublicInput::BlsScalar(BlsScalar::from(25u64), 0),
             PublicInput::BlsScalar(BlsScalar::from(100u64), 0),
         ];
-        circuit.verify_proof(
-            &pub_params,
-            &verifier_key,
-            b"TestCirc",
-            &proof,
-            &public_inputs2,
-        )
+        circuit.verify_proof(&pub_params, &verifier_key, b"Test", &proof, &public_inputs2)
     }
 }

--- a/src/circuit_builder.rs
+++ b/src/circuit_builder.rs
@@ -71,8 +71,7 @@ where
         Ok((
             prover
                 .prover_key
-                .expect("Unexpected error. Missing ProverKey in compilation")
-                .clone(),
+                .expect("Unexpected error. Missing ProverKey in compilation"),
             verifier
                 .verifier_key
                 .expect("Unexpected error. Missing VerifierKey in compilation"),


### PR DESCRIPTION
The API was not flexible enough and it was forcing us
to repeat a lot of code.

- Trait now comes with build_pi, gen_proof, compile & verify_proof
fn's already implemented.
- It forces the user to implement the getters and setters for the PI
vector storage.
- It carries the circuit size already hardcored in it.

We've also defined the method pos() for PublicInput in order to get
quick access to them.