### PR TITLE
Add getters to avoid trimming for OpeningKey obtention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `alloc` feature to the crate. [#345](https://github.com/dusk-network/plonk/issues/345)
 - Add `rayon` behind `std` feature to boost proving performance.[#512](https://github.com/dusk-network/plonk/issues/512)
 - Add `rayon` behind `std` feature to boost verifying performance.[#514](https://github.com/dusk-network/plonk/issues/514)
+- Add alternative getters for `OpeningKey` & `CommitKey` in `PublicParameters`. [#510](https://github.com/dusk-network/plonk/issues/510)
 
 ### Changed
 
@@ -19,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make the crate `no_std`. [#350](https://github.com/dusk-network/plonk/issues/350)
 - Change 'from_projective' method for the implementation of the ::from trait.  [#433] (https://github.com/dusk-network/plonk/issues/433)
 - Update to `canonical-0.6`. [#494](https://github.com/dusk-network/plonk/issues/494)
+
+### Removed
+
+- Removed trimming step from `Circuit::Verify_proof`. [#510](https://github.com/dusk-network/plonk/issues/510)
 
 ## [0.7.0] - 06-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `alloc` feature to the crate. [#345](https://github.com/dusk-network/plonk/issues/345)
+- Add `rayon` behind `std` feature to boost proving performance.[#512](https://github.com/dusk-network/plonk/issues/512)
+- Add `rayon` behind `std` feature to boost verifying performance.[#514](https://github.com/dusk-network/plonk/issues/514)
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ dusk-bls12_381 = {version = "0.8.0-rc.0", default-features = false, features = [
 dusk-jubjub = {version = "0.10.0-rc.0", default-features = false}
 itertools = {version = "0.9", default-features = false}
 hashbrown = {version = "0.9", default-features=false, features = ["ahash"]}
+rayon = {version = "1.3", optional = true}
 cfg-if = "1.0"
 # Dusk related deps for WASMI serde
 canonical = {version = "0.6", optional = true}
@@ -47,7 +48,8 @@ std = [
     "dusk-jubjub/default",
     "itertools/default",
     "hashbrown/default",
-    "alloc"
+    "alloc",
+    "rayon"
 ]
 alloc = ["dusk-bls12_381/alloc"]
 nightly = []
@@ -55,3 +57,10 @@ trace = []
 trace-print = ["trace"]
 canon = ["dusk-bls12_381/canon", "dusk-jubjub/canon", "canonical", "canonical_derive"]
 
+
+[profile.release]
+debug = false
+panic = 'abort'
+lto = true
+incremental = false
+codegen-units = 1

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -176,15 +176,17 @@ pub fn verify_proof(
     pub_inputs_positions: &[usize],
     transcript_init: &'static [u8],
 ) -> Result<(), Error> {
-    let trim_size = verifier_key.padded_circuit_size();
-    let (_, vk) = pub_params.trim(trim_size)?;
-
     let mut verifier = Verifier::new(transcript_init);
     verifier.verifier_key = Some(*verifier_key);
     verifier.verify(
         proof,
-        &vk,
-        build_pi(pub_inputs_values, pub_inputs_positions, trim_size).as_slice(),
+        pub_params.opening_key(),
+        build_pi(
+            pub_inputs_values,
+            pub_inputs_positions,
+            verifier_key.padded_circuit_size(),
+        )
+        .as_slice(),
     )
 }
 

--- a/src/commitment_scheme/kzg10/srs.rs
+++ b/src/commitment_scheme/kzg10/srs.rs
@@ -26,6 +26,18 @@ pub struct PublicParameters {
 }
 
 impl PublicParameters {
+    /// Returns an untrimmed [`CommitKey`] reference contained in the
+    /// `PublicParameters` instance.
+    pub fn commit_key(&self) -> &CommitKey {
+        &self.commit_key
+    }
+
+    /// Returns an [`OpeningKey`] reference contained in the
+    /// `PublicParameters` instance.
+    pub fn opening_key(&self) -> &OpeningKey {
+        &self.opening_key
+    }
+
     /// Setup generates the public parameters using a random number generator.
     /// This method will in most cases be used for testing and exploration.
     /// In reality, a `Trusted party` or a `Multiparty Computation` will used to
@@ -146,7 +158,7 @@ impl PublicParameters {
         Ok(pp)
     }
 
-    /// Trim truncates the prover key to allow the prover to commit to
+    /// Truncates the prover key to allow the prover to commit to
     /// polynomials up to the and including the truncated degree.
     /// Returns an error if the truncated degree is larger than the public
     /// parameters configured degree.

--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -121,12 +121,15 @@ pub(crate) mod alloc {
         fft::EvaluationDomain,
         proof_system::widget::VerifierKey,
         transcript::TranscriptProtocol,
+        util::batch_inversion,
     };
     use ::alloc::vec::Vec;
     use dusk_bls12_381::{
         multiscalar_mul::msm_variable_base, BlsScalar, G1Affine,
     };
     use merlin::Transcript;
+    #[cfg(feature = "std")]
+    use rayon::prelude::*;
 
     impl Proof {
         /// Performs the verification of a `Proof` returning a boolean result.
@@ -261,9 +264,11 @@ pub(crate) mod alloc {
 
             // Commitment Scheme
             // Now we delegate computation to the commitment scheme by batch
-            // checking two proofs The `AggregateProof`, which is a proof
-            // that all the necessary polynomials evaluated at `z_challenge` are
-            // correct and a `SingleProof` which is proof that the
+            // checking two proofs.
+            //
+            // The `AggregateProof`, which proves that all the necessary
+            // polynomials evaluated at `z_challenge` are
+            // correct and a `Proof` which is proof that the
             // permutation polynomial evaluated at the shifted root of unity is
             // correct
 
@@ -460,21 +465,23 @@ pub(crate) mod alloc {
         z_h_eval * denom.invert().unwrap()
     }
 
-    #[warn(clippy::needless_range_loop)]
     fn compute_barycentric_eval(
         evaluations: &[BlsScalar],
         point: &BlsScalar,
         domain: &EvaluationDomain,
     ) -> BlsScalar {
-        use crate::util::batch_inversion;
-
         let numerator = (point.pow(&[domain.size() as u64, 0, 0, 0])
             - BlsScalar::one())
             * domain.size_inv;
 
         // Indices with non-zero evaluations
-        let non_zero_evaluations: Vec<usize> = (0..evaluations.len())
-            .into_iter()
+        #[cfg(not(feature = "std"))]
+        let range = (0..evaluations.len()).into_iter();
+
+        #[cfg(feature = "std")]
+        let range = (0..evaluations.len()).into_par_iter();
+
+        let non_zero_evaluations: Vec<usize> = range
             .filter(|&i| {
                 let evaluation = &evaluations[i];
                 evaluation != &BlsScalar::zero()
@@ -482,8 +489,14 @@ pub(crate) mod alloc {
             .collect();
 
         // Only compute the denominators with non-zero evaluations
-        let mut denominators: Vec<BlsScalar> = (0..non_zero_evaluations.len())
-            .into_iter()
+        #[cfg(not(feature = "std"))]
+        let range = (0..non_zero_evaluations.len()).into_iter();
+
+        #[cfg(feature = "std")]
+        let range = (0..non_zero_evaluations.len()).into_par_iter();
+
+        let mut denominators: Vec<BlsScalar> = range
+            .clone()
             .map(|i| {
                 // index of non-zero evaluation
                 let index = non_zero_evaluations[i];
@@ -494,8 +507,7 @@ pub(crate) mod alloc {
             .collect();
         batch_inversion(&mut denominators);
 
-        let result: BlsScalar = (0..non_zero_evaluations.len())
-            .into_iter()
+        let result: BlsScalar = range
             .map(|i| {
                 let eval_index = non_zero_evaluations[i];
                 let eval = evaluations[eval_index];

--- a/src/proof_system/quotient_poly.rs
+++ b/src/proof_system/quotient_poly.rs
@@ -11,6 +11,8 @@ use crate::{
 };
 use alloc::vec::Vec;
 use dusk_bls12_381::BlsScalar;
+#[cfg(feature = "std")]
+use rayon::prelude::*;
 
 /// This quotient polynomial can only be used for the standard composer
 /// Each composer will need to implement their own method for computing the
@@ -94,8 +96,13 @@ pub(crate) fn compute(
         (alpha, beta, gamma),
     );
 
-    let quotient: Vec<_> = (0..domain_4n.size())
-        .into_iter()
+    #[cfg(not(feature = "std"))]
+    let range = (0..domain_4n.size()).into_iter();
+
+    #[cfg(feature = "std")]
+    let range = (0..domain_4n.size()).into_par_iter();
+
+    let quotient: Vec<_> = range
         .map(|i| {
             let numerator = t_1[i] + t_2[i];
             let denominator = prover_key.v_h_coset_4n()[i];
@@ -129,8 +136,13 @@ fn compute_circuit_satisfiability_equation(
     let domain_4n = EvaluationDomain::new(4 * domain.size()).unwrap();
     let pi_eval_4n = domain_4n.coset_fft(pi_poly);
 
-    let t: Vec<_> = (0..domain_4n.size())
-        .into_iter()
+    #[cfg(not(feature = "std"))]
+    let range = (0..domain_4n.size()).into_iter();
+
+    #[cfg(feature = "std")]
+    let range = (0..domain_4n.size()).into_par_iter();
+
+    let t: Vec<_> = range
         .map(|i| {
             let wl = &wl_eval_4n[i];
             let wr = &wr_eval_4n[i];
@@ -212,8 +224,13 @@ fn compute_permutation_checks(
         compute_first_lagrange_poly_scaled(domain, alpha.square());
     let l1_alpha_sq_evals = domain_4n.coset_fft(&l1_poly_alpha.coeffs);
 
-    let t: Vec<_> = (0..domain_4n.size())
-        .into_iter()
+    #[cfg(not(feature = "std"))]
+    let range = (0..domain_4n.size()).into_iter();
+
+    #[cfg(feature = "std")]
+    let range = (0..domain_4n.size()).into_par_iter();
+
+    let t: Vec<_> = range
         .map(|i| {
             prover_key.permutation.compute_quotient_i(
                 i,


### PR DESCRIPTION
There are times as for example in the `Circuit::verify_proof` fn
where we just need to retrive the `OpeningKey` from a
`PublicParameters` instance without any need of trimming them
ie. trim the `CommitKey`.

Therefore, this PR adds an alternative way to obtain the `CommitKey`
and the `OpeningKey` and implements the second one in the circuit
module.

Resolves: #510