### PR TITLE
Release version 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 12-03-21
+
+### Changed
+
+- Change `PublicParameters::trim` visibility to `pub`. [#460](https://github.com/dusk-network/plonk/issues/460)
+- Change `StandardComposer::construct_dense_pi_vec` visibility to `pub`.[#461](https://github.com/dusk-network/plonk/issues/461)
+
 ## [0.6.0] - 11-03-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-plonk"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>",
            "Luke Pearson <luke@dusk.network>", 
            "CPerezz <carlos@dusk.network>"] 

--- a/src/commitment_scheme/kzg10/srs.rs
+++ b/src/commitment_scheme/kzg10/srs.rs
@@ -143,7 +143,7 @@ impl PublicParameters {
     /// polynomials up to the and including the truncated degree.
     /// Returns an error if the truncated degree is larger than the public
     /// parameters configured degree.
-    pub(crate) fn trim(
+    pub fn trim(
         &self,
         truncated_degree: usize,
     ) -> Result<(CommitKey, OpeningKey), Error> {

--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -90,7 +90,7 @@ impl StandardComposer {
 
     /// Constructs a dense vector of the Public Inputs from the positions and
     /// the sparse vector that contains the values.
-    pub(crate) fn construct_dense_pi_vec(&self) -> Vec<BlsScalar> {
+    pub fn construct_dense_pi_vec(&self) -> Vec<BlsScalar> {
         let mut pi = vec![BlsScalar::zero(); self.n];
         self.public_inputs_sparse_store
             .iter()


### PR DESCRIPTION
Resolves #464 

## [0.6.1] - 12-03-21

### Changed

- Change `PublicParameters::trim` visibility to `pub`. [#460](https://github.com/dusk-network/plonk/issues/460)
- Change `StandardComposer::construct_dense_pi_vec` visibility to `pub`.[#461](https://github.com/dusk-network/plonk/issues/461)