### PR TITLE
Cut visibility of crate types & functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed previous implementations attached to `PublicInputValues`. [#416](https://github.com/dusk-network/plonk/issues/416)
 - Deprecated `anyhow` and `thiserror` [#343](https://github.com/dusk-network/plonk/issues/343)
 - Remove uncessary `match` branch for `var_c` [#414](https://github.com/dusk-network/plonk/issues/414)
-- Remove legacy fn's and move to test modules the only-for-testing ones. [#434](https://github.com/dusk-network/plonk/issues/434)
+- Remove legacy fns and move to test modules the only-for-testing ones. [#434](https://github.com/dusk-network/plonk/issues/434)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed previous implementations attached to `PublicInputValues`. [#416](https://github.com/dusk-network/plonk/issues/416)
 - Deprecated `anyhow` and `thiserror` [#343](https://github.com/dusk-network/plonk/issues/343)
 - Remove uncessary `match` branch for `var_c` [#414](https://github.com/dusk-network/plonk/issues/414)
+- Remove legacy fn's and move to test modules the only-for-testing ones. [#434](https://github.com/dusk-network/plonk/issues/434)
 
 ### Changed
 
@@ -26,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace `collections::HashMap` by `hashbrown::HashMap`. [#424](https://github.com/dusk-network/plonk/issues/424)
 - `Circuit` trait now only requires `padded_circuit_size` for trimming. [#351](https://github.com/dusk-network/plonk/issues/351)
 - Remove `verify_proof` & `build_pi` from `Circuit`. [#396](https://github.com/dusk-network/plonk/issues/396)
-- Updated the native errors to all originate from the same enum
+- Updated the native errors to all originate from the same enum [#343](https://github.com/dusk-network/plonk/issues/343)
 
 ## [0.5.1] - 02-02-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Constrained as much as possible the visibility of fn's, structs and it's fields [#438](https://github.com/dusk-network/plonk/issues/438)]
+- Constrained as much as possible the visibility of fns, structs and it's fields [#438](https://github.com/dusk-network/plonk/issues/438)]
 - Store the sparse repr of the PI and positions in a `BTreeMap` [#427](https://github.com/dusk-network/plonk/issues/427)
 - Transcript Init and trim size are associated constants of the Circuit trait [#351](https://github.com/dusk-network/plonk/issues/351)
 - Replace `collections::HashMap` by `hashbrown::HashMap`. [#424](https://github.com/dusk-network/plonk/issues/424)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Constrained as much as possible the visibility of fn's, structs and it's fields [#438](https://github.com/dusk-network/plonk/issues/438)]
 - Store the sparse repr of the PI and positions in a `BTreeMap` [#427](https://github.com/dusk-network/plonk/issues/427)
 - Transcript Init and trim size are associated constants of the Circuit trait [#351](https://github.com/dusk-network/plonk/issues/351)
 - Replace `collections::HashMap` by `hashbrown::HashMap`. [#424](https://github.com/dusk-network/plonk/issues/424)

--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -351,7 +351,7 @@ mod test {
     // Creates an opening proof that a polynomial `p` was correctly evaluated at
     // p(z) and produced the value `v`. ie v = p(z).
     // Returns an error if the polynomials degree is too large.
-    pub fn open_single(
+    fn open_single(
         ck: &CommitKey,
         polynomial: &Polynomial,
         value: &BlsScalar,
@@ -369,7 +369,7 @@ mod test {
     // same point and that each evaluation produced the correct evaluation
     // point. Returns an error if any of the polynomial's degrees are too
     // large.
-    pub fn open_multiple(
+    fn open_multiple(
         ck: &CommitKey,
         polynomials: &[Polynomial],
         evaluations: Vec<BlsScalar>,
@@ -404,7 +404,7 @@ mod test {
     // f(z) ie. only the remainder changes. We can therefore compute the
     // witness as f(x) / x - z and only use the remainder term f(z) during
     // verification.
-    pub fn compute_single_witness(
+    fn compute_single_witness(
         polynomial: &Polynomial,
         point: &BlsScalar,
     ) -> Polynomial {

--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -313,9 +313,94 @@ fn check_degree_is_within_bounds(
 }
 #[cfg(test)]
 mod test {
+    use super::super::{AggregateProof, PublicParameters};
+    use super::*;
     use crate::fft::Polynomial;
-    use crate::prelude::*;
+    use dusk_bls12_381::BlsScalar;
     use merlin::Transcript;
+
+    // Checks that a polynomial `p` was evaluated at a point `z` and returned
+    // the value specified `v`. ie. v = p(z).
+    pub fn check(op_key: &OpeningKey, point: BlsScalar, proof: Proof) -> bool {
+        let inner_a: G1Affine = (proof.commitment_to_polynomial.0
+            - (op_key.g * proof.evaluated_point))
+            .into();
+
+        let inner_b: G2Affine = (op_key.beta_h - (op_key.h * point)).into();
+        let prepared_inner_b = G2Prepared::from(-inner_b);
+
+        let pairing = dusk_bls12_381::multi_miller_loop(&[
+            (&inner_a, &op_key.prepared_h),
+            (&proof.commitment_to_witness.0, &prepared_inner_b),
+        ])
+        .final_exponentiation();
+
+        pairing == dusk_bls12_381::Gt::identity()
+    }
+
+    // Creates an opening proof that a polynomial `p` was correctly evaluated at
+    // p(z) and produced the value `v`. ie v = p(z).
+    // Returns an error if the polynomials degree is too large.
+    pub fn open_single(
+        ck: &CommitKey,
+        polynomial: &Polynomial,
+        value: &BlsScalar,
+        point: &BlsScalar,
+    ) -> Result<Proof, Error> {
+        let witness_poly = compute_single_witness(polynomial, point);
+        Ok(Proof {
+            commitment_to_witness: ck.commit(&witness_poly)?,
+            evaluated_point: *value,
+            commitment_to_polynomial: ck.commit(polynomial)?,
+        })
+    }
+
+    // Creates an opening proof that multiple polynomials were evaluated at the
+    // same point and that each evaluation produced the correct evaluation
+    // point. Returns an error if any of the polynomial's degrees are too
+    // large.
+    pub fn open_multiple(
+        ck: &CommitKey,
+        polynomials: &[Polynomial],
+        evaluations: Vec<BlsScalar>,
+        point: &BlsScalar,
+        transcript: &mut Transcript,
+    ) -> Result<AggregateProof, Error> {
+        // Commit to polynomials
+        let mut polynomial_commitments = Vec::with_capacity(polynomials.len());
+        for poly in polynomials.iter() {
+            polynomial_commitments.push(ck.commit(poly)?)
+        }
+
+        // Compute the aggregate witness for polynomials
+        let witness_poly =
+            ck.compute_aggregate_witness(polynomials, point, transcript);
+
+        // Commit to witness polynomial
+        let witness_commitment = ck.commit(&witness_poly)?;
+
+        let aggregate_proof = AggregateProof {
+            commitment_to_witness: witness_commitment,
+            evaluated_points: evaluations,
+            commitments_to_polynomials: polynomial_commitments,
+        };
+        Ok(aggregate_proof)
+    }
+
+    // For a given polynomial `p` and a point `z`, compute the witness
+    // for p(z) using Ruffini's method for simplicity.
+    // The Witness is the quotient of f(x) - f(z) / x-z.
+    // However we note that the quotient polynomial is invariant under the value
+    // f(z) ie. only the remainder changes. We can therefore compute the
+    // witness as f(x) / x - z and only use the remainder term f(z) during
+    // verification.
+    pub fn compute_single_witness(
+        polynomial: &Polynomial,
+        point: &BlsScalar,
+    ) -> Polynomial {
+        // Computes `f(x) / x-z`, returning it as the witness poly
+        polynomial.ruffini(*point)
+    }
 
     // Creates a proving key and verifier key based on a specified degree
     fn setup_test(degree: usize) -> (CommitKey, OpeningKey) {
@@ -326,21 +411,21 @@ mod test {
     #[test]
     fn test_basic_commit() {
         let degree = 25;
-        let (proving_key, opening_key) = setup_test(degree);
+        let (ck, opening_key) = setup_test(degree);
         let point = BlsScalar::from(10);
 
         let poly = Polynomial::rand(degree, &mut rand::thread_rng());
         let value = poly.evaluate(&point);
 
-        let proof = proving_key.open_single(&poly, &value, &point).unwrap();
+        let proof = open_single(&ck, &poly, &value, &point).unwrap();
 
-        let ok = opening_key.check(point, proof);
+        let ok = check(&opening_key, point, proof);
         assert!(ok);
     }
     #[test]
     fn test_batch_verification() {
         let degree = 25;
-        let (proving_key, vk) = setup_test(degree);
+        let (ck, vk) = setup_test(degree);
 
         let point_a = BlsScalar::from(10);
         let point_b = BlsScalar::from(11);
@@ -348,18 +433,14 @@ mod test {
         // Compute secret polynomial a
         let poly_a = Polynomial::rand(degree, &mut rand::thread_rng());
         let value_a = poly_a.evaluate(&point_a);
-        let proof_a = proving_key
-            .open_single(&poly_a, &value_a, &point_a)
-            .unwrap();
-        assert!(vk.check(point_a, proof_a));
+        let proof_a = open_single(&ck, &poly_a, &value_a, &point_a).unwrap();
+        assert!(check(&vk, point_a, proof_a));
 
         // Compute secret polynomial b
         let poly_b = Polynomial::rand(degree, &mut rand::thread_rng());
         let value_b = poly_b.evaluate(&point_b);
-        let proof_b = proving_key
-            .open_single(&poly_b, &value_b, &point_b)
-            .unwrap();
-        assert!(vk.check(point_b, proof_b));
+        let proof_b = open_single(&ck, &poly_b, &value_b, &point_b).unwrap();
+        assert!(check(&vk, point_b, proof_b));
 
         assert!(vk
             .batch_check(
@@ -372,7 +453,7 @@ mod test {
     #[test]
     fn test_aggregate_witness() {
         let max_degree = 27;
-        let (proving_key, opening_key) = setup_test(max_degree);
+        let (ck, opening_key) = setup_test(max_degree);
         let point = BlsScalar::from(10);
 
         // Committer's View
@@ -387,21 +468,21 @@ mod test {
             let poly_c = Polynomial::rand(27, &mut rand::thread_rng());
             let poly_c_eval = poly_c.evaluate(&point);
 
-            proving_key
-                .open_multiple(
-                    &[poly_a, poly_b, poly_c],
-                    vec![poly_a_eval, poly_b_eval, poly_c_eval],
-                    &point,
-                    &mut Transcript::new(b"agg_flatten"),
-                )
-                .unwrap()
+            open_multiple(
+                &ck,
+                &[poly_a, poly_b, poly_c],
+                vec![poly_a_eval, poly_b_eval, poly_c_eval],
+                &point,
+                &mut Transcript::new(b"agg_flatten"),
+            )
+            .unwrap()
         };
 
         // Verifier's View
         let ok = {
             let flattened_proof =
                 aggregated_proof.flatten(&mut Transcript::new(b"agg_flatten"));
-            opening_key.check(point, flattened_proof)
+            check(&opening_key, point, flattened_proof)
         };
 
         assert!(ok);
@@ -410,7 +491,7 @@ mod test {
     #[test]
     fn test_batch_with_aggregation() {
         let max_degree = 28;
-        let (proving_key, opening_key) = setup_test(max_degree);
+        let (ck, opening_key) = setup_test(max_degree);
         let point_a = BlsScalar::from(10);
         let point_b = BlsScalar::from(11);
 
@@ -429,18 +510,17 @@ mod test {
             let poly_d = Polynomial::rand(28, &mut rand::thread_rng());
             let poly_d_eval = poly_d.evaluate(&point_b);
 
-            let aggregated_proof = proving_key
-                .open_multiple(
-                    &[poly_a, poly_b, poly_c],
-                    vec![poly_a_eval, poly_b_eval, poly_c_eval],
-                    &point_a,
-                    &mut Transcript::new(b"agg_batch"),
-                )
-                .unwrap();
+            let aggregated_proof = open_multiple(
+                &ck,
+                &[poly_a, poly_b, poly_c],
+                vec![poly_a_eval, poly_b_eval, poly_c_eval],
+                &point_a,
+                &mut Transcript::new(b"agg_batch"),
+            )
+            .unwrap();
 
-            let single_proof = proving_key
-                .open_single(&poly_d, &poly_d_eval, &point_b)
-                .unwrap();
+            let single_proof =
+                open_single(&ck, &poly_d, &poly_d_eval, &point_b).unwrap();
 
             (aggregated_proof, single_proof)
         };

--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -161,13 +161,11 @@ impl CommitKey {
         &self,
         poly_degree: usize,
     ) -> Result<(), Error> {
-        if poly_degree == 0 {
-            return Err(Error::PolynomialDegreeIsZero);
+        match (poly_degree == 0, poly_degree > self.max_degree()) {
+            (true, _) => Err(Error::PolynomialDegreeIsZero),
+            (false, true) => Err(Error::PolynomialDegreeTooLarge),
+            (false, false) => Ok(()),
         }
-        if poly_degree > self.max_degree() {
-            return Err(Error::PolynomialDegreeTooLarge);
-        }
-        Ok(())
     }
 
     /// Commits to a polynomial returning the corresponding `Commitment`.

--- a/src/commitment_scheme/kzg10/mod.rs
+++ b/src/commitment_scheme/kzg10/mod.rs
@@ -19,28 +19,28 @@ use merlin::Transcript;
 #[derive(Copy, Clone, Debug)]
 /// Proof that a polynomial `p` was correctly evaluated at a point `z`
 /// producing the evaluated point p(z).
-pub struct Proof {
+pub(crate) struct Proof {
     /// This is a commitment to the witness polynomial.
-    pub commitment_to_witness: Commitment,
+    commitment_to_witness: Commitment,
     /// This is the result of evaluating a polynomial at the point `z`.
-    pub evaluated_point: BlsScalar,
+    evaluated_point: BlsScalar,
     /// This is the commitment to the polynomial that you want to prove a
     /// statement about.
-    pub commitment_to_polynomial: Commitment,
+    commitment_to_polynomial: Commitment,
 }
 
 /// Proof that multiple polynomials were correctly evaluated at a point `z`,
 /// each producing their respective evaluated points p_i(z).
 #[derive(Debug)]
-pub struct AggregateProof {
+pub(crate) struct AggregateProof {
     /// This is a commitment to the aggregated witness polynomial.
-    pub commitment_to_witness: Commitment,
+    commitment_to_witness: Commitment,
     /// These are the results of the evaluating each polynomial at the point
     /// `z`.
-    pub evaluated_points: Vec<BlsScalar>,
+    evaluated_points: Vec<BlsScalar>,
     /// These are the commitments to the polynomials which you want to prove a
     /// statement about.
-    pub commitments_to_polynomials: Vec<Commitment>,
+    commitments_to_polynomials: Vec<Commitment>,
 }
 
 impl AggregateProof {

--- a/src/commitment_scheme/kzg10/mod.rs
+++ b/src/commitment_scheme/kzg10/mod.rs
@@ -45,7 +45,7 @@ pub(crate) struct AggregateProof {
 
 impl AggregateProof {
     /// Initialises an `AggregatedProof` with the commitment to the witness.
-    pub fn with_witness(witness: Commitment) -> AggregateProof {
+    pub(crate) fn with_witness(witness: Commitment) -> AggregateProof {
         AggregateProof {
             commitment_to_witness: witness,
             evaluated_points: Vec::new(),
@@ -55,7 +55,7 @@ impl AggregateProof {
 
     /// Adds an evaluated point with the commitment to the polynomial which
     /// produced it.
-    pub fn add_part(&mut self, part: (BlsScalar, Commitment)) {
+    pub(crate) fn add_part(&mut self, part: (BlsScalar, Commitment)) {
         self.evaluated_points.push(part.0);
         self.commitments_to_polynomials.push(part.1);
     }
@@ -63,7 +63,7 @@ impl AggregateProof {
     /// Flattens an `AggregateProof` into a `Proof`.
     /// The transcript must have the same view as the transcript that was used
     /// to aggregate the witness in the proving stage.
-    pub fn flatten(&self, transcript: &mut Transcript) -> Proof {
+    pub(crate) fn flatten(&self, transcript: &mut Transcript) -> Proof {
         let challenge = transcript.challenge_scalar(b"aggregate_witness");
         let powers =
             powers_of(&challenge, self.commitments_to_polynomials.len() - 1);
@@ -96,23 +96,23 @@ impl AggregateProof {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 /// Holds a commitment to a polynomial in a form of a `G1Affine` Bls12_381
 /// point.
-pub struct Commitment(
+pub(crate) struct Commitment(
     /// The commitment is a group element.
-    pub G1Affine,
+    pub(crate) G1Affine,
 );
 
 impl Commitment {
     /// Builds a `Commitment` from a Bls12_381 `G1Projective` point.
-    pub fn from_projective(g: G1Projective) -> Self {
+    pub(crate) fn from_projective(g: G1Projective) -> Self {
         Self(g.into())
     }
     /// Builds a `Commitment` from a Bls12_381 `G1Affine` point.
-    pub fn from_affine(g: G1Affine) -> Self {
+    pub(crate) fn from_affine(g: G1Affine) -> Self {
         Self(g)
     }
     /// Builds an empty `Commitment` which is equivalent to the
     /// `G1Affine` identity point in Bls12_381.
-    pub fn empty() -> Self {
+    fn empty() -> Self {
         Commitment(G1Affine::identity())
     }
 }

--- a/src/commitment_scheme/kzg10/srs.rs
+++ b/src/commitment_scheme/kzg10/srs.rs
@@ -132,7 +132,7 @@ impl PublicParameters {
     /// polynomials up to the and including the truncated degree.
     /// Returns an error if the truncated degree is larger than the public
     /// parameters configured degree.
-    pub fn trim(
+    pub(crate) fn trim(
         &self,
         truncated_degree: usize,
     ) -> Result<(CommitKey, OpeningKey), Error> {

--- a/src/fft/domain.rs
+++ b/src/fft/domain.rs
@@ -14,7 +14,6 @@
 
 use super::Evaluations;
 use crate::error::Error;
-use core::fmt;
 use dusk_bls12_381::{BlsScalar, GENERATOR, ROOT_OF_UNITY, TWO_ADACITY};
 use rayon::iter::{
     IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator,

--- a/src/fft/domain.rs
+++ b/src/fft/domain.rs
@@ -83,16 +83,6 @@ impl EvaluationDomain {
             generator_inv: GENERATOR.invert().unwrap(),
         })
     }
-    /// Return the size of a domain that is large enough for evaluations of a
-    /// polynomial having `num_coeffs` coefficients.
-    pub fn compute_size_of_domain(num_coeffs: usize) -> Option<usize> {
-        let size = num_coeffs.next_power_of_two();
-        if size.trailing_zeros() < TWO_ADACITY {
-            Some(size)
-        } else {
-            None
-        }
-    }
 
     /// Return the size of `self`.
     pub fn size(&self) -> usize {
@@ -243,76 +233,6 @@ impl EvaluationDomain {
             cur_pow: 0,
             domain: *self,
         }
-    }
-
-    /// The target polynomial is the zero polynomial in our
-    /// evaluation domain, so we must perform division over
-    /// a coset.
-    pub fn divide_by_vanishing_poly_on_coset_in_place(
-        &self,
-        evals: &mut [BlsScalar],
-    ) {
-        let i = self
-            .evaluate_vanishing_polynomial(&GENERATOR)
-            .invert()
-            .unwrap();
-
-        evals.par_iter_mut().for_each(|eval| *eval *= &i);
-    }
-
-    /// Given an index which assumes the first elements of this domain are the
-    /// elements of another (sub)domain with size size_s,
-    /// this returns the actual index into this domain.
-    ///
-    /// # Panics
-    /// When the index of self is smaller than the other provided.
-    pub fn reindex_by_subdomain(&self, other: Self, index: usize) -> usize {
-        assert!(self.size() >= other.size());
-        // Let this subgroup be G, and the subgroup we're re-indexing by be S.
-        // Since its a subgroup, the 0th element of S is at index 0 in G, the
-        // first element of S is at index |G|/|S|, the second at
-        // 2*|G|/|S|, etc. Thus for an index i that corresponds to S,
-        // the index in G is i*|G|/|S|
-        let period = self.size() / other.size();
-        if index < other.size() {
-            index * period
-        } else {
-            // Let i now be the index of this element in G \ S
-            // Let x be the number of elements in G \ S, for every element in S.
-            // Then x = (|G|/|S| - 1). At index i in G \ S, the
-            // number of elements in S that appear before the index
-            // in G to which i corresponds to, is floor(i / x) + 1.
-            // The +1 is because index 0 of G is S_0, so the
-            // position is offset by at least one. The floor(i / x) term is
-            // because after x elements in G \ S, there is one more element from
-            // S that will have appeared in G.
-            let i = index - other.size();
-            let x = period - 1;
-            i + (i / x) + 1
-        }
-    }
-
-    /// Perform O(n) multiplication of two polynomials that are presented by
-    /// their evaluations in the domain.
-    /// Returns the evaluations of the product over the domain.
-    ///
-    /// Assumes that the domain is large enough to allow for successful
-    /// interpolation after multiplication.
-    #[must_use]
-    pub fn mul_polynomials_in_evaluation_domain(
-        &self,
-        self_evals: &[BlsScalar],
-        other_evals: &[BlsScalar],
-    ) -> Vec<BlsScalar> {
-        assert_eq!(self_evals.len(), other_evals.len());
-        let mut result = self_evals.to_vec();
-
-        result
-            .par_iter_mut()
-            .zip(other_evals)
-            .for_each(|(a, b)| *a *= b);
-
-        result
     }
 }
 

--- a/src/fft/domain.rs
+++ b/src/fft/domain.rs
@@ -24,28 +24,22 @@ use std::ops::MulAssign;
 /// Defines a domain over which finite field (I)FFTs can be performed. Works
 /// only for fields that have a large multiplicative subgroup of size that is
 /// a power-of-2.
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct EvaluationDomain {
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub(crate) struct EvaluationDomain {
     /// The size of the domain.
-    pub size: u64,
+    pub(crate) size: u64,
     /// `log_2(self.size)`.
-    pub log_size_of_group: u32,
+    pub(crate) log_size_of_group: u32,
     /// Size of the domain as a field element.
-    pub size_as_field_element: BlsScalar,
+    pub(crate) size_as_field_element: BlsScalar,
     /// Inverse of the size in the field.
-    pub size_inv: BlsScalar,
+    pub(crate) size_inv: BlsScalar,
     /// A generator of the subgroup.
-    pub group_gen: BlsScalar,
+    pub(crate) group_gen: BlsScalar,
     /// Inverse of the generator of the subgroup.
-    pub group_gen_inv: BlsScalar,
+    pub(crate) group_gen_inv: BlsScalar,
     /// Multiplicative generator of the finite field.
-    pub generator_inv: BlsScalar,
-}
-
-impl fmt::Debug for EvaluationDomain {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Multiplicative subgroup of size {}", self.size)
-    }
+    pub(crate) generator_inv: BlsScalar,
 }
 
 impl EvaluationDomain {

--- a/src/fft/evaluations.rs
+++ b/src/fft/evaluations.rs
@@ -15,7 +15,7 @@ use dusk_bls12_381::BlsScalar;
 
 /// Stores a polynomial in evaluation form.
 #[derive(PartialEq, Eq, Debug, Clone)]
-pub struct Evaluations {
+pub(crate) struct Evaluations {
     /// The evaluations of a polynomial over the domain `D`
     pub evals: Vec<BlsScalar>,
     #[doc(hidden)]

--- a/src/fft/evaluations.rs
+++ b/src/fft/evaluations.rs
@@ -32,11 +32,6 @@ impl Evaluations {
     }
 
     /// Interpolate a polynomial from a list of evaluations
-    pub fn interpolate_by_ref(&self) -> Polynomial {
-        Polynomial::from_coefficients_vec(self.domain.ifft(&self.evals))
-    }
-
-    /// Interpolate a polynomial from a list of evaluations
     pub fn interpolate(self) -> Polynomial {
         let Self { mut evals, domain } = self;
         domain.ifft_in_place(&mut evals);

--- a/src/fft/evaluations.rs
+++ b/src/fft/evaluations.rs
@@ -17,14 +17,14 @@ use dusk_bls12_381::BlsScalar;
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub(crate) struct Evaluations {
     /// The evaluations of a polynomial over the domain `D`
-    pub evals: Vec<BlsScalar>,
+    pub(crate) evals: Vec<BlsScalar>,
     #[doc(hidden)]
     domain: EvaluationDomain,
 }
 
 impl Evaluations {
     /// Construct `Self` from evaluations and a domain.
-    pub fn from_vec_and_domain(
+    pub(crate) fn from_vec_and_domain(
         evals: Vec<BlsScalar>,
         domain: EvaluationDomain,
     ) -> Self {
@@ -32,7 +32,7 @@ impl Evaluations {
     }
 
     /// Interpolate a polynomial from a list of evaluations
-    pub fn interpolate(self) -> Polynomial {
+    pub(crate) fn interpolate(self) -> Polynomial {
         let Self { mut evals, domain } = self;
         domain.ifft_in_place(&mut evals);
         Polynomial::from_coefficients_vec(evals)

--- a/src/fft/mod.rs
+++ b/src/fft/mod.rs
@@ -11,6 +11,6 @@ pub(crate) mod domain;
 pub(crate) mod evaluations;
 pub(crate) mod polynomial;
 
-pub use domain::EvaluationDomain;
-pub use evaluations::Evaluations;
-pub use polynomial::Polynomial;
+pub(crate) use domain::EvaluationDomain;
+pub(crate) use evaluations::Evaluations;
+pub(crate) use polynomial::Polynomial;

--- a/src/fft/polynomial.rs
+++ b/src/fft/polynomial.rs
@@ -140,17 +140,6 @@ impl Polynomial {
 
         Ok(Polynomial { coeffs })
     }
-
-    #[cfg(test)]
-    /// Outputs a polynomial of degree `d` where each coefficient is sampled
-    /// uniformly at random from the field `F`.
-    pub(crate) fn rand<R: RngCore + CryptoRng>(d: usize, mut rng: &mut R) -> Self {
-        let mut random_coeffs = Vec::with_capacity(d + 1);
-        for _ in 0..=d {
-            random_coeffs.push(util::random_scalar(&mut rng));
-        }
-        Self::from_coefficients_vec(random_coeffs)
-    }
 }
 
 use std::iter::Sum;
@@ -451,6 +440,19 @@ impl<'a, 'b> Sub<&'a BlsScalar> for &'b Polynomial {
 mod test {
     use super::*;
     use rand_core::{CryptoRng, RngCore};
+
+    impl Polynomial {
+        /// Outputs a polynomial of degree `d` where each coefficient is sampled
+        /// uniformly at random from the field `F`.
+        pub(crate) fn rand<R: RngCore + CryptoRng>(d: usize, mut rng: &mut R) -> Self {
+            let mut random_coeffs = Vec::with_capacity(d + 1);
+            for _ in 0..=d {
+                random_coeffs.push(util::random_scalar(&mut rng));
+            }
+            Self::from_coefficients_vec(random_coeffs)
+        }
+    }
+
     #[test]
     fn test_ruffini() {
         // X^2 + 4X + 4

--- a/src/fft/polynomial.rs
+++ b/src/fft/polynomial.rs
@@ -8,8 +8,11 @@
 //! Where each coefficient is represented using a position in the underlying
 //! vector.
 use super::{EvaluationDomain, Evaluations};
+use crate::error::Error;
 use crate::util;
 use dusk_bls12_381::BlsScalar;
+use dusk_bytes::{DeserializableSlice, Serializable};
+#[cfg(test)]
 use rand_core::{CryptoRng, RngCore};
 use rayon::iter::{
     IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator,
@@ -20,7 +23,7 @@ use std::ops::{Add, AddAssign, Deref, DerefMut, Mul, Neg, Sub, SubAssign};
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 /// Polynomial represents a polynomial in coeffiient form.
-pub struct Polynomial {
+pub(crate) struct Polynomial {
     /// The coefficient of `x^i` is stored at location `i` in `self.coeffs`.
     pub coeffs: Vec<BlsScalar>,
 }
@@ -41,12 +44,12 @@ impl DerefMut for Polynomial {
 
 impl Polynomial {
     /// Returns the zero polynomial.
-    pub fn zero() -> Self {
+    pub(crate) const fn zero() -> Self {
         Self { coeffs: Vec::new() }
     }
 
     /// Checks if the given polynomial is zero.
-    pub fn is_zero(&self) -> bool {
+    pub(crate) fn is_zero(&self) -> bool {
         self.coeffs.is_empty()
             || self
                 .coeffs
@@ -55,7 +58,7 @@ impl Polynomial {
     }
 
     /// Constructs a new polynomial from a list of coefficients.
-    pub fn from_coefficients_slice(coeffs: &[BlsScalar]) -> Self {
+    pub(crate) fn from_coefficients_slice(coeffs: &[BlsScalar]) -> Self {
         Self::from_coefficients_vec(coeffs.to_vec())
     }
 
@@ -63,7 +66,7 @@ impl Polynomial {
     ///
     /// # Panics
     /// When the length of the coeffs is zero.
-    pub fn from_coefficients_vec(coeffs: Vec<BlsScalar>) -> Self {
+    pub(crate) fn from_coefficients_vec(coeffs: Vec<BlsScalar>) -> Self {
         let mut result = Self { coeffs };
         // While there are zeros at the end of the coefficient vector, pop them
         // off.
@@ -79,7 +82,7 @@ impl Polynomial {
     }
 
     /// Returns the degree of the polynomial.
-    pub fn degree(&self) -> usize {
+    pub(crate) fn degree(&self) -> usize {
         if self.is_zero() {
             return 0;
         }
@@ -100,7 +103,7 @@ impl Polynomial {
         }
     }
     /// Evaluates `self` at the given `point` in the field.
-    pub fn evaluate(&self, point: &BlsScalar) -> BlsScalar {
+    pub(crate) fn evaluate(&self, point: &BlsScalar) -> BlsScalar {
         if self.is_zero() {
             return BlsScalar::zero();
         }
@@ -120,9 +123,30 @@ impl Polynomial {
         sum
     }
 
+    /// Given a Polynomial, return it in it's byte representation coefficient by coefficient.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.coeffs
+            .iter()
+            .map(|item| item.to_bytes().to_vec())
+            .flatten()
+            .collect()
+    }
+
+    /// Generate a Polynomial from a slice of bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Polynomial, Error> {
+        let coeffs = bytes
+            .chunks(BlsScalar::SIZE)
+            .map(|chunk| BlsScalar::from_slice(chunk))
+            .collect::<Result<Vec<BlsScalar>, dusk_bytes::Error>>()
+            .map_err(|_| Error::BlsScalarMalformed)?;
+
+        Ok(Polynomial { coeffs })
+    }
+
+    #[cfg(test)]
     /// Outputs a polynomial of degree `d` where each coefficient is sampled
     /// uniformly at random from the field `F`.
-    pub fn rand<R: RngCore + CryptoRng>(d: usize, mut rng: &mut R) -> Self {
+    pub(crate) fn rand<R: RngCore + CryptoRng>(d: usize, mut rng: &mut R) -> Self {
         let mut random_coeffs = Vec::with_capacity(d + 1);
         for _ in 0..=d {
             random_coeffs.push(util::random_scalar(&mut rng));

--- a/src/fft/polynomial.rs
+++ b/src/fft/polynomial.rs
@@ -8,10 +8,8 @@
 //! Where each coefficient is represented using a position in the underlying
 //! vector.
 use super::{EvaluationDomain, Evaluations};
-use crate::error::Error;
 use crate::util;
 use dusk_bls12_381::BlsScalar;
-use dusk_bytes::{DeserializableSlice, Serializable};
 use rayon::iter::{
     IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator,
     ParallelIterator,
@@ -119,26 +117,6 @@ impl Polynomial {
             sum += &eval;
         }
         sum
-    }
-
-    /// Given a Polynomial, return it in it's byte representation coefficient by coefficient.
-    pub fn to_bytes(&self) -> Vec<u8> {
-        self.coeffs
-            .iter()
-            .map(|item| item.to_bytes().to_vec())
-            .flatten()
-            .collect()
-    }
-
-    /// Generate a Polynomial from a slice of bytes.
-    pub fn from_bytes(bytes: &[u8]) -> Result<Polynomial, Error> {
-        let coeffs = bytes
-            .chunks(BlsScalar::SIZE)
-            .map(|chunk| BlsScalar::from_slice(chunk))
-            .collect::<Result<Vec<BlsScalar>, dusk_bytes::Error>>()
-            .map_err(|_| Error::BlsScalarMalformed)?;
-
-        Ok(Polynomial { coeffs })
     }
 }
 

--- a/src/fft/polynomial.rs
+++ b/src/fft/polynomial.rs
@@ -21,7 +21,7 @@ use std::ops::{Add, AddAssign, Deref, DerefMut, Mul, Neg, Sub, SubAssign};
 /// Polynomial represents a polynomial in coeffiient form.
 pub(crate) struct Polynomial {
     /// The coefficient of `x^i` is stored at location `i` in `self.coeffs`.
-    pub coeffs: Vec<BlsScalar>,
+    pub(crate) coeffs: Vec<BlsScalar>,
 }
 
 impl Deref for Polynomial {
@@ -422,7 +422,10 @@ mod test {
     impl Polynomial {
         /// Outputs a polynomial of degree `d` where each coefficient is sampled
         /// uniformly at random from the field `F`.
-        pub(crate) fn rand<R: RngCore + CryptoRng>(d: usize, mut rng: &mut R) -> Self {
+        pub(crate) fn rand<R: RngCore + CryptoRng>(
+            d: usize,
+            mut rng: &mut R,
+        ) -> Self {
             let mut random_coeffs = Vec::with_capacity(d + 1);
             for _ in 0..=d {
                 random_coeffs.push(util::random_scalar(&mut rng));

--- a/src/fft/polynomial.rs
+++ b/src/fft/polynomial.rs
@@ -12,8 +12,6 @@ use crate::error::Error;
 use crate::util;
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Serializable};
-#[cfg(test)]
-use rand_core::{CryptoRng, RngCore};
 use rayon::iter::{
     IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator,
     ParallelIterator,
@@ -452,6 +450,7 @@ impl<'a, 'b> Sub<&'a BlsScalar> for &'b Polynomial {
 #[cfg(test)]
 mod test {
     use super::*;
+    use rand_core::{CryptoRng, RngCore};
     #[test]
     fn test_ruffini() {
         // X^2 + 4X + 4

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,15 +57,15 @@ mod macros;
 
 mod bit_iterator;
 pub mod circuit;
-pub mod commitment_scheme;
+mod commitment_scheme;
 pub mod constraint_system;
-pub mod error;
-pub mod fft;
+mod error;
+mod fft;
 mod permutation;
 pub mod prelude;
 pub mod proof_system;
 mod serialisation;
-pub mod transcript;
+mod transcript;
 mod util;
 
 #[cfg(feature = "nightly")]

--- a/src/permutation/mod.rs
+++ b/src/permutation/mod.rs
@@ -7,4 +7,4 @@
 pub(crate) mod constants;
 #[allow(clippy::module_inception)]
 pub(crate) mod permutation;
-pub use permutation::Permutation;
+pub(crate) use permutation::Permutation;

--- a/src/permutation/permutation.rs
+++ b/src/permutation/permutation.rs
@@ -17,18 +17,18 @@ use rayon::iter::*;
 /// to create the permutation polynomial. In the literature, Z(X) is the
 /// "accumulator", this is what this codebase calls the permutation polynomial.
 #[derive(Debug)]
-pub struct Permutation {
+pub(crate) struct Permutation {
     // Maps a variable to the wires that it is associated to
     pub(crate) variable_map: HashMap<Variable, Vec<WireData>>,
 }
 
 impl Permutation {
     /// Creates a permutation struct with an expected capacity of zero
-    pub fn new() -> Permutation {
+    pub(crate) fn new() -> Permutation {
         Permutation::with_capacity(0)
     }
     /// Creates a permutation struct with an expected capacity of `n`
-    pub fn with_capacity(expected_size: usize) -> Permutation {
+    pub(crate) fn with_capacity(expected_size: usize) -> Permutation {
         Permutation {
             variable_map: HashMap::with_capacity(expected_size),
         }
@@ -36,7 +36,7 @@ impl Permutation {
     /// Creates a new Variable by incrementing the index of the Variable Map
     /// This is correct as whenever we add a new Variable into the system
     /// It is always allocated in the Variable Map
-    pub fn new_variable(&mut self) -> Variable {
+    pub(crate) fn new_variable(&mut self) -> Variable {
         // Generate the Variable
         let var = Variable(self.variable_map.keys().len());
 
@@ -82,7 +82,11 @@ impl Permutation {
         self.add_variable_to_map(d, fourth);
     }
 
-    pub fn add_variable_to_map(&mut self, var: Variable, wire_data: WireData) {
+    pub(crate) fn add_variable_to_map(
+        &mut self,
+        var: Variable,
+        wire_data: WireData,
+    ) {
         assert!(self.valid_variables(&[var]));
 
         // Since we always allocate space for the Vec of WireData when a
@@ -165,7 +169,7 @@ impl Permutation {
 
     /// Computes the sigma polynomials which are used to build the permutation
     /// polynomial
-    pub fn compute_sigma_polynomials(
+    pub(crate) fn compute_sigma_polynomials(
         &mut self,
         n: usize,
         domain: &EvaluationDomain,

--- a/src/proof_system/linearisation_poly.rs
+++ b/src/proof_system/linearisation_poly.rs
@@ -12,52 +12,52 @@ use dusk_bls12_381::BlsScalar;
 use dusk_bytes::Serializable;
 
 /// Evaluations at points `z` or and `z * root of unity`
-pub struct Evaluations {
-    pub proof: ProofEvaluations,
+pub(crate) struct Evaluations {
+    pub(crate) proof: ProofEvaluations,
     // Evaluation of the linearisation sigma polynomial at `z`
     pub quot_eval: BlsScalar,
 }
 
 /// Proof Evaluations is a subset of all of the evaluations. These evaluations
 /// will be added to the proof
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub struct ProofEvaluations {
+#[derive(Debug, Eq, PartialEq, Clone, Default)]
+pub(crate) struct ProofEvaluations {
     // Evaluation of the witness polynomial for the left wire at `z`
-    pub a_eval: BlsScalar,
+    pub(crate) a_eval: BlsScalar,
     // Evaluation of the witness polynomial for the right wire at `z`
-    pub b_eval: BlsScalar,
+    pub(crate) b_eval: BlsScalar,
     // Evaluation of the witness polynomial for the output wire at `z`
-    pub c_eval: BlsScalar,
+    pub(crate) c_eval: BlsScalar,
     // Evaluation of the witness polynomial for the fourth wire at `z`
-    pub d_eval: BlsScalar,
+    pub(crate) d_eval: BlsScalar,
     //
-    pub a_next_eval: BlsScalar,
+    pub(crate) a_next_eval: BlsScalar,
     //
-    pub b_next_eval: BlsScalar,
+    pub(crate) b_next_eval: BlsScalar,
     // Evaluation of the witness polynomial for the fourth wire at `z * root of
     // unity`
-    pub d_next_eval: BlsScalar,
+    pub(crate) d_next_eval: BlsScalar,
     // Evaluation of the arithmetic selector polynomial at `z`
-    pub q_arith_eval: BlsScalar,
+    pub(crate) q_arith_eval: BlsScalar,
     //
-    pub q_c_eval: BlsScalar,
+    pub(crate) q_c_eval: BlsScalar,
     //
-    pub q_l_eval: BlsScalar,
+    pub(crate) q_l_eval: BlsScalar,
     //
-    pub q_r_eval: BlsScalar,
+    pub(crate) q_r_eval: BlsScalar,
     // Evaluation of the left sigma polynomial at `z`
-    pub left_sigma_eval: BlsScalar,
+    pub(crate) left_sigma_eval: BlsScalar,
     // Evaluation of the right sigma polynomial at `z`
-    pub right_sigma_eval: BlsScalar,
+    pub(crate) right_sigma_eval: BlsScalar,
     // Evaluation of the out sigma polynomial at `z`
-    pub out_sigma_eval: BlsScalar,
+    pub(crate) out_sigma_eval: BlsScalar,
 
     // Evaluation of the linearisation sigma polynomial at `z`
-    pub lin_poly_eval: BlsScalar,
+    pub(crate) lin_poly_eval: BlsScalar,
 
     // (Shifted) Evaluation of the permutation polynomial at `z * root of
     // unity`
-    pub perm_eval: BlsScalar,
+    pub(crate) perm_eval: BlsScalar,
 }
 
 impl ProofEvaluations {
@@ -137,7 +137,7 @@ impl ProofEvaluations {
 
 #[allow(clippy::too_many_arguments)]
 /// Compute the linearisation polynomial
-pub fn compute(
+pub(crate) fn compute(
     domain: &EvaluationDomain,
     prover_key: &ProverKey,
     (

--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -38,32 +38,32 @@ pub const PROOF_SIZE: usize = Proof::serialised_size();
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct Proof {
     /// Commitment to the witness polynomial for the left wires.
-    pub a_comm: Commitment,
+    pub(crate) a_comm: Commitment,
     /// Commitment to the witness polynomial for the right wires.
-    pub b_comm: Commitment,
+    pub(crate) b_comm: Commitment,
     /// Commitment to the witness polynomial for the output wires.
-    pub c_comm: Commitment,
+    pub(crate) c_comm: Commitment,
     /// Commitment to the witness polynomial for the fourth wires.
-    pub d_comm: Commitment,
+    pub(crate) d_comm: Commitment,
 
     /// Commitment to the permutation polynomial.
-    pub z_comm: Commitment,
+    pub(crate) z_comm: Commitment,
 
     /// Commitment to the quotient polynomial.
-    pub t_1_comm: Commitment,
+    pub(crate) t_1_comm: Commitment,
     /// Commitment to the quotient polynomial.
-    pub t_2_comm: Commitment,
+    pub(crate) t_2_comm: Commitment,
     /// Commitment to the quotient polynomial.
-    pub t_3_comm: Commitment,
+    pub(crate) t_3_comm: Commitment,
     /// Commitment to the quotient polynomial.
-    pub t_4_comm: Commitment,
+    pub(crate) t_4_comm: Commitment,
 
     /// Commitment to the opening polynomial.
-    pub w_z_comm: Commitment,
+    pub(crate) w_z_comm: Commitment,
     /// Commitment to the shifted opening polynomial.
-    pub w_zw_comm: Commitment,
+    pub(crate) w_zw_comm: Commitment,
     /// Subset of all of the evaluations added to the proof.
-    pub evaluations: ProofEvaluations,
+    pub(crate) evaluations: ProofEvaluations,
 }
 
 impl_serde!(Proof);

--- a/src/proof_system/widget/arithmetic/mod.rs
+++ b/src/proof_system/widget/arithmetic/mod.rs
@@ -7,5 +7,5 @@
 mod proverkey;
 mod verifierkey;
 
-pub use proverkey::ProverKey;
-pub use verifierkey::VerifierKey;
+pub(crate) use proverkey::ProverKey;
+pub(crate) use verifierkey::VerifierKey;

--- a/src/proof_system/widget/arithmetic/proverkey.rs
+++ b/src/proof_system/widget/arithmetic/proverkey.rs
@@ -8,7 +8,7 @@ use crate::fft::{Evaluations, Polynomial};
 use dusk_bls12_381::BlsScalar;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub struct ProverKey {
+pub(crate) struct ProverKey {
     pub q_m: (Polynomial, Evaluations),
     pub q_l: (Polynomial, Evaluations),
     pub q_r: (Polynomial, Evaluations),

--- a/src/proof_system/widget/arithmetic/verifierkey.rs
+++ b/src/proof_system/widget/arithmetic/verifierkey.rs
@@ -9,7 +9,7 @@ use crate::proof_system::linearisation_poly::ProofEvaluations;
 use dusk_bls12_381::{BlsScalar, G1Affine};
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub struct VerifierKey {
+pub(crate) struct VerifierKey {
     pub q_m: Commitment,
     pub q_l: Commitment,
     pub q_r: Commitment,

--- a/src/proof_system/widget/ecc/curve_addition/mod.rs
+++ b/src/proof_system/widget/ecc/curve_addition/mod.rs
@@ -7,5 +7,5 @@
 mod proverkey;
 mod verifierkey;
 
-pub use proverkey::ProverKey;
-pub use verifierkey::VerifierKey;
+pub(crate) use proverkey::ProverKey;
+pub(crate) use verifierkey::VerifierKey;

--- a/src/proof_system/widget/ecc/curve_addition/proverkey.rs
+++ b/src/proof_system/widget/ecc/curve_addition/proverkey.rs
@@ -9,8 +9,8 @@ use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::EDWARDS_D;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub struct ProverKey {
-    pub q_variable_group_add: (Polynomial, Evaluations),
+pub(crate) struct ProverKey {
+    pub(crate) q_variable_group_add: (Polynomial, Evaluations),
 }
 
 impl ProverKey {

--- a/src/proof_system/widget/ecc/curve_addition/verifierkey.rs
+++ b/src/proof_system/widget/ecc/curve_addition/verifierkey.rs
@@ -10,8 +10,8 @@ use dusk_bls12_381::{BlsScalar, G1Affine};
 use dusk_jubjub::EDWARDS_D;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub struct VerifierKey {
-    pub q_variable_group_add: Commitment,
+pub(crate) struct VerifierKey {
+    pub(crate) q_variable_group_add: Commitment,
 }
 
 impl VerifierKey {

--- a/src/proof_system/widget/ecc/mod.rs
+++ b/src/proof_system/widget/ecc/mod.rs
@@ -4,5 +4,5 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-pub mod curve_addition;
-pub mod scalar_mul;
+pub(crate) mod curve_addition;
+pub(crate) mod scalar_mul;

--- a/src/proof_system/widget/ecc/scalar_mul/fixed_base/mod.rs
+++ b/src/proof_system/widget/ecc/scalar_mul/fixed_base/mod.rs
@@ -7,8 +7,8 @@
 mod proverkey;
 mod verifierkey;
 
-pub use proverkey::ProverKey;
-pub use verifierkey::VerifierKey;
+pub(crate) use proverkey::ProverKey;
+pub(crate) use verifierkey::VerifierKey;
 
 // Note: The ECC gadget does not check that the initial point is on the curve
 // for two reasons:

--- a/src/proof_system/widget/ecc/scalar_mul/fixed_base/proverkey.rs
+++ b/src/proof_system/widget/ecc/scalar_mul/fixed_base/proverkey.rs
@@ -10,11 +10,11 @@ use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::EDWARDS_D;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub struct ProverKey {
-    pub q_l: (Polynomial, Evaluations),
-    pub q_r: (Polynomial, Evaluations),
-    pub q_c: (Polynomial, Evaluations),
-    pub q_fixed_group_add: (Polynomial, Evaluations),
+pub(crate) struct ProverKey {
+    pub(crate) q_l: (Polynomial, Evaluations),
+    pub(crate) q_r: (Polynomial, Evaluations),
+    pub(crate) q_c: (Polynomial, Evaluations),
+    pub(crate) q_fixed_group_add: (Polynomial, Evaluations),
 }
 
 impl ProverKey {

--- a/src/proof_system/widget/ecc/scalar_mul/fixed_base/verifierkey.rs
+++ b/src/proof_system/widget/ecc/scalar_mul/fixed_base/verifierkey.rs
@@ -11,10 +11,10 @@ use dusk_bls12_381::{BlsScalar, G1Affine};
 use dusk_jubjub::EDWARDS_D;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub struct VerifierKey {
-    pub q_l: Commitment,
-    pub q_r: Commitment,
-    pub q_fixed_group_add: Commitment,
+pub(crate) struct VerifierKey {
+    pub(crate) q_l: Commitment,
+    pub(crate) q_r: Commitment,
+    pub(crate) q_fixed_group_add: Commitment,
 }
 
 impl VerifierKey {

--- a/src/proof_system/widget/logic/mod.rs
+++ b/src/proof_system/widget/logic/mod.rs
@@ -7,8 +7,8 @@
 mod proverkey;
 mod verifierkey;
 
-pub use proverkey::ProverKey;
-pub use verifierkey::VerifierKey;
+pub(crate) use proverkey::ProverKey;
+pub(crate) use verifierkey::VerifierKey;
 
 /// Common functionality across both the ProverKey and VerifierKey are
 /// listed below

--- a/src/proof_system/widget/logic/proverkey.rs
+++ b/src/proof_system/widget/logic/proverkey.rs
@@ -11,9 +11,9 @@ use crate::fft::{Evaluations, Polynomial};
 use dusk_bls12_381::BlsScalar;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub struct ProverKey {
-    pub q_c: (Polynomial, Evaluations),
-    pub q_logic: (Polynomial, Evaluations),
+pub(crate) struct ProverKey {
+    pub(crate) q_c: (Polynomial, Evaluations),
+    pub(crate) q_logic: (Polynomial, Evaluations),
 }
 
 impl ProverKey {

--- a/src/proof_system/widget/logic/verifierkey.rs
+++ b/src/proof_system/widget/logic/verifierkey.rs
@@ -10,9 +10,9 @@ use crate::proof_system::linearisation_poly::ProofEvaluations;
 use dusk_bls12_381::{BlsScalar, G1Affine};
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub struct VerifierKey {
-    pub q_c: Commitment,
-    pub q_logic: Commitment,
+pub(crate) struct VerifierKey {
+    pub(crate) q_c: Commitment,
+    pub(crate) q_logic: Commitment,
 }
 
 impl VerifierKey {

--- a/src/proof_system/widget/permutation/mod.rs
+++ b/src/proof_system/widget/permutation/mod.rs
@@ -7,5 +7,5 @@
 mod proverkey;
 mod verifierkey;
 
-pub use proverkey::ProverKey;
-pub use verifierkey::VerifierKey;
+pub(crate) use proverkey::ProverKey;
+pub(crate) use verifierkey::VerifierKey;

--- a/src/proof_system/widget/permutation/proverkey.rs
+++ b/src/proof_system/widget/permutation/proverkey.rs
@@ -10,16 +10,18 @@ use crate::permutation::constants::{K1, K2, K3};
 use dusk_bls12_381::BlsScalar;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub struct ProverKey {
-    pub left_sigma: (Polynomial, Evaluations),
-    pub right_sigma: (Polynomial, Evaluations),
-    pub out_sigma: (Polynomial, Evaluations),
-    pub fourth_sigma: (Polynomial, Evaluations),
-    pub linear_evaluations: Evaluations, /* Evaluations of f(x) = X [XXX:
-                                          * Remove this and benchmark if it
-                                          * makes a considerable difference
-                                          * -- These are just the domain
-                                          * elements] */
+pub(crate) struct ProverKey {
+    pub(crate) left_sigma: (Polynomial, Evaluations),
+    pub(crate) right_sigma: (Polynomial, Evaluations),
+    pub(crate) out_sigma: (Polynomial, Evaluations),
+    pub(crate) fourth_sigma: (Polynomial, Evaluations),
+    pub(crate) linear_evaluations: Evaluations,
+    /* Evaluations of f(x) = X
+     * [XXX: Remove this and
+     * benchmark if it makes a
+     * considerable difference
+     * -- These are just the
+     * domain elements] */
 }
 
 impl ProverKey {

--- a/src/proof_system/widget/permutation/verifierkey.rs
+++ b/src/proof_system/widget/permutation/verifierkey.rs
@@ -12,11 +12,11 @@ use crate::proof_system::linearisation_poly::ProofEvaluations;
 use dusk_bls12_381::{BlsScalar, G1Affine};
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub struct VerifierKey {
-    pub left_sigma: Commitment,
-    pub right_sigma: Commitment,
-    pub out_sigma: Commitment,
-    pub fourth_sigma: Commitment,
+pub(crate) struct VerifierKey {
+    pub(crate) left_sigma: Commitment,
+    pub(crate) right_sigma: Commitment,
+    pub(crate) out_sigma: Commitment,
+    pub(crate) fourth_sigma: Commitment,
 }
 
 impl VerifierKey {

--- a/src/proof_system/widget/range/mod.rs
+++ b/src/proof_system/widget/range/mod.rs
@@ -7,12 +7,9 @@
 mod proverkey;
 mod verifierkey;
 
-pub use proverkey::ProverKey;
-pub use verifierkey::VerifierKey;
-
-/// Common functionality across both the ProverKey and VerifierKey are
-/// listed below
 use dusk_bls12_381::BlsScalar;
+pub(crate) use proverkey::ProverKey;
+pub(crate) use verifierkey::VerifierKey;
 
 // Computes f(f-1)(f-2)(f-3)
 fn delta(f: BlsScalar) -> BlsScalar {

--- a/src/proof_system/widget/range/proverkey.rs
+++ b/src/proof_system/widget/range/proverkey.rs
@@ -9,8 +9,8 @@ use crate::fft::{Evaluations, Polynomial};
 use dusk_bls12_381::BlsScalar;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub struct ProverKey {
-    pub q_range: (Polynomial, Evaluations),
+pub(crate) struct ProverKey {
+    pub(crate) q_range: (Polynomial, Evaluations),
 }
 
 impl ProverKey {

--- a/src/proof_system/widget/range/verifierkey.rs
+++ b/src/proof_system/widget/range/verifierkey.rs
@@ -10,8 +10,8 @@ use crate::proof_system::linearisation_poly::ProofEvaluations;
 use dusk_bls12_381::{BlsScalar, G1Affine};
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub struct VerifierKey {
-    pub q_range: Commitment,
+pub(crate) struct VerifierKey {
+    pub(crate) q_range: Commitment,
 }
 
 impl VerifierKey {

--- a/src/serialisation.rs
+++ b/src/serialisation.rs
@@ -23,7 +23,7 @@ pub fn read_n(n: usize, bytes: &[u8]) -> Result<(&[u8], &[u8]), Error> {
 
 /// Reads 32 bytes and converts it to a BlsScalar
 /// Returns the remaining bytes
-pub fn read_scalar(bytes: &[u8]) -> Result<(BlsScalar, &[u8]), Error> {
+pub(crate) fn read_scalar(bytes: &[u8]) -> Result<(BlsScalar, &[u8]), Error> {
     let (bytes, rest) = read_n(BlsScalar::SIZE, bytes)?;
 
     BlsScalar::from_slice(bytes)
@@ -32,13 +32,13 @@ pub fn read_scalar(bytes: &[u8]) -> Result<(BlsScalar, &[u8]), Error> {
 }
 
 /// Writes a BlsScalar into a mutable slice
-pub fn write_scalar(scalar: &BlsScalar, bytes: &mut Vec<u8>) {
+pub(crate) fn write_scalar(scalar: &BlsScalar, bytes: &mut Vec<u8>) {
     bytes.extend_from_slice(&scalar.to_bytes());
 }
 
 /// Reads 48 bytes and converts it to a G1Affine
 /// Returns the remaining bytes
-pub fn read_g1_affine(bytes: &[u8]) -> Result<(G1Affine, &[u8]), Error> {
+pub(crate) fn read_g1_affine(bytes: &[u8]) -> Result<(G1Affine, &[u8]), Error> {
     let (bytes, rest) = read_n(G1Affine::SIZE, bytes)?;
 
     G1Affine::from_slice(bytes)
@@ -48,23 +48,25 @@ pub fn read_g1_affine(bytes: &[u8]) -> Result<(G1Affine, &[u8]), Error> {
 
 /// Reads 48 bytes and converts it to a Commitment
 /// Returns the remaining bytes
-pub fn read_commitment(bytes: &[u8]) -> Result<(Commitment, &[u8]), Error> {
+pub(crate) fn read_commitment(
+    bytes: &[u8],
+) -> Result<(Commitment, &[u8]), Error> {
     let (g1, rest) = read_g1_affine(bytes)?;
     Ok((Commitment::from_affine(g1), rest))
 }
 /// Writes a G1Affine into a mutable slice
-pub fn write_g1_affine(affine: &G1Affine, bytes: &mut Vec<u8>) {
+pub(crate) fn write_g1_affine(affine: &G1Affine, bytes: &mut Vec<u8>) {
     let bytes48 = affine.to_bytes();
     bytes.extend_from_slice(&bytes48);
 }
 /// Writes a Commitment into a mutable slice
-pub fn write_commitment(commitment: &Commitment, bytes: &mut Vec<u8>) {
+pub(crate) fn write_commitment(commitment: &Commitment, bytes: &mut Vec<u8>) {
     write_g1_affine(&commitment.0, bytes)
 }
 
 /// Reads 96 bytes and converts it to a G2Affine
 /// Returns the remaining bytes
-pub fn read_g2_affine(bytes: &[u8]) -> Result<(G2Affine, &[u8]), Error> {
+pub(crate) fn read_g2_affine(bytes: &[u8]) -> Result<(G2Affine, &[u8]), Error> {
     let (bytes, rest) = read_n(G2Affine::SIZE, bytes)?;
 
     G2Affine::from_slice(bytes)
@@ -74,20 +76,22 @@ pub fn read_g2_affine(bytes: &[u8]) -> Result<(G2Affine, &[u8]), Error> {
 
 /// Reads 8 bytes and converts it to a u64
 /// Returns the remaining bytes
-pub fn read_u64(bytes: &[u8]) -> Result<(u64, &[u8]), Error> {
+pub(crate) fn read_u64(bytes: &[u8]) -> Result<(u64, &[u8]), Error> {
     let (bytes8, rest) = read_n(8, bytes)?;
     let mut arr8 = [0u8; 8];
     arr8.copy_from_slice(bytes8);
     Ok((u64::from_be_bytes(arr8), rest))
 }
 /// Writes a u64 into a mutable slice
-pub fn write_u64(val: u64, bytes: &mut Vec<u8>) {
+pub(crate) fn write_u64(val: u64, bytes: &mut Vec<u8>) {
     bytes.extend_from_slice(&u64::to_be_bytes(val));
 }
 
 /// Reads the bytes slice and parses a Vector of scalars
 /// Returns the remaining bytes
-pub fn read_scalars(bytes: &[u8]) -> Result<(Vec<BlsScalar>, &[u8]), Error> {
+pub(crate) fn read_scalars(
+    bytes: &[u8],
+) -> Result<(Vec<BlsScalar>, &[u8]), Error> {
     let (num_scalars, mut bytes) = read_u64(bytes)?;
 
     let mut poly_vec = Vec::new();
@@ -99,7 +103,7 @@ pub fn read_scalars(bytes: &[u8]) -> Result<(Vec<BlsScalar>, &[u8]), Error> {
     Ok((poly_vec, bytes))
 }
 /// Writes a Vector of scalars into a mutable slice
-pub fn write_scalars(val: &[BlsScalar], bytes: &mut Vec<u8>) {
+pub(crate) fn write_scalars(val: &[BlsScalar], bytes: &mut Vec<u8>) {
     let num_scalars = val.len() as u64;
     write_u64(num_scalars, bytes);
 
@@ -109,17 +113,19 @@ pub fn write_scalars(val: &[BlsScalar], bytes: &mut Vec<u8>) {
 }
 /// Reads the bytes slice and parses a Polynomial
 /// Returns the remaining bytes
-pub fn read_polynomial(bytes: &[u8]) -> Result<(Polynomial, &[u8]), Error> {
+pub(crate) fn read_polynomial(
+    bytes: &[u8],
+) -> Result<(Polynomial, &[u8]), Error> {
     let (poly_vec, rest) = read_scalars(bytes)?;
     Ok((Polynomial::from_coefficients_vec(poly_vec), rest))
 }
 /// Writes a Polynomial into a mutable slice
-pub fn write_polynomial(val: &Polynomial, bytes: &mut Vec<u8>) {
+pub(crate) fn write_polynomial(val: &Polynomial, bytes: &mut Vec<u8>) {
     write_scalars(&val.coeffs, bytes);
 }
 /// Reads the bytes slice and parses an Evaluation struct
 /// Returns the remaining bytes
-pub fn read_evaluations(
+pub(crate) fn read_evaluations(
     domain: EvaluationDomain,
     bytes: &[u8],
 ) -> Result<(Evaluations, &[u8]), Error> {
@@ -130,7 +136,7 @@ pub fn read_evaluations(
     Ok((evals, rest))
 }
 /// Writes an Evaluation struct into a mutable slice
-pub fn write_evaluations(val: &Evaluations, bytes: &mut Vec<u8>) {
+pub(crate) fn write_evaluations(val: &Evaluations, bytes: &mut Vec<u8>) {
     write_scalars(&val.evals, bytes)
 }
 

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -13,7 +13,7 @@ use merlin::Transcript;
 
 /// Transcript adds an abstraction over the Merlin transcript
 /// For convenience
-pub trait TranscriptProtocol {
+pub(crate) trait TranscriptProtocol {
     /// Append a `commitment` with the given `label`.
     fn append_commitment(&mut self, label: &'static [u8], comm: &Commitment);
 


### PR DESCRIPTION
Currently, we expose a way too much things when indeed we should try
to expose publicly in the API only the necessary stuff.

We have modules as fft or transcript_protocol which shouldn't be pub.
Also there are quite some structures which are pub but never meant to
be used by the lib consumers.

The idea is that with this PR we're able to make more clear which are
the things that the consumer is suposed to call or do.

Closes #438

**Blocked by the merge of #434 . Once done, this needs to be rebased to `release-0.6` and then could be reviewed**