### PR TITLE
Change trim() visibility to pub

### DIFF
--- a/src/commitment_scheme/kzg10/srs.rs
+++ b/src/commitment_scheme/kzg10/srs.rs
@@ -143,7 +143,7 @@ impl PublicParameters {
     /// polynomials up to the and including the truncated degree.
     /// Returns an error if the truncated degree is larger than the public
     /// parameters configured degree.
-    pub(crate) fn trim(
+    pub fn trim(
         &self,
         truncated_degree: usize,
     ) -> Result<(CommitKey, OpeningKey), Error> {


### PR DESCRIPTION
Make `PublicParameters::trim` a public method
avaliable for backwards testing compatibility
reasons.

Resolves: #460 