### PR TITLE
Change dense PI construction fn in Composer

### DIFF
--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -90,7 +90,7 @@ impl StandardComposer {
 
     /// Constructs a dense vector of the Public Inputs from the positions and
     /// the sparse vector that contains the values.
-    pub(crate) fn construct_dense_pi_vec(&self) -> Vec<BlsScalar> {
+    pub fn construct_dense_pi_vec(&self) -> Vec<BlsScalar> {
         let mut pi = vec![BlsScalar::zero(); self.n];
         self.public_inputs_sparse_store
             .iter()


### PR DESCRIPTION
There's no other way to enable easy tests for the
users that develop gadgets that is not implement
the Gadget as if it was a Circuit by itself which is
nonsensical.

So this changes the fn visibility to `pub` for
`StandardComposer::construct_dense_pi_vec`.

Resolves: #461