### PR TITLE
Remove hyperlink from SNARK docs.

### DIFF
--- a/docs/notes-prove-verify.md
+++ b/docs/notes-prove-verify.md
@@ -98,7 +98,8 @@ wires are not repeated by using
 randomness given by the verifier. 
 
 This process is better explained in 
-the permutation [notes](notes-pa).
+within the permutation section of
+the notes.
 
 After the constraints
 are made, they are formatted into a 


### PR DESCRIPTION
The docs file had a faulty hyperlink. This is because within files it is not possible to connect to mod level markdowns.
This is now removed.

This closes #415 
