### PR TITLE
Replace omega_roots with scalar 1

### DIFF
--- a/src/proof_system/linearisation_poly.rs
+++ b/src/proof_system/linearisation_poly.rs
@@ -198,8 +198,6 @@ pub fn compute(
     let h_1_next_eval = h_1_poly.evaluate(&(z_challenge * domain.group_gen));
     let t_next_eval = table_poly.evaluate(&(z_challenge * domain.group_gen));
 
-    let omega_roots = domain.elements().last().unwrap();
-
     let f_1 = compute_circuit_satisfiability(
         (
             range_separation_challenge,
@@ -239,7 +237,6 @@ pub fn compute(
         &h_1_poly,
         &h_2_poly,
         &lookup_perm_eval,
-        &omega_roots,
     );
 
     let lin_poly = &f_1 + &f_2;

--- a/src/proof_system/quotient_poly.rs
+++ b/src/proof_system/quotient_poly.rs
@@ -288,8 +288,6 @@ fn compute_permutation_checks(
     let ln_poly_alpha_7 = compute_last_lagrange_poly_scaled(domain, alpha_7);
     let ln_alpha_7_evals = domain_4n.coset_fft(&ln_poly_alpha_7.coeffs);
 
-    let omega_roots = domain.elements().last().unwrap();
-
     let t: Vec<_> = (0..domain_4n.size())
         .into_par_iter()
         .map(|i| {
@@ -319,7 +317,6 @@ fn compute_permutation_checks(
                 &gamma,
                 &delta,
                 &epsilon,
-                &omega_roots,
             )
         })
         .collect();

--- a/src/proof_system/widget/permutation/proverkey.rs
+++ b/src/proof_system/widget/permutation/proverkey.rs
@@ -46,7 +46,6 @@ impl ProverKey {
         gamma: &BlsScalar,
         delta: &BlsScalar,
         epsilon: &BlsScalar,
-        omega_roots: &BlsScalar,
     ) -> BlsScalar {
         let a = self.compute_quotient_identity_range_check_i(
             index, w_l_i, w_r_i, w_o_i, w_4_i, z_i, alpha, beta, gamma,
@@ -63,7 +62,6 @@ impl ProverKey {
             alpha,
             delta,
             epsilon,
-            omega_roots,
         );
         let d = self.compute_lookup_quotient_copy_range_check_i(
             index,
@@ -75,7 +73,6 @@ impl ProverKey {
             alpha,
             delta,
             epsilon,
-            omega_roots,
         );
         let e = self.compute_quotient_term_check_first_la_grange_polys(
             z_i,
@@ -123,7 +120,6 @@ impl ProverKey {
         alpha: &BlsScalar,
         delta: &BlsScalar,
         epsilon: &BlsScalar,
-        omega_roots: &BlsScalar,
     ) -> BlsScalar {
         let x = self.linear_evaluations[index];
         let alpha_5 = alpha * alpha * alpha * alpha * alpha;
@@ -131,7 +127,7 @@ impl ProverKey {
         // Compute multi use fn, 1 + delta
         let one_plus_delta = BlsScalar::one() + delta;
 
-        let a_1 = x - omega_roots;
+        let a_1 = x - BlsScalar::one();
         let a_2 = epsilon + f_i;
         let a_3 = (epsilon * one_plus_delta) + t_i + (delta * t_i_next);
 
@@ -178,7 +174,6 @@ impl ProverKey {
         alpha: &BlsScalar,
         delta: &BlsScalar,
         epsilon: &BlsScalar,
-        omega_roots: &BlsScalar,
     ) -> BlsScalar {
         let alpha_5 = alpha * alpha * alpha * alpha * alpha;
 
@@ -187,7 +182,7 @@ impl ProverKey {
         let epsilon_one_plus_delta = epsilon * one_plus_delta;
 
         let x = self.linear_evaluations[index];
-        let a_1 = x - omega_roots;
+        let a_1 = x - BlsScalar::one();
         let a_2 = epsilon_one_plus_delta + h_1_i + (delta * h_1_i_next);
         let a_3 = epsilon_one_plus_delta + h_2_i + (delta * h_2_i_next);
 
@@ -252,7 +247,6 @@ impl ProverKey {
         h_1_poly: &Polynomial,
         h_2_poly: &Polynomial,
         lookup_perm_eval: &BlsScalar,
-        omega_roots: &BlsScalar,
     ) -> Polynomial {
         let a = self.compute_lineariser_identity_range_check(
             (&a_eval, &b_eval, &c_eval, &d_eval),
@@ -274,7 +268,6 @@ impl ProverKey {
             delta,
             epsilon,
             z_challenge,
-            omega_roots,
             f_eval,
             t_eval,
             t_next_eval,
@@ -285,7 +278,6 @@ impl ProverKey {
             delta,
             epsilon,
             z_challenge,
-            omega_roots,
             lookup_perm_eval,
             h_1_eval,
             h_1_next_eval,
@@ -357,7 +349,6 @@ impl ProverKey {
         delta: &BlsScalar,
         epsilon: &BlsScalar,
         z_challenge: &BlsScalar,
-        omega_roots: &BlsScalar,
         f_eval: &BlsScalar,
         t_eval: &BlsScalar,
         t_next_eval: &BlsScalar,
@@ -369,7 +360,7 @@ impl ProverKey {
         // Compute commonly used term (1 + delta)
         let one_plus_delta = delta + BlsScalar::one();
         // (z_challenge - omega^n)
-        let a_1 = &(z_challenge - omega_roots);
+        let a_1 = &(z_challenge - BlsScalar::one());
 
         // (epsilon + f_eval)
         let a_2 = epsilon + f_eval;
@@ -428,7 +419,7 @@ impl ProverKey {
         delta: &BlsScalar,
         epsilon: &BlsScalar,
         z_challenge: &BlsScalar,
-        omega_roots: &BlsScalar,
+        
         p_eval: &BlsScalar,
         h_1_eval: &BlsScalar,
         h_1_next_eval: &BlsScalar,
@@ -438,7 +429,7 @@ impl ProverKey {
         let alpha_5 = alpha * alpha * alpha * alpha * alpha;
 
         // (z_challenge - omega^n)
-        let a_1 = &(z_challenge - omega_roots);
+        let a_1 = &(z_challenge - BlsScalar::one());
 
         // (epsilon(1 + delta) + h_1_eval + (delta * h_1_next_eval))
         let a = epsilon * (delta + BlsScalar::one());

--- a/src/proof_system/widget/permutation/proverkey.rs
+++ b/src/proof_system/widget/permutation/proverkey.rs
@@ -54,25 +54,10 @@ impl ProverKey {
             index, w_l_i, w_r_i, w_o_i, w_4_i, z_i_next, alpha, beta, gamma,
         );
         let c = self.compute_lookup_quotient_identity_range_check_i(
-            index,
-            f_i,
-            t_i,
-            t_i_next,
-            p_i,
-            alpha,
-            delta,
-            epsilon,
+            index, f_i, t_i, t_i_next, p_i, alpha, delta, epsilon,
         );
         let d = self.compute_lookup_quotient_copy_range_check_i(
-            index,
-            h_1_i,
-            h_2_i,
-            h_1_i_next,
-            h_2_i_next,
-            p_i_next,
-            alpha,
-            delta,
-            epsilon,
+            index, h_1_i, h_2_i, h_1_i_next, h_2_i_next, p_i_next, alpha, delta, epsilon,
         );
         let e = self.compute_quotient_term_check_first_la_grange_polys(
             z_i,
@@ -419,7 +404,7 @@ impl ProverKey {
         delta: &BlsScalar,
         epsilon: &BlsScalar,
         z_challenge: &BlsScalar,
-        
+
         p_eval: &BlsScalar,
         h_1_eval: &BlsScalar,
         h_1_next_eval: &BlsScalar,


### PR DESCRIPTION
In the plookup paper and our document with code changes a factor of `x-omega^n` (or something similar) is included in several places where computing plookup permutation checks. Since `omega` is an nth root of unity, `omega^n` equals 1. Here `omega^n` has been replaced with `BlsScalar::one()` and references to `omega_roots` have been removed.