### PR TITLE
Turbo composer renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Changed
+
+- Change `StandardComposer` to `TurboComposer`. [#288](https://github.com/dusk-network/plonk/pull/288)
+
 ### Fixed
 
 - Fix the document references and typos [#533](https://github.com/dusk-network/plonk/pull/533)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ impl Circuit for TestCircuit {
     const CIRCUIT_ID: [u8; 32] = [0xff; 32];
     fn gadget(
         &mut self,
-        composer: &mut StandardComposer,
+        composer: &mut TurboComposer,
     ) -> Result<(), Error> {
         let a = composer.add_input(self.a);
         let b = composer.add_input(self.b);

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -7,7 +7,7 @@
 //! Tools & traits for PLONK circuits
 
 use crate::commitment_scheme::kzg10::PublicParameters;
-use crate::constraint_system::StandardComposer;
+use crate::constraint_system::TurboComposer;
 use crate::error::Error;
 use crate::proof_system::{Proof, Prover, ProverKey, Verifier, VerifierKey};
 use alloc::vec::Vec;
@@ -134,7 +134,7 @@ impl VerifierData {
 ///     const CIRCUIT_ID: [u8; 32] = [0xff; 32];
 ///     fn gadget(
 ///         &mut self,
-///         composer: &mut StandardComposer,
+///         composer: &mut TurboComposer,
 ///     ) -> Result<(), Error> {
 ///         // Add fixed witness zero
 ///         let zero = composer.add_witness_to_circuit_description(BlsScalar::zero());
@@ -231,7 +231,7 @@ where
     /// Circuit identifier associated constant.
     const CIRCUIT_ID: [u8; 32];
     /// Gadget implementation used to fill the composer.
-    fn gadget(&mut self, composer: &mut StandardComposer) -> Result<(), Error>;
+    fn gadget(&mut self, composer: &mut TurboComposer) -> Result<(), Error>;
     /// Compiles the circuit by using a function that returns a `Result`
     /// with the `ProverKey`, `VerifierKey` and the circuit size.
     fn compile(
@@ -331,7 +331,7 @@ fn build_pi(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::constraint_system::StandardComposer;
+    use crate::constraint_system::TurboComposer;
     use crate::proof_system::ProverKey;
 
     // Implements a circuit that checks:
@@ -354,7 +354,7 @@ mod tests {
         const CIRCUIT_ID: [u8; 32] = [0xff; 32];
         fn gadget(
             &mut self,
-            composer: &mut StandardComposer,
+            composer: &mut TurboComposer,
         ) -> Result<(), Error> {
             let a = composer.add_input(self.a);
             let b = composer.add_input(self.b);

--- a/src/constraint_system/arithmetic.rs
+++ b/src/constraint_system/arithmetic.rs
@@ -4,11 +4,11 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::constraint_system::StandardComposer;
+use crate::constraint_system::TurboComposer;
 use crate::constraint_system::Variable;
 use dusk_bls12_381::BlsScalar;
 
-impl StandardComposer {
+impl TurboComposer {
     /// Adds a width-3 add gate to the circuit, linking the addition of the
     /// provided inputs, scaled by the selector coefficients with the output
     /// provided.
@@ -177,7 +177,7 @@ impl StandardComposer {
         c
     }
 
-    /// Adds a [`StandardComposer::big_add_gate`] with the left and right
+    /// Adds a [`TurboComposer::big_add_gate`] with the left and right
     /// inputs and it's scaling factors, computing & returning the output
     /// (result) [`Variable`], and adding the corresponding addition
     /// constraint.
@@ -198,7 +198,7 @@ impl StandardComposer {
         self.big_add(q_l_a, q_r_b, None, q_c, pi)
     }
 
-    /// Adds a [`StandardComposer::big_add_gate`] with the left, right and
+    /// Adds a [`TurboComposer::big_add_gate`] with the left, right and
     /// fourth inputs and it's scaling factors, computing & returning the
     /// output (result) [`Variable`] and adding the corresponding addition
     /// constraint.
@@ -243,7 +243,7 @@ impl StandardComposer {
         self.big_add_gate(a, b, c, Some(d), q_l, q_r, q_o, q_4, q_c, pi)
     }
 
-    /// Adds a [`StandardComposer::big_mul_gate`] with the left, right
+    /// Adds a [`TurboComposer::big_mul_gate`] with the left, right
     /// and fourth inputs and it's scaling factors, computing & returning
     /// the output (result) [`Variable`] and adding the corresponding mul
     /// constraint.
@@ -268,7 +268,7 @@ impl StandardComposer {
         self.big_mul(q_m, a, b, None, q_c, pi)
     }
 
-    /// Adds a width-4 [`StandardComposer::big_mul_gate`] with the left, right
+    /// Adds a width-4 [`TurboComposer::big_mul_gate`] with the left, right
     /// and fourth inputs and it's scaling factors, computing & returning
     /// the output (result) [`Variable`] and adding the corresponding mul
     /// constraint.

--- a/src/constraint_system/boolean.rs
+++ b/src/constraint_system/boolean.rs
@@ -4,11 +4,11 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::constraint_system::StandardComposer;
+use crate::constraint_system::TurboComposer;
 use crate::constraint_system::Variable;
 use dusk_bls12_381::BlsScalar;
 
-impl StandardComposer {
+impl TurboComposer {
     /// Adds a boolean constraint (also known as binary constraint) where
     /// the gate eq. will enforce that the [`Variable`] received is either `0`
     /// or `1` by adding a constraint in the circuit.

--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -7,7 +7,7 @@
 //! A `Composer` could be understood as some sort of Trait that is actually
 //! defining some kind of Circuit Builder for PLONK.
 //!
-//! In that sense, here we have the implementation of the [`StandardComposer`]
+//! In that sense, here we have the implementation of the [`TurboComposer`]
 //! which has been designed in order to provide the maximum amount of
 //! performance while having a big scope in utility terms.
 //!
@@ -25,33 +25,33 @@ use alloc::vec::Vec;
 use dusk_bls12_381::BlsScalar;
 use hashbrown::HashMap;
 
-/// The StandardComposer is the circuit-builder tool that the `dusk-plonk`
+/// The TurboComposer is the circuit-builder tool that the `dusk-plonk`
 /// repository provides so that circuit descriptions can be written, stored and
 /// transformed into a [`Proof`](crate::proof_system::Proof) at some point.
 ///
-/// A StandardComposer stores all of the circuit information, being this one
+/// A TurboComposer stores all of the circuit information, being this one
 /// all of the witness and circuit descriptors info (values, positions in the
 /// circuits, gates and Wires that occupy..), the public inputs, the connection
 /// relationships between the witnesses and how they're repesented as Wires (so
 /// basically the Permutation argument etc..).
 ///
-/// The StandardComposer also grants us a way to introduce our secret
+/// The TurboComposer also grants us a way to introduce our secret
 /// witnesses in a for of a [`Variable`] into the circuit description as well as
 /// the public inputs. We can do this with methods like
-/// [`StandardComposer::add_input`].
+/// [`TurboComposer::add_input`].
 ///
-/// The StandardComposer also contains as associated functions all the
+/// The TurboComposer also contains as associated functions all the
 /// neccessary tools to be able to istrument the circuits that the user needs
 /// through the addition of gates. There are functions that may add a single
-/// gate to the circuit as for example [`StandardComposer::add_gate`] and others
+/// gate to the circuit as for example [`TurboComposer::add_gate`] and others
 /// that can add several gates to the circuit description such as
-/// [`StandardComposer::conditional_select`].
+/// [`TurboComposer::conditional_select`].
 ///
 /// Each gate or group of gates adds an specific functionallity or operation to
 /// de circuit description, and so, that's why we can understand
-/// the StandardComposer as a builder.
+/// the TurboComposer as a builder.
 #[derive(Debug)]
-pub struct StandardComposer {
+pub struct TurboComposer {
     /// Number of arithmetic gates in the circuit
     pub(crate) n: usize,
 
@@ -106,7 +106,7 @@ pub struct StandardComposer {
     pub(crate) perm: Permutation,
 }
 
-impl StandardComposer {
+impl TurboComposer {
     /// Returns the number of gates in the circuit
     pub fn circuit_size(&self) -> usize {
         self.n
@@ -136,14 +136,14 @@ impl StandardComposer {
     }
 }
 
-impl Default for StandardComposer {
+impl Default for TurboComposer {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl StandardComposer {
-    /// Generates a new empty `StandardComposer` with all of it's fields
+impl TurboComposer {
+    /// Generates a new empty `TurboComposer` with all of it's fields
     /// set to hold an initial capacity of 0.
     ///
     /// # Note
@@ -152,7 +152,7 @@ impl StandardComposer {
     /// holds `Vec` for every polynomial, and these will need to be re-allocated
     /// each time the circuit grows considerably.
     pub fn new() -> Self {
-        StandardComposer::with_expected_size(0)
+        TurboComposer::with_expected_size(0)
     }
 
     /// Fixes a [`Variable`] in the witness to be a part of the circuit
@@ -171,7 +171,7 @@ impl StandardComposer {
     /// since the `Vec`s will already have an appropriate allocation at the
     /// beginning of the composing stage.
     pub fn with_expected_size(expected_size: usize) -> Self {
-        let mut composer = StandardComposer {
+        let mut composer = TurboComposer {
             n: 0,
 
             q_m: Vec::with_capacity(expected_size),
@@ -331,7 +331,7 @@ impl StandardComposer {
     /// # Note
     /// The `bit` used as input which is a [`Variable`] should had previously
     /// been constrained to be either 1 or 0 using a bool constrain. See:
-    /// [`StandardComposer::boolean_gate`].
+    /// [`TurboComposer::boolean_gate`].
     pub fn conditional_select(
         &mut self,
         bit: Variable,
@@ -376,7 +376,7 @@ impl StandardComposer {
     /// # Note
     /// The `bit` used as input which is a [`Variable`] should had previously
     /// been constrained to be either 1 or 0 using a bool constrain. See:
-    /// [`StandardComposer::boolean_gate`].
+    /// [`TurboComposer::boolean_gate`].
     pub fn conditional_select_zero(
         &mut self,
         bit: Variable,
@@ -394,7 +394,7 @@ impl StandardComposer {
     /// # Note
     /// The `bit` used as input which is a [`Variable`] should had previously
     /// been constrained to be either 1 or 0 using a bool constrain. See:
-    /// [`StandardComposer::boolean_gate`].
+    /// [`TurboComposer::boolean_gate`].
     pub fn conditional_select_one(
         &mut self,
         bit: Variable,
@@ -483,7 +483,7 @@ impl StandardComposer {
 
     /// Utility function that allows to check on the "front-end"
     /// side of the PLONK implementation if the identity polynomial
-    /// is satisfied for each one of the [`StandardComposer`]'s gates.
+    /// is satisfied for each one of the [`TurboComposer`]'s gates.
     ///
     /// The recommended usage is to derive the std output and the std error to a
     /// text file and analyze there the gates.
@@ -630,7 +630,7 @@ mod tests {
     #[test]
     /// Tests that a circuit initially has 3 gates
     fn test_initial_circuit_size() {
-        let composer: StandardComposer = StandardComposer::new();
+        let composer: TurboComposer = TurboComposer::new();
         // Circuit size is n+3 because
         // - We have an extra gate which forces the first witness to be zero.
         //   This is used when the advice wire is not being used.

--- a/src/constraint_system/ecc/curve_addition/fixed_base_gate.rs
+++ b/src/constraint_system/ecc/curve_addition/fixed_base_gate.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::constraint_system::StandardComposer;
+use crate::constraint_system::TurboComposer;
 use crate::constraint_system::Variable;
 use dusk_bls12_381::BlsScalar;
 
@@ -37,7 +37,7 @@ pub(crate) struct WnafRound {
     pub xy_beta: BlsScalar,
 }
 
-impl StandardComposer {
+impl TurboComposer {
     /// Fixed group addition of a jubjub point
     pub(crate) fn fixed_group_add(&mut self, wnaf_round: WnafRound) {
         self.w_l.push(wnaf_round.acc_x);

--- a/src/constraint_system/ecc/curve_addition/variable_base_gate.rs
+++ b/src/constraint_system/ecc/curve_addition/variable_base_gate.rs
@@ -5,11 +5,11 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::constraint_system::ecc::Point;
-use crate::constraint_system::StandardComposer;
+use crate::constraint_system::TurboComposer;
 use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{JubJubAffine, JubJubExtended};
 
-impl StandardComposer {
+impl TurboComposer {
     /// Adds two curve points together using a curve addition gate
     /// Note that since the points are not fixed the generator is not a part of
     /// the circuit description, however it is less efficient for a program
@@ -97,7 +97,7 @@ mod test {
     /// algorithm. This method is slower than WNaf and is just meant to be the
     /// source of truth to test the WNaf method.
     pub fn classical_point_addition(
-        composer: &mut StandardComposer,
+        composer: &mut TurboComposer,
         point_a: Point,
         point_b: Point,
     ) -> Point {

--- a/src/constraint_system/ecc/mod.rs
+++ b/src/constraint_system/ecc/mod.rs
@@ -9,7 +9,7 @@ pub mod curve_addition;
 /// Gates related to scalar multiplication
 pub mod scalar_mul;
 
-use crate::constraint_system::{variable::Variable, StandardComposer};
+use crate::constraint_system::{variable::Variable, TurboComposer};
 use dusk_bls12_381::BlsScalar;
 
 /// Represents a JubJub point in the circuit
@@ -21,7 +21,7 @@ pub struct Point {
 
 impl Point {
     /// Returns an identity point
-    pub fn identity(composer: &mut StandardComposer) -> Point {
+    pub fn identity(composer: &mut TurboComposer) -> Point {
         let one = composer.add_witness_to_circuit_description(BlsScalar::one());
         Point {
             x: composer.zero_var,
@@ -39,7 +39,7 @@ impl Point {
     }
 }
 
-impl StandardComposer {
+impl TurboComposer {
     /// Converts an JubJubAffine into a constraint system Point
     /// without constraining the values
     pub fn add_affine(&mut self, affine: dusk_jubjub::JubJubAffine) -> Point {
@@ -115,7 +115,7 @@ impl StandardComposer {
     /// # Note
     /// The `bit` used as input which is a [`Variable`] should had previously
     /// been constrained to be either 1 or 0 using a bool constrain. See:
-    /// [`StandardComposer::boolean_gate`].
+    /// [`TurboComposer::boolean_gate`].
     pub fn conditional_point_select(
         &mut self,
         point_a: Point,
@@ -136,7 +136,7 @@ impl StandardComposer {
     /// # Note
     /// The `bit` used as input which is a [`Variable`] should had previously
     /// been constrained to be either 1 or 0 using a bool constrain. See:
-    /// [`StandardComposer::boolean_gate`].
+    /// [`TurboComposer::boolean_gate`].
     fn conditional_select_identity(
         &mut self,
         bit: Variable,

--- a/src/constraint_system/ecc/scalar_mul/fixed_base.rs
+++ b/src/constraint_system/ecc/scalar_mul/fixed_base.rs
@@ -6,7 +6,7 @@
 
 use crate::constraint_system::ecc::curve_addition::fixed_base_gate::WnafRound;
 use crate::constraint_system::ecc::Point;
-use crate::constraint_system::{variable::Variable, StandardComposer};
+use crate::constraint_system::{variable::Variable, TurboComposer};
 use alloc::vec::Vec;
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::Serializable;
@@ -27,7 +27,7 @@ fn compute_wnaf_point_multiples(
     dusk_jubjub::batch_normalize(&mut multiples).collect()
 }
 
-impl StandardComposer {
+impl TurboComposer {
     /// Adds an elliptic curve Scalar multiplication gate to the circuit
     /// description.
     ///

--- a/src/constraint_system/ecc/scalar_mul/variable_base.rs
+++ b/src/constraint_system/ecc/scalar_mul/variable_base.rs
@@ -5,17 +5,17 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::constraint_system::ecc::Point;
-use crate::constraint_system::{variable::Variable, StandardComposer};
+use crate::constraint_system::{variable::Variable, TurboComposer};
 use alloc::vec::Vec;
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::Serializable;
 
-impl StandardComposer {
+impl TurboComposer {
     /// Adds a variable-base scalar multiplication to the circuit description.
     ///
     /// # Note
     /// If you're planning to multiply always by the generator of the Scalar
-    /// field, you should use [`StandardComposer::fixed_base_scalar_mul`]
+    /// field, you should use [`TurboComposer::fixed_base_scalar_mul`]
     /// which is optimized for fixed_base ops.
     pub fn variable_base_scalar_mul(
         &mut self,

--- a/src/constraint_system/helper.rs
+++ b/src/constraint_system/helper.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use super::StandardComposer;
+use super::TurboComposer;
 use crate::commitment_scheme::kzg10::PublicParameters;
 use crate::error::Error;
 use crate::proof_system::{Prover, Verifier};
@@ -12,7 +12,7 @@ use dusk_bls12_381::BlsScalar;
 use rand_core::OsRng;
 
 /// Adds dummy constraints using arithmetic gates
-pub(crate) fn dummy_gadget(n: usize, composer: &mut StandardComposer) {
+pub(crate) fn dummy_gadget(n: usize, composer: &mut TurboComposer) {
     let one = BlsScalar::one();
 
     let var_one = composer.add_input(one);
@@ -31,7 +31,7 @@ pub(crate) fn dummy_gadget(n: usize, composer: &mut StandardComposer) {
 /// Takes a generic gadget function with no auxillary input and
 /// tests whether it passes an end-to-end test
 pub(crate) fn gadget_tester(
-    gadget: fn(composer: &mut StandardComposer),
+    gadget: fn(composer: &mut TurboComposer),
     n: usize,
 ) -> Result<(), Error> {
     // Common View

--- a/src/constraint_system/logic.rs
+++ b/src/constraint_system/logic.rs
@@ -5,13 +5,13 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::bit_iterator::*;
-use crate::constraint_system::StandardComposer;
+use crate::constraint_system::TurboComposer;
 use crate::constraint_system::{Variable, WireData};
 use alloc::vec::Vec;
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::Serializable;
 
-impl StandardComposer {
+impl TurboComposer {
     /// Performs a logical AND or XOR op between the inputs provided for the
     /// specified number of bits.
     ///

--- a/src/constraint_system/mod.rs
+++ b/src/constraint_system/mod.rs
@@ -26,7 +26,7 @@ pub mod logic;
 /// Range gate
 pub mod range;
 
-pub use composer::StandardComposer;
+pub use composer::TurboComposer;
 pub use ecc::Point;
 pub use variable::Variable;
 pub(crate) use variable::WireData;

--- a/src/constraint_system/range.rs
+++ b/src/constraint_system/range.rs
@@ -5,13 +5,13 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::bit_iterator::*;
-use crate::constraint_system::StandardComposer;
+use crate::constraint_system::TurboComposer;
 use crate::constraint_system::{Variable, WireData};
 use alloc::vec::Vec;
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::Serializable;
 
-impl StandardComposer {
+impl TurboComposer {
     /// Adds a range-constraint gate that checks and constrains a
     /// [`Variable`] to be inside of the range \[0,num_bits\].
     ///
@@ -25,7 +25,7 @@ impl StandardComposer {
         // Adds `variable` into the appropriate witness position
         // based on the accumulator number a_i
         let add_wire =
-            |composer: &mut StandardComposer, i: usize, variable: Variable| {
+            |composer: &mut TurboComposer, i: usize, variable: Variable| {
                 // Since four quads can fit into one gate, the gate index does
                 // not change for every four wires
                 let gate_index = composer.circuit_size() + (i / 4);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@
 //!
 //! If you want to see library usage examples, please check:
 //! <https://github.com/dusk-network/plonk/tree/v0.1.0/examples>
+
 // Bitshift/Bitwise ops are allowed to gain performance.
 #![allow(clippy::suspicious_arithmetic_impl)]
 // Some structs do not have AddAssign or MulAssign impl.

--- a/src/permutation/permutation.rs
+++ b/src/permutation/permutation.rs
@@ -729,14 +729,14 @@ impl Permutation {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::constraint_system::StandardComposer;
+    use crate::constraint_system::TurboComposer;
     use crate::fft::Polynomial;
     use dusk_bls12_381::BlsScalar;
     use rand_core::OsRng;
 
     #[test]
     fn test_multizip_permutation_poly() {
-        let mut cs = StandardComposer::with_expected_size(4);
+        let mut cs = TurboComposer::with_expected_size(4);
         let x1 = cs.add_input(BlsScalar::from_raw([4, 0, 0, 0]));
         let x2 = cs.add_input(BlsScalar::from_raw([12, 0, 0, 0]));
         let x3 = cs.add_input(BlsScalar::from_raw([8, 0, 0, 0]));

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -16,7 +16,7 @@ pub use crate::{
         key::{CommitKey, OpeningKey},
         PublicParameters,
     },
-    constraint_system::{Point, StandardComposer, Variable},
+    constraint_system::{Point, TurboComposer, Variable},
     proof_system::{Prover, ProverKey, Verifier},
 };
 

--- a/src/proof_system/preprocess.rs
+++ b/src/proof_system/preprocess.rs
@@ -7,7 +7,7 @@
 //! Methods to preprocess the constraint system for use in a proof
 
 use crate::commitment_scheme::kzg10::CommitKey;
-use crate::constraint_system::StandardComposer;
+use crate::constraint_system::TurboComposer;
 
 use crate::error::Error;
 use crate::fft::{EvaluationDomain, Evaluations, Polynomial};
@@ -35,7 +35,7 @@ pub(crate) struct SelectorPolynomials {
     fourth_sigma: Polynomial,
 }
 
-impl StandardComposer {
+impl TurboComposer {
     /// Pads the circuit to the next power of two.
     ///
     /// # Note
@@ -414,7 +414,7 @@ mod test {
     /// Tests that the circuit gets padded to the correct length
     /// XXX: We can do this test without dummy_gadget method
     fn test_pad() {
-        let mut composer: StandardComposer = StandardComposer::new();
+        let mut composer: TurboComposer = TurboComposer::new();
         dummy_gadget(100, &mut composer);
 
         // Pad the circuit to next power of two

--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -7,7 +7,7 @@
 //! A Proof stores the commitments to all of the elements that
 //! are needed to univocally identify a prove of some statement.
 //!
-//! This module contains the implementation of the `StandardComposer`s
+//! This module contains the implementation of the `TurboComposer`s
 //! `Proof` structure and it's methods.
 
 use super::linearisation_poly::ProofEvaluations;

--- a/src/proof_system/prover.rs
+++ b/src/proof_system/prover.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     commitment_scheme::kzg10::CommitKey,
-    constraint_system::{StandardComposer, Variable},
+    constraint_system::{TurboComposer, Variable},
     error::Error,
     fft::{EvaluationDomain, Polynomial},
     proof_system::{
@@ -25,15 +25,15 @@ pub struct Prover {
     /// ProverKey which is used to create proofs about a specific PLONK circuit
     pub prover_key: Option<ProverKey>,
 
-    pub(crate) cs: StandardComposer,
+    pub(crate) cs: TurboComposer,
     /// Store the messages exchanged during the preprocessing stage
     /// This is copied each time, we make a proof
     pub preprocessed_transcript: Transcript,
 }
 
 impl Prover {
-    /// Returns a mutable copy of the underlying [`StandardComposer`].
-    pub fn mut_cs(&mut self) -> &mut StandardComposer {
+    /// Returns a mutable copy of the underlying [`TurboComposer`].
+    pub fn mut_cs(&mut self) -> &mut TurboComposer {
         &mut self.cs
     }
 
@@ -61,7 +61,7 @@ impl Prover {
     pub fn new(label: &'static [u8]) -> Prover {
         Prover {
             prover_key: None,
-            cs: StandardComposer::new(),
+            cs: TurboComposer::new(),
             preprocessed_transcript: Transcript::new(label),
         }
     }
@@ -70,7 +70,7 @@ impl Prover {
     pub fn with_expected_size(label: &'static [u8], size: usize) -> Prover {
         Prover {
             prover_key: None,
-            cs: StandardComposer::with_expected_size(size),
+            cs: TurboComposer::with_expected_size(size),
             preprocessed_transcript: Transcript::new(label),
         }
     }
@@ -126,7 +126,7 @@ impl Prover {
     /// This function is used when the user wants to make multiple proofs with
     /// the same circuit.
     pub fn clear_witness(&mut self) {
-        self.cs = StandardComposer::new();
+        self.cs = TurboComposer::new();
     }
 
     /// Clears all data in the `Prover` instance.

--- a/src/proof_system/verifier.rs
+++ b/src/proof_system/verifier.rs
@@ -5,7 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::commitment_scheme::kzg10::{CommitKey, OpeningKey};
-use crate::constraint_system::StandardComposer;
+use crate::constraint_system::TurboComposer;
 use crate::error::Error;
 use crate::proof_system::widget::VerifierKey;
 use crate::proof_system::Proof;
@@ -18,7 +18,7 @@ pub struct Verifier {
     /// VerificationKey which is used to verify a specific PLONK circuit
     pub verifier_key: Option<VerifierKey>,
 
-    pub(crate) cs: StandardComposer,
+    pub(crate) cs: TurboComposer,
     /// Store the messages exchanged during the preprocessing stage
     /// This is copied each time, we make a proof, so that we can use the same
     /// verifier to Verify multiple proofs from the same circuit. If this
@@ -38,7 +38,7 @@ impl Verifier {
     pub fn new(label: &'static [u8]) -> Verifier {
         Verifier {
             verifier_key: None,
-            cs: StandardComposer::new(),
+            cs: TurboComposer::new(),
             preprocessed_transcript: Transcript::new(label),
         }
     }
@@ -47,7 +47,7 @@ impl Verifier {
     pub fn with_expected_size(label: &'static [u8], size: usize) -> Verifier {
         Verifier {
             verifier_key: None,
-            cs: StandardComposer::with_expected_size(size),
+            cs: TurboComposer::with_expected_size(size),
             preprocessed_transcript: Transcript::new(label),
         }
     }
@@ -58,7 +58,7 @@ impl Verifier {
     }
 
     /// Returns a mutable copy of the underlying composer.
-    pub fn mut_cs(&mut self) -> &mut StandardComposer {
+    pub fn mut_cs(&mut self) -> &mut TurboComposer {
         &mut self.cs
     }
 


### PR DESCRIPTION
- Change `StandardComposer` to `TurboComposer`. 
Resolves: #288