### PR TITLE
Fix typo and change to match statement

### DIFF
--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -116,29 +116,29 @@ impl CommitKey {
     /// Truncates the commit key to a lower max degree.
     /// Returns an error if the truncated degree is zero or if the truncated
     /// degree is larger than the max degree of the commit key.
-    // FIXME: Use a match maybe?
     pub(crate) fn truncate(
         &self,
         mut truncated_degree: usize,
     ) -> Result<CommitKey, Error> {
-        if truncated_degree == 1 {
-            truncated_degree += 1;
+        match truncated_degree {
+            1 => {
+                truncated_degree += 1;
+                let truncated_powers = Self {
+                    powers_of_g: self.powers_of_g[..=truncated_degree].to_vec(),
+                };
+                Ok(truncated_powers)
+            }
+            // Check that the truncated degree is not zero
+            0 => Err(Error::TruncatedDegreeIsZero),
+            // Check that max degree is less than truncated degree
+            i if i > self.max_degree() => Err(Error::TruncatedDegreeTooLarge),
+            _ => {
+                let truncated_powers = Self {
+                    powers_of_g: self.powers_of_g[..=truncated_degree].to_vec(),
+                };
+                Ok(truncated_powers)
+            }
         }
-        // Check that the truncated degree is not zero
-        if truncated_degree == 0 {
-            return Err(Error::TruncatedDegreeIsZero);
-        }
-
-        // Check that max degree is less than truncated degree
-        if truncated_degree > self.max_degree() {
-            return Err(Error::TruncatedDegreeTooLarge);
-        }
-
-        let truncated_powers = Self {
-            powers_of_g: self.powers_of_g[..=truncated_degree].to_vec(),
-        };
-
-        Ok(truncated_powers)
     }
 
     /// Checks whether the polynomial we are committing to:

--- a/src/commitment_scheme/kzg10/srs.rs
+++ b/src/commitment_scheme/kzg10/srs.rs
@@ -40,8 +40,8 @@ impl PublicParameters {
 
     /// Setup generates the public parameters using a random number generator.
     /// This method will in most cases be used for testing and exploration.
-    /// In reality, a `Trusted party` or a `Multiparty Computation` will used to
-    /// generate the SRS. Returns an error if the configured degree is less
+    /// In reality, a `Trusted party` or a `Multiparty Computation` will be used
+    /// to generate the SRS. Returns an error if the configured degree is less
     /// than one.
     pub fn setup<R: RngCore + CryptoRng>(
         max_degree: usize,


### PR DESCRIPTION
There are two changes.
- I found a typo so I fixed it
- I changed the `if` statement to the `match` statement