### PR TITLE
Fix Error type used for Serializable impl Proof

### DIFF
--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -85,7 +85,7 @@ impl<S: Store> Canon<S> for Proof {
 impl Serializable<{ 11 * Commitment::SIZE + ProofEvaluations::SIZE }>
     for Proof
 {
-    type Error = Error;
+    type Error = dusk_bytes::Error;
 
     #[allow(unused_must_use)]
     fn to_bytes(&self) -> [u8; Self::SIZE] {


### PR DESCRIPTION
In order to impl the propper `BadLenght` trait & others we need to set
the associated error for the `Serializable` trait impl for `Proof` as
`dusk_bytes::Error` and take profit of the conversion with `?` to convert
the error into a `plonk::Error` when needed.

Resolves: #447