### PR TITLE
Make alternating

### DIFF
--- a/src/plookup/multiset.rs
+++ b/src/plookup/multiset.rs
@@ -116,6 +116,23 @@ impl MultiSet {
         (first_half, second_half)
     }
 
+    /// Splits a multiset into alternating halves of the same length
+    /// as specified in the Plonkup paper. A multiset must have even
+    /// cardinality to be split in this manner.
+    pub fn halve_alternating(&self) -> (MultiSet, MultiSet) {
+        let mut evens = vec![];
+        let mut odds = vec![];
+        for i in 0..self.len() {
+            if i % 2 == 0 {
+                evens.push(self.0[i]);
+            } else {
+                odds.push(self.0[i]);
+            }
+        }
+
+        (MultiSet(evens), MultiSet(odds))
+    }
+
     /// Treats each element in the multiset as evaluation points
     /// Computes IFFT of the set of evaluation points
     /// and returns the coefficients as a Polynomial data structure

--- a/src/proof_system/prover.rs
+++ b/src/proof_system/prover.rs
@@ -202,7 +202,7 @@ impl Prover {
 
         // Compress all wires into a single vector
         // Long version is checked against wire polys later and needs equal them in length (n)
-        let compressed_f_long = MultiSet::compress_four_arity(
+        let compressed_f_multiset = MultiSet::compress_four_arity(
             [
                 &MultiSet::from(&f_1_scalar[..]),
                 &MultiSet::from(&f_2_scalar[..]),
@@ -212,30 +212,15 @@ impl Prover {
             zeta,
         );
 
-        // Short version skips the first element and is used in plookup permutation checks. Ought to be length n-1.
-        let compressed_f_short = MultiSet::compress_four_arity(
-            [
-                &MultiSet::from(&f_1_scalar[1..]),
-                &MultiSet::from(&f_2_scalar[1..]),
-                &MultiSet::from(&f_3_scalar[1..]),
-                &MultiSet::from(&f_4_scalar[1..]),
-            ],
-            zeta,
-        );
-
         // Compute long query poly
-        let f_poly_long =
-            Polynomial::from_coefficients_vec(domain.ifft(&compressed_f_long.0.as_slice()));
-
-        // Compute short query poly
-        let f_poly_short =
-            Polynomial::from_coefficients_vec(domain.ifft(&compressed_f_short.0.as_slice()));
+        let f_poly =
+            Polynomial::from_coefficients_vec(domain.ifft(&compressed_f_multiset.0.as_slice()));
 
         // Commit to query polynomial
-        let f_poly_short_commit = commit_key.commit(&f_poly_short)?;
+        let f_poly_commit = commit_key.commit(&f_poly)?;
 
         // Add f_poly commitment to transcript
-        transcript.append_commitment(b"f", &f_poly_short_commit);
+        transcript.append_commitment(b"f", &f_poly_commit);
 
         // 2. Compute permutation polynomial
         //
@@ -275,11 +260,11 @@ impl Prover {
 
         // Compute s, as the sorted and concatenated version of f and t
         let s = compressed_t_multiset
-            .sorted_concat(&compressed_f_short)
+            .sorted_concat(&compressed_f_multiset)
             .unwrap();
 
         // Compute first and second halves of s, as h_1 and h_2
-        let (h_1, h_2) = s.halve();
+        let (h_1, h_2) = s.halve_alternating();
 
         // Compute h polys
         let h_1_poly = Polynomial::from_coefficients_vec(domain.ifft(&h_1.0.as_slice()));
@@ -297,7 +282,7 @@ impl Prover {
         let p_poly =
             Polynomial::from_coefficients_slice(&self.cs.perm.compute_lookup_permutation_poly(
                 &domain,
-                &compressed_f_short.0,
+                &compressed_f_multiset.0,
                 &compressed_t_multiset.0,
                 &h_1.0,
                 &h_2.0,
@@ -330,8 +315,7 @@ impl Prover {
             &z_poly,
             &p_poly,
             (&w_l_poly, &w_r_poly, &w_o_poly, &w_4_poly),
-            &f_poly_long,
-            &f_poly_short,
+            &f_poly,
             &table_poly,
             &h_1_poly,
             &h_2_poly,
@@ -391,8 +375,7 @@ impl Prover {
             &w_4_poly,
             &t_poly,
             &z_poly,
-            &f_poly_long,
-            &f_poly_short,
+            &f_poly,
             &h_1_poly,
             &h_2_poly,
             &table_poly,
@@ -446,7 +429,7 @@ impl Prover {
                 prover_key.permutation.left_sigma.0.clone(),
                 prover_key.permutation.right_sigma.0.clone(),
                 prover_key.permutation.out_sigma.0.clone(),
-                f_poly_short,
+                f_poly,
                 h_1_poly.clone(),
             ],
             &z_challenge,
@@ -471,7 +454,7 @@ impl Prover {
             c_comm: w_o_poly_commit,
             d_comm: w_4_poly_commit,
 
-            f_comm: f_poly_short_commit,
+            f_comm: f_poly_commit,
 
             h_1_comm: h_1_poly_commit,
             h_2_comm: h_2_poly_commit,

--- a/src/proof_system/prover.rs
+++ b/src/proof_system/prover.rs
@@ -402,7 +402,7 @@ impl Prover {
         transcript.append_scalar(b"lookup_perm_eval", &evaluations.proof.lookup_perm_eval);
         transcript.append_scalar(b"h_1_eval", &evaluations.proof.h_1_eval);
         transcript.append_scalar(b"h_1_next_eval", &evaluations.proof.h_1_next_eval);
-        transcript.append_scalar(b"h_2_next_eval", &evaluations.proof.h_2_next_eval);
+        transcript.append_scalar(b"h_2_eval", &evaluations.proof.h_2_eval);
         transcript.append_scalar(b"t_eval", &evaluations.quot_eval);
         transcript.append_scalar(b"r_eval", &evaluations.proof.lin_poly_eval);
 
@@ -431,6 +431,7 @@ impl Prover {
                 prover_key.permutation.out_sigma.0.clone(),
                 f_poly,
                 h_1_poly.clone(),
+                h_2_poly,
             ],
             &z_challenge,
             &mut transcript,
@@ -439,9 +440,7 @@ impl Prover {
 
         // Compute aggregate witness to polynomials evaluated at the shifted evaluation challenge
         let shifted_aggregate_witness = commit_key.compute_aggregate_witness(
-            &[
-                z_poly, w_l_poly, w_r_poly, w_4_poly, h_1_poly, h_2_poly, p_poly,
-            ],
+            &[z_poly, w_l_poly, w_r_poly, w_4_poly, h_1_poly, p_poly],
             &(z_challenge * domain.group_gen),
             &mut transcript,
         );

--- a/src/proof_system/widget/lookup/proverkey.rs
+++ b/src/proof_system/widget/lookup/proverkey.rs
@@ -19,15 +19,12 @@ impl ProverKey {
     pub(crate) fn compute_quotient_i(
         &self,
         index: usize,
-        x_i: &BlsScalar,
-        omega_inv: &BlsScalar,
         lookup_separation_challenge: &BlsScalar,
         w_l_i: &BlsScalar,
         w_r_i: &BlsScalar,
         w_o_i: &BlsScalar,
         w_4_i: &BlsScalar,
-        f_long_i: &BlsScalar,
-        f_short_i: &BlsScalar,
+        f_i: &BlsScalar,
         p_i: &BlsScalar,
         p_i_next: &BlsScalar,
         t_i: &BlsScalar,
@@ -35,18 +32,13 @@ impl ProverKey {
         h_1_i: &BlsScalar,
         h_1_i_next: &BlsScalar,
         h_2_i: &BlsScalar,
-        h_2_i_next: &BlsScalar,
         l_first_i: &BlsScalar,
-        l_last_i: &BlsScalar,
         (delta, epsilon): (&BlsScalar, &BlsScalar),
         zeta: &BlsScalar,
     ) -> BlsScalar {
         let l_sep_2 = lookup_separation_challenge.square();
         let l_sep_3 = l_sep_2 * lookup_separation_challenge;
-        let l_sep_4 = l_sep_3 * lookup_separation_challenge;
-        let l_sep_5 = l_sep_4 * lookup_separation_challenge;
 
-        let x_minus_omega_inv = x_i - omega_inv;
         let one_plus_delta = delta + BlsScalar::one();
         let epsilon_one_plus_delta = epsilon * one_plus_delta;
 
@@ -55,99 +47,77 @@ impl ProverKey {
             let q_lookup_i = self.q_lookup.1[index];
             let compressed_tuple = compress(*w_l_i, *w_r_i, *w_o_i, *w_4_i, *zeta);
 
-            q_lookup_i * (compressed_tuple - f_long_i) * lookup_separation_challenge
+            q_lookup_i * (compressed_tuple - f_i) * lookup_separation_challenge
         };
 
         // L0(X) * (p(X) − 1) * α_1^2
         let b = { l_first_i * (p_i - BlsScalar::one()) * l_sep_2 };
 
-        // (X−omega^(-1)) * p(X) * (1+δ) * (ε+f(X)) * (ε*(1+δ) + t(X) + δt(Xω)) * α_1^3
+        // p(X) * (1+δ) * (ε+f(X)) * (ε*(1+δ) + t(X) + δt(Xω)) * α_1^3
         let c = {
-            let c_1 = epsilon + f_short_i;
+            let c_1 = epsilon + f_i;
             let c_2 = epsilon_one_plus_delta + t_i + delta * t_i_next;
 
-            x_minus_omega_inv * p_i * one_plus_delta * c_1 * c_2 * l_sep_3
+            p_i * one_plus_delta * c_1 * c_2 * l_sep_3
         };
 
-        // −(X − omega^(-1)) * p(Xω) * (ε*(1+δ) + h1(X) + δ*h1(Xω)) * (ε*(1+δ) + h2(X) + δ*h2(Xω)) * α_1^3
+        // − p(Xω) * (ε*(1+δ) + h1(X) + δ*h2(X)) * (ε*(1+δ) + h2(X) + δ*h1(Xω)) * α_1^3
         let d = {
-            let d_1 = epsilon_one_plus_delta + h_1_i + delta * h_1_i_next;
-            let d_2 = epsilon_one_plus_delta + h_2_i + delta * h_2_i_next;
+            let d_1 = epsilon_one_plus_delta + h_1_i + delta * h_2_i;
+            let d_2 = epsilon_one_plus_delta + h_2_i + delta * h_1_i_next;
 
-            -x_minus_omega_inv * p_i_next * d_1 * d_2 * l_sep_3
+            - p_i_next * d_1 * d_2 * l_sep_3
         };
 
-        // L_n-1(X) * (h1(X) − h2(Xω)) * α_1^4
-        let e = { l_last_i * (h_1_i - h_2_i_next) * l_sep_4 };
-
-        // L_n-1(X) * (p(X) − 1) * α_1^5
-        let f = { l_last_i * (p_i - BlsScalar::one()) * l_sep_5 };
-
-        a + b + c + d + e + f
+        a + b + c + d
     }
 
     /// Compute linearisation for lookup gates
     pub(crate) fn compute_linearisation(
         &self,
-        omega_inv: &BlsScalar,
-        f_long_eval: &BlsScalar,
-        f_short_eval: &BlsScalar,
+        f_eval: &BlsScalar,
         t_eval: &BlsScalar,
         t_next_eval: &BlsScalar,
         h_1_eval: &BlsScalar,
-        h_1_next_eval: &BlsScalar,
+        h_2_eval: &BlsScalar,
         p_next_eval: &BlsScalar,
         l1_eval: &BlsScalar,
-        ln_eval: &BlsScalar,
         p_poly: &Polynomial,
-        h_1_poly: &Polynomial,
         h_2_poly: &Polynomial,
         (delta, epsilon): (&BlsScalar, &BlsScalar),
-        z_challenge: &BlsScalar,
         lookup_separation_challenge: &BlsScalar,
     ) -> Polynomial {
         let l_sep_2 = lookup_separation_challenge.square();
         let l_sep_3 = l_sep_2 * lookup_separation_challenge;
-        let l_sep_4 = l_sep_3 * lookup_separation_challenge;
-        let l_sep_5 = l_sep_4 * lookup_separation_challenge;
 
-        let z_minus_omega_inv = z_challenge - omega_inv;
         let one_plus_delta = delta + BlsScalar::one();
         let epsilon_one_plus_delta = epsilon * one_plus_delta;
 
         // - q_lookup(X) * f_eval * lookup_separation_challenge
-        let a = { &self.q_lookup.0 * &(-f_long_eval * lookup_separation_challenge) };
+        let a = { &self.q_lookup.0 * &(-f_eval * lookup_separation_challenge) };
 
         // p(X) * L0(z) * α_1^2
         let b = { p_poly * &(l1_eval * l_sep_2) };
 
-        // (z − omega^(-1)) * p(X) * (1 + δ) * (ε + f_bar) * (ε(1+δ) + t_bar + δ*tω_bar) * α_1^3
+        // p(X) * (1 + δ) * (ε + f_bar) * (ε(1+δ) + t_bar + δ*tω_bar) * α_1^3
         let c = {
-            let c_0 = epsilon + f_short_eval;
+            let c_0 = epsilon + f_eval;
             let c_1 = epsilon_one_plus_delta + t_eval + delta * t_next_eval;
 
-            p_poly * &(z_minus_omega_inv * one_plus_delta * c_0 * c_1 * l_sep_3)
+            p_poly * &(one_plus_delta * c_0 * c_1 * l_sep_3)
         };
 
-        // − (z − omega^(-1)) * pω_bar * (ε(1+δ) + h1_bar + δh1ω_bar) * h2(X) * α_1^3
+        // − pω_bar * (ε(1+δ) + h1_bar + δh2_bar) * h2(X) * α_1^3
         let d = {
-            let d_0 = epsilon_one_plus_delta + h_1_eval + delta * h_1_next_eval;
+            let d_0 = epsilon_one_plus_delta + h_1_eval + delta * h_2_eval;
 
-            h_2_poly * &(-z_minus_omega_inv * p_next_eval * d_0 * l_sep_3)
+            h_2_poly * &(-p_next_eval * d_0 * l_sep_3)
         };
-
-        // L_n−1(z) * h1(X) * α_1^4
-        let e = { h_1_poly * &(ln_eval * l_sep_4) };
-
-        // L_n−1(z) * p(X) * α_1^5
-        let f = { p_poly * &(ln_eval * l_sep_5) };
 
         let mut r = a;
         r += &b;
         r += &c;
         r += &d;
-        r += &e;
-        r += &f;
 
         r
     }

--- a/src/proof_system/widget/lookup/proverkey.rs
+++ b/src/proof_system/widget/lookup/proverkey.rs
@@ -66,7 +66,7 @@ impl ProverKey {
             let d_1 = epsilon_one_plus_delta + h_1_i + delta * h_2_i;
             let d_2 = epsilon_one_plus_delta + h_2_i + delta * h_1_i_next;
 
-            - p_i_next * d_1 * d_2 * l_sep_3
+            -p_i_next * d_1 * d_2 * l_sep_3
         };
 
         a + b + c + d

--- a/src/proof_system/widget/lookup/verifierkey.rs
+++ b/src/proof_system/widget/lookup/verifierkey.rs
@@ -20,62 +20,45 @@ impl VerifierKey {
         scalars: &mut Vec<BlsScalar>,
         points: &mut Vec<G1Affine>,
         evaluations: &ProofEvaluations,
-        z_challenge: &BlsScalar,
         (delta, epsilon): (&BlsScalar, &BlsScalar),
         l1_eval: &BlsScalar,
-        ln_eval: &BlsScalar,
         t_eval: &BlsScalar,
         t_next_eval: &BlsScalar,
-        h_1_comm: G1Affine,
         h_2_comm: G1Affine,
         p_comm: G1Affine,
-        omega_inv: &BlsScalar,
     ) {
         let l_sep_2 = lookup_separation_challenge.square();
         let l_sep_3 = lookup_separation_challenge * l_sep_2;
-        let l_sep_4 = lookup_separation_challenge * l_sep_3;
-        let l_sep_5 = lookup_separation_challenge * l_sep_4;
 
         // - f_eval * q_lookup * alpha_1
-        let a = -evaluations.f_long_eval * lookup_separation_challenge;
+        let a = -evaluations.f_eval * lookup_separation_challenge;
         scalars.push(a);
         points.push(self.q_lookup.0);
 
-        // l_n(z) * alpha_1^4
-        let b = { ln_eval * l_sep_4 };
-        scalars.push(b);
-        points.push(h_1_comm);
-
-        // - ((z - omega_inv)*p_next_eval*(epsilon*(1 + delta) + h_1_eval + delta*h_1_next_eval)*alpha_1^3)*h_2
+        // - (p_next_eval*(epsilon*(1 + delta) + h_1_eval + delta*h_2_eval)*alpha_1^3)*h_2
         let c = {
-            let c_0 = -(z_challenge - omega_inv);
+            let c_0 = &evaluations.lookup_perm_eval;
 
-            let c_1 = &evaluations.lookup_perm_eval;
-
-            let c_2 = epsilon * (BlsScalar::one() + delta)
+            let c_1 = epsilon * (BlsScalar::one() + delta)
                 + &evaluations.h_1_eval
-                + delta * &evaluations.h_1_next_eval;
+                + delta * &evaluations.h_2_eval;
 
-            c_0 * c_1 * c_2 * l_sep_3
+            -c_0 * c_1 * l_sep_3
         };
         scalars.push(c);
         points.push(h_2_comm);
 
-        // (z - omega_inv)(1 + delta)(e + f_eval)(epsilon(1 + delta) + t_eval + (delta * t_next_eval) * alpha_1^3 + l_1(z) * alpha_1^2 + l_n(z) * alpha_1^5)
+        // (1 + delta)(e + f_eval)(epsilon*(1 + delta) + t_eval + (delta * t_next_eval) * alpha_1^3 + l_1(z) * alpha_1^2
         let d = {
-            let d_0 = z_challenge - omega_inv;
+            let d_0 = BlsScalar::one() + delta;
 
-            let d_1 = BlsScalar::one() + delta;
+            let d_1 = epsilon + evaluations.f_eval;
 
-            let d_2 = epsilon + evaluations.f_short_eval;
+            let d_2 = (epsilon * d_0 + t_eval + (delta * t_next_eval)) * l_sep_3;
 
-            let d_3 = (epsilon * d_1 + t_eval + (delta * t_next_eval)) * l_sep_3;
+            let d_3 = l1_eval * l_sep_2;
 
-            let d_4 = l1_eval * l_sep_2;
-
-            let d_5 = ln_eval * l_sep_5;
-
-            (d_0 * d_1 * d_2 * d_3) + d_4 + d_5
+            (d_0 * d_1 * d_2) + d_3
         };
 
         scalars.push(d);


### PR DESCRIPTION
The plookup permutation product argument is changed to use an alternating split for h1 and h2, and the prover and verifier algorithms have been modified to match.