### PR TITLE
Implement ID associated const for Circuit trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ pub struct TestCircuit {
 }
 
 impl Circuit for TestCircuit {
+    // You could generate the ID by hashing the `gadget()` fn code
+    // in a proc_macro with something like Blake3.
+    const CIRCUIT_ID: [u8; 32] = *b"0x000000000000000000000000000000";
     fn gadget(&mut self, composer: &mut StandardComposer) -> Result<(), Error> {
         let a = composer.add_input(self.a);
         let b = composer.add_input(self.b);

--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ pub struct TestCircuit {
 }
 
 impl Circuit for TestCircuit {
-    // You could generate the ID by hashing the `gadget()` fn code
-    // in a proc_macro with something like Blake3.
-    const CIRCUIT_ID: [u8; 32] = *b"0x000000000000000000000000000000";
+    const CIRCUIT_ID: [u8; 32] = [0xff; 32];
     fn gadget(&mut self, composer: &mut StandardComposer) -> Result<(), Error> {
         let a = composer.add_input(self.a);
         let b = composer.add_input(self.b);

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -47,6 +47,9 @@ pub trait Circuit
 where
     Self: Sized,
 {
+    /// An identifier constant that you can use to disseminate between similar
+    /// circuits.
+    const CIRCUIT_ID: [u8; 32];
     /// Gadget implementation used to fill the composer.
     fn gadget(&mut self, composer: &mut StandardComposer) -> Result<(), Error>;
     /// Compiles the circuit by using a function that returns a `Result`
@@ -167,6 +170,7 @@ mod tests {
     }
 
     impl Circuit for TestCircuit {
+        const CIRCUIT_ID: [u8; 32] = *b"0x000000000000000000000000000000";
         fn gadget(
             &mut self,
             composer: &mut StandardComposer,

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -47,8 +47,7 @@ pub trait Circuit
 where
     Self: Sized,
 {
-    /// An identifier constant that you can use to disseminate between similar
-    /// circuits.
+    /// Circuit identifier associated constant.
     const CIRCUIT_ID: [u8; 32];
     /// Gadget implementation used to fill the composer.
     fn gadget(&mut self, composer: &mut StandardComposer) -> Result<(), Error>;
@@ -170,7 +169,7 @@ mod tests {
     }
 
     impl Circuit for TestCircuit {
-        const CIRCUIT_ID: [u8; 32] = *b"0x000000000000000000000000000000";
+        const CIRCUIT_ID: [u8; 32] = [0xff; 32];
         fn gadget(
             &mut self,
             composer: &mut StandardComposer,


### PR DESCRIPTION
As discussed with the core team, this would enable features like
circuit versioning with techniqes like:
> You could generate the ID by hashing the `gadget()` fn code
in a proc_macro with something like Blake3.

Resolves: #417