### PR TITLE
Update to canonical 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make the crate `no_std`. [#350](https://github.com/dusk-network/plonk/issues/350)
 - Change 'from_projective' method for the implementation of the ::from trait.  [#433] (https://github.com/dusk-network/plonk/issues/433)
+- Update to `canonical-0.6`. [#494](https://github.com/dusk-network/plonk/issues/494)
 
 ## [0.7.0] - 06-04-21
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ itertools = {version = "0.9", default-features = false}
 hashbrown = {version = "0.9", default-features=false, features = ["ahash"]}
 cfg-if = "1.0"
 # Dusk related deps for WASMI serde
-canonical = {version = "0.5", optional = true}
-canonical_derive = {version = "0.5", optional = true}
+canonical = {version = "0.6", optional = true}
+canonical_derive = {version = "0.6", optional = true}
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -12,8 +12,6 @@ use crate::error::Error;
 use crate::proof_system::{Proof, Prover, ProverKey, Verifier, VerifierKey};
 use alloc::vec::Vec;
 #[cfg(feature = "canon")]
-use canonical::Canon;
-#[cfg(feature = "canon")]
 use canonical_derive::Canon;
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Serializable, Write};


### PR DESCRIPTION
Resolves: #494

Do we need to derive `Canon` for any data structure that doesn't derive it now such as `Proof`? So that we don't need to treat it as `Vec<u8>`?

Would be nice to know and address on a follow-up PR.