### PR TITLE
rm uncessary match branch mentioned in #414

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Removed
 - Deprecated `anyhow` and `thiserror` [#343](https://github.com/dusk-network/plonk/issues/343)
+- Remove uncessary `match` branch for `var_c` [#414](https://github.com/dusk-network/plonk/issues/414)
 ### Changed
 - Updated the native errors to all originate from the same enum
 

--- a/src/constraint_system/logic.rs
+++ b/src/constraint_system/logic.rs
@@ -169,13 +169,7 @@ impl StandardComposer {
             // Get variables pointing to the previous accumulated values.
             let var_a = self.add_input(left_accumulator);
             let var_b = self.add_input(right_accumulator);
-            // On the last row of the program memory, we need to pad the
-            // output wire with a zero since we started to include it's
-            // accumulators one gate before the other wire ones.
-            let var_c = match i == num_quads {
-                true => self.zero_var,
-                false => self.add_input(prod_quad_fr),
-            };
+            let var_c = self.add_input(prod_quad_fr);
             let var_4 = self.add_input(out_accumulator);
             // Add the variables to the variable map linking them to it's
             // corresponding gate index.


### PR DESCRIPTION
Remove uncessary `match` branch for `var_c` [#414](https://github.com/dusk-network/plonk/issues/414)