### PR TITLE
Add `VerifierData` struct 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Implement `VerifierData` structure. [#466](https://github.com/dusk-network/plonk/issues/466)
+
 ## [0.6.1] - 12-03-21
 
 ### Changed

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -91,14 +91,13 @@ impl VerifierData {
     }
 
     /// Serializes [`VerifierData`] from a slice of bytes.
-    pub fn from_slice(buf: &[u8]) -> Result<Self, Error> {
-        let mut buffer = &buf[..];
-        let key = VerifierKey::from_reader(&mut buffer)?;
-        let pos_num = u32::from_reader(&mut buffer)? as usize;
+    pub fn from_slice(mut buf: &[u8]) -> Result<Self, Error> {
+        let key = VerifierKey::from_reader(&mut buf)?;
+        let pos_num = u32::from_reader(&mut buf)? as usize;
 
         let mut pi_pos = vec![];
         for _ in 0..pos_num {
-            pi_pos.push(u32::from_reader(&mut buffer)? as usize);
+            pi_pos.push(u32::from_reader(&mut buf)? as usize);
         }
 
         Ok(Self { key, pi_pos })

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -48,8 +48,8 @@ impl From<JubJubAffine> for PublicInputValue {
 /// This structure can be seen as a link between the [`Circuit`] public input
 /// positions and the [`VerifierKey`] that the Verifier needs to use.
 pub struct VerifierData {
-    pub(self) key: VerifierKey,
-    pub(self) pi_pos: Vec<usize>,
+    key: VerifierKey,
+    pi_pos: Vec<usize>,
 }
 
 impl VerifierData {
@@ -293,7 +293,9 @@ mod tests {
         use std::io::Write;
         use tempdir::TempDir;
 
-        let tmp = TempDir::new("plonk-keys-test-full").unwrap().into_path();
+        let tmp = TempDir::new("plonk-keys-test-full")
+            .expect("IO error")
+            .into_path();
         let pp_path = tmp.clone().join("pp_testcirc");
         let pk_path = tmp.clone().join("pk_testcirc");
         let vd_path = tmp.clone().join("vd_testcirc");
@@ -302,10 +304,10 @@ mod tests {
         let pp_p = PublicParameters::setup(1 << 12, &mut rand::thread_rng())?;
         File::create(&pp_path)
             .and_then(|mut f| f.write(pp_p.to_raw_var_bytes().as_slice()))
-            .unwrap();
+            .expect("IO error");
 
         // Read PublicParameters
-        let pp = fs::read(pp_path).unwrap();
+        let pp = fs::read(pp_path).expect("IO error");
         let pp =
             unsafe { PublicParameters::from_slice_unchecked(pp.as_slice()) };
 
@@ -318,10 +320,10 @@ mod tests {
         // Write the keys
         File::create(&pk_path)
             .and_then(|mut f| f.write(pk_p.to_var_bytes().as_slice()))
-            .unwrap();
+            .expect("IO error");
 
         // Read ProverKey
-        let pk = fs::read(pk_path).unwrap();
+        let pk = fs::read(pk_path).expect("IO error");
         let pk = ProverKey::from_slice(pk.as_slice())?;
 
         assert_eq!(pk, pk_p);
@@ -332,8 +334,8 @@ mod tests {
             .and_then(|mut f| {
                 f.write(og_verifier_data.to_var_bytes().as_slice())
             })
-            .unwrap();
-        let vd = fs::read(vd_path).unwrap();
+            .expect("IO error");
+        let vd = fs::read(vd_path).expect("IO error");
         let verif_data = VerifierData::from_slice(vd.as_slice())?;
         assert_eq!(og_verifier_data.key(), verif_data.key());
         assert_eq!(og_verifier_data.pi_pos(), verif_data.pi_pos());


### PR DESCRIPTION
The Public Input positions and the VerifierKey are two items related
logically but not in terms of code. Therefore, it would be nice to also
link them in the code.

By adding `VerifierData` the verifier can always have linked
the pi_positions and the keys of the same circuit linked
with a struct that is serializable.

Resolved: #466