### PR TITLE
Add flag-featured Canon-derived ecc libs usage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4] - 02-11-20
+### Added
+- `canon` feature to manage `Canon` derivations usage in ecc libs.
+### Changed
+- dusk-jubjub update to `v0.4.0`
+- dusk-bls12_381 update to `v0.2.0`
 
 ## [0.3.3] - 02-11-20
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.3.3] - 02-11-20
+### Changed
+- dusk-jubjub update to `v0.3.11`
+
 ## [0.3.2] - 29-10-20
 ### Changed
 - dusk-bls12_381 update to `v0.1.5`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ merlin = "2.0.0"
 rand = "0.7.2"
 rand_core = { version = "0.5", default-features = false }
 # Built by default with "std", "alloc", "pairing", "groups" and "endo" features.
-dusk-bls12_381 = "0.1.5"
+dusk-bls12_381 = "0.2.0"
 itertools = "0.9.0"
 rand_chacha = "0.2"
 rayon = "1.3.0"
 anyhow = "1.0.32"
-dusk-jubjub = "0.3.11"
+dusk-jubjub = "0.4.0"
 thiserror = "1.0"
 serde = "1.0"
 
@@ -44,3 +44,4 @@ rustdoc-args = [ "--html-in-header", "katex-header.html" ]
 nightly = []
 trace = []
 trace-print = ["trace"]
+canon = ["dusk-bls12_381/canon", "dusk-jubjub/canon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-plonk"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>",
            "Luke Pearson <luke@dusk.network>", 
            "CPerezz <carlos@dusk.network>"] 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-plonk"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>",
            "Luke Pearson <luke@dusk.network>", 
            "CPerezz <carlos@dusk.network>"] 
@@ -30,7 +30,7 @@ itertools = "0.9.0"
 rand_chacha = "0.2"
 rayon = "1.3.0"
 anyhow = "1.0.32"
-dusk-jubjub = "0.3.10"
+dusk-jubjub = "0.3.11"
 thiserror = "1.0"
 serde = "1.0"
 


### PR DESCRIPTION
Ready to merge once https://github.com/dusk-network/jubjub/pull/52 gets merged.

Adds the jubjub version that includes `Canon` derived for `ExtendedPoint`.