### PR TITLE
Fix import paths for lib components 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix circuit debuggger compilation issues. [#488](https://github.com/dusk-network/plonk/issues/488)
+- Fix import paths for lib components. [#489](https://github.com/dusk-network/plonk/issues/489)
 
 ## [0.6.1] - 12-03-21
 

--- a/src/commitment_scheme/mod.rs
+++ b/src/commitment_scheme/mod.rs
@@ -18,4 +18,6 @@ trait CommitmentScheme {
     type Proof;
 }
 
-pub mod kzg10;
+pub(crate) mod kzg10;
+pub use kzg10::key;
+pub use kzg10::PublicParameters;

--- a/src/constraint_system/mod.rs
+++ b/src/constraint_system/mod.rs
@@ -24,5 +24,6 @@ pub mod logic;
 /// Range gate
 pub mod range;
 
+pub(crate) use variable::WireData;
 pub use composer::StandardComposer;
-pub use variable::{Variable, WireData};
+pub use variable::Variable;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,13 +54,13 @@
 
 mod bit_iterator;
 pub mod circuit;
-mod commitment_scheme;
+pub mod commitment_scheme;
 pub mod constraint_system;
-mod error;
+pub mod error;
 mod fft;
 mod permutation;
 pub mod prelude;
-mod proof_system;
+pub mod proof_system;
 mod transcript;
 mod util;
 

--- a/src/proof_system/mod.rs
+++ b/src/proof_system/mod.rs
@@ -10,12 +10,12 @@ pub(crate) mod linearisation_poly;
 mod preprocess;
 
 /// Represents a PLONK Proof
-pub mod proof;
+pub(crate) mod proof;
 /// Represents a PLONK Prover
-pub mod prover;
+pub(crate) mod prover;
 pub(crate) mod quotient_poly;
 /// Represents a PLONK Verifier
-pub mod verifier;
+pub(crate) mod verifier;
 pub(crate) mod widget;
 
 pub use proof::Proof;


### PR DESCRIPTION
Now all of the lib components that are at some point needed can be
fetched not only from prelude but also from the respective module
paths.

Resolves: #489