### PR TITLE
Trim size as param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 05-10-20
+### Added
+- Method to change the `trim_params_size` for the `Circuit` trait.
 
 ## [0.3.0] - 05-10-20
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-plonk"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>",
            "Luke Pearson <luke@dusk.network>", 
            "CPerezz <carlos@dusk.network>"] 


### PR DESCRIPTION
On the cases where we have variable-size circuits,
we need a way to use different trim_sizes for our Circuit
instance. With the previous API this was not possible.

Therefore, the method `set_trim_size` has been added.