### PR TITLE
Add benchmarks to the crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add back benchmarks to the crate. [#555](https://github.com/dusk-network/plonk/issue/555)
 ### Changed
 
-- Change `StandardComposer` to `TurboComposer`. [#288](https://github.com/dusk-network/plonk/pull/288)
+- Change `StandardComposer` to `TurboComposer`. [#288](https://github.com/dusk-network/plonk/issue/288)
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,12 @@ canonical = {version = "0.6", optional = true}
 canonical_derive = {version = "0.6", optional = true}
 
 [dev-dependencies]
+criterion = "0.3"
 tempdir = "0.3"
+
+[[bench]]
+name = "plonk"
+harness = false
 
 [features]
 default = ["std"]
@@ -52,3 +57,12 @@ alloc = ["dusk-bls12_381/alloc"]
 trace = []
 trace-print = ["trace"]
 canon = ["dusk-bls12_381/canon", "dusk-jubjub/canon", "canonical", "canonical_derive"]
+
+[profile.bench]
+opt-level = 3
+debug = false
+debug-assertions = false
+overflow-checks = false
+lto = true
+incremental = false
+codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ For a circuit-size of `2^16` constraints/gates:
 - Proving time: `5.46s`
 - Verification time: `9.34ms`. **(This time will not vary depending on the circuit-size.)**
 
+For more results, please run `cargo bench` to get a full report of benchmarks in respect of constraint numbers.
+
 ## Acknowledgements
 
 - Reference implementation AztecProtocol/Barretenberg

--- a/benches/plonk.rs
+++ b/benches/plonk.rs
@@ -1,0 +1,153 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use dusk_bls12_381::BlsScalar;
+use dusk_plonk::circuit::{self, Circuit, VerifierData};
+// Using prelude until PP is available on regular import path
+use dusk_plonk::constraint_system::TurboComposer;
+use dusk_plonk::error::Error;
+use dusk_plonk::prelude::PublicParameters;
+use dusk_plonk::proof_system::{Proof, ProverKey};
+
+#[derive(Debug, Clone, Copy)]
+struct BenchCircuit {
+    degree: usize,
+}
+
+impl<T> From<T> for BenchCircuit
+where
+    T: Into<usize>,
+{
+    fn from(degree: T) -> Self {
+        Self {
+            degree: 1 << degree.into(),
+        }
+    }
+}
+
+impl Circuit for BenchCircuit {
+    const CIRCUIT_ID: [u8; 32] = [0xff; 32];
+
+    fn gadget(&mut self, composer: &mut TurboComposer) -> Result<(), Error> {
+        let mut a = BlsScalar::from(2u64);
+        let mut b = BlsScalar::from(3u64);
+        let mut c;
+
+        while composer.circuit_size() < self.padded_circuit_size() {
+            a += BlsScalar::one();
+            b += BlsScalar::one();
+            c = a * b + a + b + BlsScalar::one();
+
+            let x = composer.add_input(a);
+            let y = composer.add_input(b);
+            let z = composer.add_input(c);
+
+            composer.poly_gate(
+                x,
+                y,
+                z,
+                BlsScalar::one(),
+                BlsScalar::one(),
+                BlsScalar::one(),
+                -BlsScalar::one(),
+                BlsScalar::one(),
+                None,
+            );
+        }
+
+        Ok(())
+    }
+
+    fn padded_circuit_size(&self) -> usize {
+        self.degree
+    }
+}
+
+fn constraint_system_prove(
+    circuit: &mut BenchCircuit,
+    pp: &PublicParameters,
+    pk: &ProverKey,
+    label: &'static [u8],
+) -> Proof {
+    circuit
+        .gen_proof(&pp, &pk, label)
+        .expect("Failed to prove bench circuit!")
+}
+
+fn constraint_system_benchmark(c: &mut Criterion) {
+    let initial_degree = 5;
+    let final_degree = 18;
+
+    let rng = &mut rand_core::OsRng;
+    let label = b"dusk-network";
+    let pp = PublicParameters::setup(1 << (final_degree - 1), rng)
+        .expect("Failed to create PP");
+
+    let data: Vec<(BenchCircuit, ProverKey, VerifierData, Proof)> =
+        (initial_degree..final_degree)
+            .map(|degree| {
+                let mut circuit = BenchCircuit::from(degree as usize);
+                let (pk, vd) =
+                    circuit.compile(&pp).expect("Failed to compile circuit!");
+
+                let proof =
+                    constraint_system_prove(&mut circuit, &pp, &pk, label);
+
+                circuit::verify_proof(
+                    &pp,
+                    vd.key(),
+                    &proof,
+                    &[],
+                    vd.pi_pos(),
+                    label,
+                )
+                .expect("Failed to verify bench circuit!");
+
+                (circuit, pk, vd, proof)
+            })
+            .collect();
+
+    data.iter().for_each(|(circuit, pk, _, _)| {
+        let mut circuit = circuit.clone();
+        let size = circuit.padded_circuit_size();
+        let power = (size as f64).log2() as usize;
+        let description = format!("Prove 2^{} = {} constraints", power, size);
+
+        c.bench_function(description.as_str(), |b| {
+            b.iter(|| {
+                constraint_system_prove(black_box(&mut circuit), &pp, pk, label)
+            })
+        });
+    });
+
+    data.iter().for_each(|(circuit, _, vd, proof)| {
+        let size = circuit.padded_circuit_size();
+        let power = (size as f64).log2() as usize;
+        let description = format!("Verify 2^{} = {} constraints", power, size);
+
+        c.bench_function(description.as_str(), |b| {
+            b.iter(|| {
+                circuit::verify_proof(
+                    &pp,
+                    vd.key(),
+                    black_box(proof),
+                    &[],
+                    vd.pi_pos(),
+                    label,
+                )
+                .expect("Failed to verify bench circuit!");
+            })
+        });
+    });
+}
+
+criterion_group! {
+    name = plonk;
+    config = Criterion::default().sample_size(10);
+    targets = constraint_system_benchmark
+}
+criterion_main!(plonk);


### PR DESCRIPTION
Results obtained with: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
```
Prove 2^5 = 32 constraints                                                                           
                        time:   [18.471 ms 18.564 ms 18.677 ms]

Prove 2^6 = 64 constraints                                                                           
                        time:   [24.155 ms 24.291 ms 24.539 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

Prove 2^7 = 128 constraints                                                                           
                        time:   [38.306 ms 38.598 ms 38.874 ms]

Prove 2^8 = 256 constraints                                                                           
                        time:   [60.509 ms 62.260 ms 64.296 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

Prove 2^9 = 512 constraints                                                                           
                        time:   [90.462 ms 92.621 ms 95.947 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

Benchmarking Prove 2^10 = 1024 constraints: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.1s or enable flat sampling.
Prove 2^10 = 1024 constraints                                                                          
                        time:   [150.89 ms 157.24 ms 164.71 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

Prove 2^11 = 2048 constraints                                                                          
                        time:   [288.66 ms 289.86 ms 291.59 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

Prove 2^12 = 4096 constraints                                                                          
                        time:   [494.76 ms 500.91 ms 511.34 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

Benchmarking Prove 2^13 = 8192 constraints: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.6s.
Prove 2^13 = 8192 constraints                                                                          
                        time:   [947.94 ms 957.07 ms 966.46 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

Benchmarking Prove 2^14 = 16384 constraints: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 18.5s.
Prove 2^14 = 16384 constraints                                                                          
                        time:   [1.8323 s 1.8603 s 1.8921 s]

Benchmarking Prove 2^15 = 32768 constraints: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 36.1s.
Prove 2^15 = 32768 constraints                                                                          
                        time:   [3.5213 s 3.5465 s 3.5755 s]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

Benchmarking Prove 2^16 = 65536 constraints: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 65.9s.
Prove 2^16 = 65536 constraints                                                                          
                        time:   [6.6283 s 6.6885 s 6.7484 s]

Benchmarking Prove 2^17 = 131072 constraints: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 133.5s.
Prove 2^17 = 131072 constraints                                                                          
                        time:   [13.369 s 13.432 s 13.501 s]

Verify 2^5 = 32 constraints                                                                           
                        time:   [9.9774 ms 10.015 ms 10.066 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

Verify 2^6 = 64 constProve 2^5 = 32 constraints                                                                           
                        time:   [18.471 ms 18.564 ms 18.677 ms]

Prove 2^6 = 64 constraints                                                                           
                        time:   [24.155 ms 24.291 ms 24.539 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

Prove 2^7 = 128 constraints                                                                           
                        time:   [38.306 ms 38.598 ms 38.874 ms]

Prove 2^8 = 256 constraints                                                                           
                        time:   [60.509 ms 62.260 ms 64.296 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

Prove 2^9 = 512 constraints                                                                           
                        time:   [90.462 ms 92.621 ms 95.947 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

Benchmarking Prove 2^10 = 1024 constraints: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.1s or enable flat sampling.
Prove 2^10 = 1024 constraints                                                                          
                        time:   [150.89 ms 157.24 ms 164.71 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

Prove 2^11 = 2048 constraints                                                                          
                        time:   [288.66 ms 289.86 ms 291.59 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

Prove 2^12 = 4096 constraints                                                                          
                        time:   [494.76 ms 500.91 ms 511.34 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

Benchmarking Prove 2^13 = 8192 constraints: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.6s.
Prove 2^13 = 8192 constraints                                                                          
                        time:   [947.94 ms 957.07 ms 966.46 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

Benchmarking Prove 2^14 = 16384 constraints: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 18.5s.
Prove 2^14 = 16384 constraints                                                                          
                        time:   [1.8323 s 1.8603 s 1.8921 s]

Benchmarking Prove 2^15 = 32768 constraints: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 36.1s.
Prove 2^15 = 32768 constraints                                                                          
                        time:   [3.5213 s 3.5465 s 3.5755 s]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

Benchmarking Prove 2^16 = 65536 constraints: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 65.9s.
Prove 2^16 = 65536 constraints                                                                          
                        time:   [6.6283 s 6.6885 s 6.7484 s]

Benchmarking Prove 2^17 = 131072 constraints: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 133.5s.
Prove 2^17 = 131072 constraints                                                                          
                        time:   [13.369 s 13.432 s 13.501 s]

Verify 2^5 = 32 constraints                                                                           
                        time:   [9.9774 ms 10.015 ms 10.066 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

Verify 2^6 = 64 constraints                                                                           
                        time:   [10.036 ms 10.177 ms 10.408 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

Verify 2^7 = 128 constraints                                                                           
                        time:   [10.139 ms 10.524 ms 10.996 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

Verify 2^8 = 256 constraints                                                                           
                        time:   [10.031 ms 10.143 ms 10.233 ms]

Verify 2^9 = 512 constraints                                                                           
                        time:   [10.069 ms 10.121 ms 10.192 ms]

Verify 2^10 = 1024 constraints                                                                           
                        time:   [10.046 ms 10.093 ms 10.126 ms]

Verify 2^11 = 2048 constraints                                                                           
                        time:   [10.083 ms 10.369 ms 10.653 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

Verify 2^12 = 4096 constraints                                                                           
                        time:   [10.194 ms 10.267 ms 10.351 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

Verify 2^13 = 8192 constraints                                                                           
                        time:   [10.157 ms 10.238 ms 10.342 ms]

Verify 2^14 = 16384 constraints                                                                           
                        time:   [10.114 ms 10.151 ms 10.217 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

Verify 2^15 = 32768 constraints                                                                           
                        time:   [10.254 ms 10.301 ms 10.384 ms]

Verify 2^16 = 65536 constraints                                                                           
                        time:   [10.409 ms 10.436 ms 10.480 ms]

Verify 2^17 = 131072 constraints                                                                           
                        time:   [10.639 ms 10.684 ms 10.728 ms]

raints                                                                           
                        time:   [10.036 ms 10.177 ms 10.408 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

Verify 2^7 = 128 constraints                                                                           
                        time:   [10.139 ms 10.524 ms 10.996 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

Verify 2^8 = 256 constraints                                                                           
                        time:   [10.031 ms 10.143 ms 10.233 ms]

Verify 2^9 = 512 constraints                                                                           
                        time:   [10.069 ms 10.121 ms 10.192 ms]

Verify 2^10 = 1024 constraints                                                                           
                        time:   [10.046 ms 10.093 ms 10.126 ms]

Verify 2^11 = 2048 constraints                                                                           
                        time:   [10.083 ms 10.369 ms 10.653 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

Verify 2^12 = 4096 constraints                                                                           
                        time:   [10.194 ms 10.267 ms 10.351 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

Verify 2^13 = 8192 constraints                                                                           
                        time:   [10.157 ms 10.238 ms 10.342 ms]

Verify 2^14 = 16384 constraints                                                                           
                        time:   [10.114 ms 10.151 ms 10.217 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

Verify 2^15 = 32768 constraints                                                                           
                        time:   [10.254 ms 10.301 ms 10.384 ms]

Verify 2^16 = 65536 constraints                                                                           
                        time:   [10.409 ms 10.436 ms 10.480 ms]

Verify 2^17 = 131072 constraints                                                                           
                        time:   [10.639 ms 10.684 ms 10.728 ms]

```

Resolves: #555