### PR TITLE
Fix query poly

### DIFF
--- a/src/proof_system/linearisation_poly.rs
+++ b/src/proof_system/linearisation_poly.rs
@@ -69,10 +69,10 @@ pub struct ProofEvaluations {
     pub h_2_next_eval: BlsScalar,
 
     /// Evaluations of the query polynomial at `z`
-    pub f_long_eval: BlsScalar,
+    pub f_eval: BlsScalar,
 
-    /// Evaluations of the query polynomial at `z`
-    pub f_short_eval: BlsScalar,
+    /// Evaluations of the query polynomial at `z * root of unity`
+    pub f_next_eval: BlsScalar,
 }
 
 impl ProofEvaluations {
@@ -128,8 +128,8 @@ impl ProofEvaluations {
         let (h_1_eval, _) = read_scalar(rest)?;
         let (h_1_next_eval, _) = read_scalar(rest)?;
         let (h_2_next_eval, _) = read_scalar(rest)?;
-        let (f_long_eval, _) = read_scalar(rest)?;
-        let (f_short_eval, _) = read_scalar(rest)?;
+        let (f_eval, _) = read_scalar(rest)?;
+        let (f_next_eval, _) = read_scalar(rest)?;
 
         let proof_evals = ProofEvaluations {
             a_eval,
@@ -153,8 +153,8 @@ impl ProofEvaluations {
             h_1_eval,
             h_1_next_eval,
             h_2_next_eval,
-            f_long_eval,
-            f_short_eval,
+            f_eval,
+            f_next_eval,
         };
         Ok(proof_evals)
     }
@@ -202,8 +202,7 @@ pub fn compute(
     w_4_poly: &Polynomial,
     t_x_poly: &Polynomial,
     z_poly: &Polynomial,
-    f_poly_long: &Polynomial,
-    f_poly_short: &Polynomial,
+    f_poly: &Polynomial,
     h_1_poly: &Polynomial,
     h_2_poly: &Polynomial,
     table_poly: &Polynomial,
@@ -223,8 +222,7 @@ pub fn compute(
     let q_l_eval = prover_key.fixed_base.q_l.0.evaluate(z_challenge);
     let q_r_eval = prover_key.fixed_base.q_r.0.evaluate(z_challenge);
     let q_lookup_eval = prover_key.lookup.q_lookup.0.evaluate(z_challenge);
-    let f_long_eval = f_poly_long.evaluate(z_challenge);
-    let f_short_eval = f_poly_short.evaluate(z_challenge);
+    let f_eval = f_poly.evaluate(z_challenge);
     let h_1_eval = h_1_poly.evaluate(z_challenge);
     let t_eval = table_poly.evaluate(z_challenge);
 
@@ -233,6 +231,7 @@ pub fn compute(
     let d_next_eval = w_4_poly.evaluate(&(z_challenge * domain.group_gen));
     let perm_eval = z_poly.evaluate(&(z_challenge * domain.group_gen));
     let lookup_perm_eval = p_poly.evaluate(&(z_challenge * domain.group_gen));
+    let f_next_eval = f_poly.evaluate(&(z_challenge* domain.group_gen));
     let h_1_next_eval = h_1_poly.evaluate(&(z_challenge * domain.group_gen));
     let h_2_next_eval = h_2_poly.evaluate(&(z_challenge * domain.group_gen));
     let t_next_eval = table_poly.evaluate(&(z_challenge * domain.group_gen));
@@ -259,8 +258,8 @@ pub fn compute(
         &b_next_eval,
         &d_next_eval,
         &q_arith_eval,
-        &f_long_eval,
-        &f_short_eval,
+        &f_eval,
+        &f_next_eval,
         &t_eval,
         &t_next_eval,
         &h_1_eval,
@@ -319,8 +318,8 @@ pub fn compute(
                 h_1_eval,
                 h_1_next_eval,
                 h_2_next_eval,
-                f_long_eval,
-                f_short_eval,
+                f_eval,
+                f_next_eval,
             },
             quot_eval,
         },
@@ -344,8 +343,8 @@ fn compute_circuit_satisfiability(
     b_next_eval: &BlsScalar,
     d_next_eval: &BlsScalar,
     q_arith_eval: &BlsScalar,
-    f_long_eval: &BlsScalar,
-    f_short_eval: &BlsScalar,
+    f_eval: &BlsScalar,
+    f_next_eval: &BlsScalar,
     t_eval: &BlsScalar,
     t_next_eval: &BlsScalar,
     h_1_eval: &BlsScalar,
@@ -417,8 +416,8 @@ fn compute_circuit_satisfiability(
 
     let f = prover_key.lookup.compute_linearisation(
         omega_inv,
-        f_long_eval,
-        f_short_eval,
+        f_eval,
+        f_next_eval,
         t_eval,
         t_next_eval,
         h_1_eval,

--- a/src/proof_system/linearisation_poly.rs
+++ b/src/proof_system/linearisation_poly.rs
@@ -231,7 +231,7 @@ pub fn compute(
     let d_next_eval = w_4_poly.evaluate(&(z_challenge * domain.group_gen));
     let perm_eval = z_poly.evaluate(&(z_challenge * domain.group_gen));
     let lookup_perm_eval = p_poly.evaluate(&(z_challenge * domain.group_gen));
-    let f_next_eval = f_poly.evaluate(&(z_challenge* domain.group_gen));
+    let f_next_eval = f_poly.evaluate(&(z_challenge * domain.group_gen));
     let h_1_next_eval = h_1_poly.evaluate(&(z_challenge * domain.group_gen));
     let h_2_next_eval = h_2_poly.evaluate(&(z_challenge * domain.group_gen));
     let t_next_eval = table_poly.evaluate(&(z_challenge * domain.group_gen));

--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -377,7 +377,7 @@ impl Proof {
             self.evaluations.out_sigma_eval,
             verifier_key.permutation.out_sigma,
         ));
-        aggregate_proof.add_part((self.evaluations.f_next_eval, self.f_comm));
+        aggregate_proof.add_part((self.evaluations.f_eval, self.f_comm));
         aggregate_proof.add_part((self.evaluations.h_1_eval, self.h_1_comm));
         // Flatten proof with opening challenge
         let flattened_proof_a = aggregate_proof.flatten(transcript);
@@ -391,6 +391,7 @@ impl Proof {
         shifted_aggregate_proof.add_part((self.evaluations.h_1_next_eval, self.h_1_comm));
         shifted_aggregate_proof.add_part((self.evaluations.h_2_next_eval, self.h_2_comm));
         shifted_aggregate_proof.add_part((self.evaluations.lookup_perm_eval, self.p_comm));
+        shifted_aggregate_proof.add_part((self.evaluations.f_next_eval, self.f_comm));
         let flattened_proof_b = shifted_aggregate_proof.flatten(transcript);
         // Add commitment to openings to transcript
         transcript.append_commitment(b"w_z", &self.w_z_comm);

--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -377,7 +377,7 @@ impl Proof {
             self.evaluations.out_sigma_eval,
             verifier_key.permutation.out_sigma,
         ));
-        aggregate_proof.add_part((self.evaluations.f_short_eval, self.f_comm));
+        aggregate_proof.add_part((self.evaluations.f_next_eval, self.f_comm));
         aggregate_proof.add_part((self.evaluations.h_1_eval, self.h_1_comm));
         // Flatten proof with opening challenge
         let flattened_proof_a = aggregate_proof.flatten(transcript);

--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -478,7 +478,10 @@ impl Proof {
             + (self.evaluations.b_eval * zeta)
             + (self.evaluations.c_eval * zeta_sq)
             + (self.evaluations.d_eval * zeta_cu);
-        let d = (BlsScalar::one() - l1_eval) *self.evaluations.q_lookup_eval * d_0 * lookup_sep_challenge;
+        let d = (BlsScalar::one() - l1_eval)
+            * self.evaluations.q_lookup_eval
+            * d_0
+            * lookup_sep_challenge;
 
         // l_1(z) * alpha_1^2
         let e = l1_eval * l_sep_2;

--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -477,7 +477,7 @@ impl Proof {
             + (self.evaluations.b_eval * zeta)
             + (self.evaluations.c_eval * zeta_sq)
             + (self.evaluations.d_eval * zeta_cu);
-        let d = self.evaluations.q_lookup_eval * d_0 * lookup_sep_challenge;
+        let d = (BlsScalar::one() - l1_eval) *self.evaluations.q_lookup_eval * d_0 * lookup_sep_challenge;
 
         // l_1(z) * alpha_1^2
         let e = l1_eval * l_sep_2;

--- a/src/proof_system/prover.rs
+++ b/src/proof_system/prover.rs
@@ -201,18 +201,19 @@ impl Prover {
             .collect::<Vec<BlsScalar>>();
 
         // Compress all wires into a single vector
-        // Long version is checked against wire polys later and needs equal them in length (n)
-        let compressed_f_long = MultiSet::compress_four_arity(
+        // This is checked against wire polys later and needs equal them in length (n)
+        // The first element is set to 0 and will be ignored later in the compression check
+        // The n-1 remaining elements are used to create the lookup permutation poly
+        let compressed_f = MultiSet::compress_four_arity(
             [
-                &MultiSet::from(&f_1_scalar[..]),
-                &MultiSet::from(&f_2_scalar[..]),
-                &MultiSet::from(&f_3_scalar[..]),
-                &MultiSet::from(&f_4_scalar[..]),
+                &MultiSet::from([&[BlsScalar::zero()], &f_1_scalar[1..]].concat().as_slice()),
+                &MultiSet::from([&[BlsScalar::zero()], &f_1_scalar[1..]].concat().as_slice()),
+                &MultiSet::from([&[BlsScalar::zero()], &f_1_scalar[1..]].concat().as_slice()),
+                &MultiSet::from([&[BlsScalar::zero()], &f_1_scalar[1..]].concat().as_slice()),
             ],
             zeta,
         );
 
-        // Short version skips the first element and is used in plookup permutation checks. Ought to be length n-1.
         let compressed_f_short = MultiSet::compress_four_arity(
             [
                 &MultiSet::from(&f_1_scalar[1..]),
@@ -223,19 +224,15 @@ impl Prover {
             zeta,
         );
 
-        // Compute long query poly
-        let f_poly_long =
-            Polynomial::from_coefficients_vec(domain.ifft(&compressed_f_long.0.as_slice()));
-
-        // Compute short query poly
-        let f_poly_short =
-            Polynomial::from_coefficients_vec(domain.ifft(&compressed_f_short.0.as_slice()));
+        // Compute query poly
+        let f_poly =
+            Polynomial::from_coefficients_vec(domain.ifft(&compressed_f.0.as_slice()));
 
         // Commit to query polynomial
-        let f_poly_short_commit = commit_key.commit(&f_poly_short)?;
+        let f_poly_commit = commit_key.commit(&f_poly)?;
 
         // Add f_poly commitment to transcript
-        transcript.append_commitment(b"f", &f_poly_short_commit);
+        transcript.append_commitment(b"f", &f_poly_commit);
 
         // 2. Compute permutation polynomial
         //
@@ -274,6 +271,7 @@ impl Prover {
         let z_challenge = transcript.challenge_scalar(b"z_challenge");
 
         // Compute s, as the sorted and concatenated version of f and t
+        // Using the "short" version leaves off the leading zero of the multiset
         let s = compressed_t_multiset
             .sorted_concat(&compressed_f_short)
             .unwrap();
@@ -293,7 +291,7 @@ impl Prover {
         transcript.append_commitment(b"h1", &h_1_poly_commit);
         transcript.append_commitment(b"h2", &h_2_poly_commit);
 
-        // Compute lookup permutation poly
+        // Compute lookup permutation poly using short version of query list
         let p_poly =
             Polynomial::from_coefficients_slice(&self.cs.perm.compute_lookup_permutation_poly(
                 &domain,
@@ -330,8 +328,7 @@ impl Prover {
             &z_poly,
             &p_poly,
             (&w_l_poly, &w_r_poly, &w_o_poly, &w_4_poly),
-            &f_poly_long,
-            &f_poly_short,
+            &f_poly,
             &table_poly,
             &h_1_poly,
             &h_2_poly,
@@ -391,8 +388,7 @@ impl Prover {
             &w_4_poly,
             &t_poly,
             &z_poly,
-            &f_poly_long,
-            &f_poly_short,
+            &f_poly,
             &h_1_poly,
             &h_2_poly,
             &table_poly,
@@ -446,7 +442,7 @@ impl Prover {
                 prover_key.permutation.left_sigma.0.clone(),
                 prover_key.permutation.right_sigma.0.clone(),
                 prover_key.permutation.out_sigma.0.clone(),
-                f_poly_short,
+                f_poly,
                 h_1_poly.clone(),
             ],
             &z_challenge,
@@ -471,7 +467,7 @@ impl Prover {
             c_comm: w_o_poly_commit,
             d_comm: w_4_poly_commit,
 
-            f_comm: f_poly_short_commit,
+            f_comm: f_poly_commit,
 
             h_1_comm: h_1_poly_commit,
             h_2_comm: h_2_poly_commit,

--- a/src/proof_system/prover.rs
+++ b/src/proof_system/prover.rs
@@ -207,9 +207,9 @@ impl Prover {
         let compressed_f = MultiSet::compress_four_arity(
             [
                 &MultiSet::from([&[BlsScalar::zero()], &f_1_scalar[1..]].concat().as_slice()),
-                &MultiSet::from([&[BlsScalar::zero()], &f_1_scalar[1..]].concat().as_slice()),
-                &MultiSet::from([&[BlsScalar::zero()], &f_1_scalar[1..]].concat().as_slice()),
-                &MultiSet::from([&[BlsScalar::zero()], &f_1_scalar[1..]].concat().as_slice()),
+                &MultiSet::from([&[BlsScalar::zero()], &f_2_scalar[1..]].concat().as_slice()),
+                &MultiSet::from([&[BlsScalar::zero()], &f_3_scalar[1..]].concat().as_slice()),
+                &MultiSet::from([&[BlsScalar::zero()], &f_4_scalar[1..]].concat().as_slice()),
             ],
             zeta,
         );

--- a/src/proof_system/prover.rs
+++ b/src/proof_system/prover.rs
@@ -442,7 +442,7 @@ impl Prover {
                 prover_key.permutation.left_sigma.0.clone(),
                 prover_key.permutation.right_sigma.0.clone(),
                 prover_key.permutation.out_sigma.0.clone(),
-                f_poly,
+                f_poly.clone(),
                 h_1_poly.clone(),
             ],
             &z_challenge,
@@ -453,7 +453,7 @@ impl Prover {
         // Compute aggregate witness to polynomials evaluated at the shifted evaluation challenge
         let shifted_aggregate_witness = commit_key.compute_aggregate_witness(
             &[
-                z_poly, w_l_poly, w_r_poly, w_4_poly, h_1_poly, h_2_poly, p_poly,
+                z_poly, w_l_poly, w_r_poly, w_4_poly, h_1_poly, h_2_poly, p_poly, f_poly,
             ],
             &(z_challenge * domain.group_gen),
             &mut transcript,

--- a/src/proof_system/prover.rs
+++ b/src/proof_system/prover.rs
@@ -225,8 +225,7 @@ impl Prover {
         );
 
         // Compute query poly
-        let f_poly =
-            Polynomial::from_coefficients_vec(domain.ifft(&compressed_f.0.as_slice()));
+        let f_poly = Polynomial::from_coefficients_vec(domain.ifft(&compressed_f.0.as_slice()));
 
         // Commit to query polynomial
         let f_poly_commit = commit_key.commit(&f_poly)?;

--- a/src/proof_system/quotient_poly.rs
+++ b/src/proof_system/quotient_poly.rs
@@ -20,8 +20,7 @@ pub(crate) fn compute(
     z_poly: &Polynomial,
     p_poly: &Polynomial,
     (w_l_poly, w_r_poly, w_o_poly, w_4_poly): (&Polynomial, &Polynomial, &Polynomial, &Polynomial),
-    f_poly_long: &Polynomial,
-    f_poly_short: &Polynomial,
+    f_poly: &Polynomial,
     t_poly: &Polynomial,
     h_1_poly: &Polynomial,
     h_2_poly: &Polynomial,
@@ -75,8 +74,7 @@ pub(crate) fn compute(
     t_eval_4n.push(t_eval_4n[3]);
 
     // Compute f(x)
-    let f_short_eval_4n = domain_4n.coset_fft(&f_poly_short);
-    let f_long_eval_4n = domain_4n.coset_fft(&f_poly_long);
+    let f_eval_4n = domain_4n.coset_fft(&f_poly);
 
     // Compute 4n eval of h_1
     let mut h_1_eval_4n = domain_4n.coset_fft(&h_1_poly);
@@ -125,8 +123,7 @@ pub(crate) fn compute(
         public_inputs_poly,
         zeta,
         (delta, epsilon),
-        &f_long_eval_4n,
-        &f_short_eval_4n,
+        &f_eval_4n,
         &p_eval_4n,
         &t_eval_4n,
         &h_1_eval_4n,
@@ -175,8 +172,7 @@ fn compute_circuit_satisfiability_equation(
     pi_poly: &Polynomial,
     zeta: &BlsScalar,
     (delta, epsilon): (&BlsScalar, &BlsScalar),
-    f_long_eval_4n: &[BlsScalar],
-    f_short_eval_4n: &[BlsScalar],
+    f_eval_4n: &[BlsScalar],
     p_eval_4n: &[BlsScalar],
     t_eval_4n: &[BlsScalar],
     h_1_eval_4n: &[BlsScalar],
@@ -210,8 +206,8 @@ fn compute_circuit_satisfiability_equation(
             let pi = &public_eval_4n[i];
             let p = &p_eval_4n[i];
             let p_next = &p_eval_4n[i + 4];
-            let f_long_i = &f_long_eval_4n[i];
-            let f_short_i = &f_short_eval_4n[i];
+            let fi = &f_eval_4n[i];
+            let fi_next = &f_eval_4n[i + 4];
             let ti = &t_eval_4n[i];
             let ti_next = &t_eval_4n[i + 4];
             let h1 = &h_1_eval_4n[i];
@@ -274,8 +270,8 @@ fn compute_circuit_satisfiability_equation(
                 &wr,
                 &wo,
                 &w4,
-                &f_long_i,
-                &f_short_i,
+                &fi,
+                &fi_next,
                 &p,
                 &p_next,
                 &ti,

--- a/src/proof_system/quotient_poly.rs
+++ b/src/proof_system/quotient_poly.rs
@@ -74,7 +74,11 @@ pub(crate) fn compute(
     t_eval_4n.push(t_eval_4n[3]);
 
     // Compute f(x)
-    let f_eval_4n = domain_4n.coset_fft(&f_poly);
+    let mut f_eval_4n = domain_4n.coset_fft(&f_poly);
+    f_eval_4n.push(f_eval_4n[0]);
+    f_eval_4n.push(f_eval_4n[1]);
+    f_eval_4n.push(f_eval_4n[2]);
+    f_eval_4n.push(f_eval_4n[3]);
 
     // Compute 4n eval of h_1
     let mut h_1_eval_4n = domain_4n.coset_fft(&h_1_poly);

--- a/src/proof_system/widget/lookup/proverkey.rs
+++ b/src/proof_system/widget/lookup/proverkey.rs
@@ -58,7 +58,10 @@ impl ProverKey {
             let q_lookup_i = self.q_lookup.1[index];
             let compressed_tuple = compress(*w_l_i, *w_r_i, *w_o_i, *w_4_i, *zeta);
 
-            (BlsScalar::one() - l_first_i) *q_lookup_i * (compressed_tuple - f_i) * lookup_separation_challenge
+            (BlsScalar::one() - l_first_i)
+                * q_lookup_i
+                * (compressed_tuple - f_i)
+                * lookup_separation_challenge
         };
 
         // L0(X) * (p(X) − 1) * α_1^2
@@ -119,7 +122,10 @@ impl ProverKey {
         let epsilon_one_plus_delta = epsilon * one_plus_delta;
 
         // - q_lookup(X) * f_eval * lookup_separation_challenge
-        let a = { &self.q_lookup.0 * &(&(l1_eval - BlsScalar::one()) * &(f_eval * lookup_separation_challenge)) };
+        let a = {
+            &self.q_lookup.0
+                * &(&(l1_eval - BlsScalar::one()) * &(f_eval * lookup_separation_challenge))
+        };
 
         // p(X) * L0(z) * α_1^2
         let b = { p_poly * &(l1_eval * l_sep_2) };

--- a/src/proof_system/widget/lookup/verifierkey.rs
+++ b/src/proof_system/widget/lookup/verifierkey.rs
@@ -36,8 +36,8 @@ impl VerifierKey {
         let l_sep_4 = lookup_separation_challenge * l_sep_3;
         let l_sep_5 = lookup_separation_challenge * l_sep_4;
 
-        // - f_eval * q_lookup * alpha_1
-        let a = -evaluations.f_long_eval * lookup_separation_challenge;
+        // (L_n(z) - 1) * f_eval * q_lookup * alpha_1
+        let a = (l1_eval - BlsScalar::one()) * evaluations.f_eval * lookup_separation_challenge;
         scalars.push(a);
         points.push(self.q_lookup.0);
 
@@ -61,13 +61,13 @@ impl VerifierKey {
         scalars.push(c);
         points.push(h_2_comm);
 
-        // (z - omega_inv)(1 + delta)(e + f_eval)(epsilon(1 + delta) + t_eval + (delta * t_next_eval) * alpha_1^3 + l_1(z) * alpha_1^2 + l_n(z) * alpha_1^5)
+        // (z - omega_inv)(1 + delta)(e + f_next_eval)(epsilon(1 + delta) + t_eval + (delta * t_next_eval) * alpha_1^3 + l_1(z) * alpha_1^2 + l_n(z) * alpha_1^5)
         let d = {
             let d_0 = z_challenge - omega_inv;
 
             let d_1 = BlsScalar::one() + delta;
 
-            let d_2 = epsilon + evaluations.f_short_eval;
+            let d_2 = epsilon + evaluations.f_next_eval;
 
             let d_3 = (epsilon * d_1 + t_eval + (delta * t_next_eval)) * l_sep_3;
 


### PR DESCRIPTION
The previous system used two slightly different versions of the query polynomial (`f` in the plookup paper) at different places in the proving system to solve a discrepancy found in the original paper. These were called `f_short` and `f_long`. However there was nothing to enforce that these polynomials were actually related.

Since `f_short` is essentially a one-element shift of `f_long`, except for one difference in the first element, the previous checks that enforce relationships could be easily modified. The modified checks now use `f` and `f_next` in place of `f_long` and `f_short` respectively. Then the `f` poly was added to the shifted aggregate witness so that `f` is checked against `f_next` in the same way other shifted polynomials are checked.