### PR TITLE
AllocatedScalar refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change `StandardComposer` to `TurboComposer`. [#288](https://github.com/dusk-network/plonk/issue/288)
-
+- Change `Variable` usage in favor of `AllocatedScalar`. [#565]((https://github.com/dusk-network/plonk/issue/565))
 ### Fixed
 
 - Fix the document references and typos [#533](https://github.com/dusk-network/plonk/pull/533)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ impl Circuit for TestCircuit {
         composer.poly_gate(
             a,
             b,
-            composer.zero_var(),
+            composer.allocated_zero(),
             BlsScalar::zero(),
             BlsScalar::one(),
             BlsScalar::one(),
@@ -57,7 +57,7 @@ impl Circuit for TestCircuit {
         composer.poly_gate(
             a,
             b,
-            composer.zero_var(),
+            composer.allocated_zero(),
             BlsScalar::one(),
             BlsScalar::zero(),
             BlsScalar::zero(),
@@ -66,7 +66,7 @@ impl Circuit for TestCircuit {
             Some(-self.d),
         );
 
-        let e = composer.add_input(self.e.into());
+        let e = composer.add_input(self.e);
         let scalar_mul_result = composer
             .fixed_base_scalar_mul(e, dusk_jubjub::GENERATOR_EXTENDED);
         // Apply the constrain

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -168,7 +168,7 @@ impl VerifierData {
 ///             Some(-self.d),
 ///         );
 ///
-///         let e = composer.add_input(self.e.into());
+///         let e = composer.add_input(self.e);
 ///         let scalar_mul_result =
 ///             composer.fixed_base_scalar_mul(
 ///                 e, dusk_jubjub::GENERATOR_EXTENDED,
@@ -362,7 +362,7 @@ mod tests {
             composer.poly_gate(
                 a,
                 b,
-                composer.zero_var,
+                composer.allocated_zero(),
                 BlsScalar::zero(),
                 BlsScalar::one(),
                 BlsScalar::one(),
@@ -377,7 +377,7 @@ mod tests {
             composer.poly_gate(
                 a,
                 b,
-                composer.zero_var,
+                composer.allocated_zero(),
                 BlsScalar::one(),
                 BlsScalar::zero(),
                 BlsScalar::zero(),
@@ -386,7 +386,7 @@ mod tests {
                 Some(-self.d),
             );
 
-            let e = composer.add_input(self.e.into());
+            let e = composer.add_input(self.e);
             let scalar_mul_result = composer
                 .fixed_base_scalar_mul(e, dusk_jubjub::GENERATOR_EXTENDED);
             // Apply the constrain

--- a/src/constraint_system/arithmetic.rs
+++ b/src/constraint_system/arithmetic.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
+
 use crate::constraint_system::{AllocatedScalar, TurboComposer};
 use dusk_bls12_381::BlsScalar;
 

--- a/src/constraint_system/arithmetic.rs
+++ b/src/constraint_system/arithmetic.rs
@@ -3,9 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
-
-use crate::constraint_system::TurboComposer;
-use crate::constraint_system::Variable;
+use crate::constraint_system::{AllocatedScalar, TurboComposer};
 use dusk_bls12_381::BlsScalar;
 
 impl TurboComposer {
@@ -14,15 +12,15 @@ impl TurboComposer {
     /// provided.
     pub fn add_gate(
         &mut self,
-        a: Variable,
-        b: Variable,
-        c: Variable,
+        a: AllocatedScalar,
+        b: AllocatedScalar,
+        c: AllocatedScalar,
         q_l: BlsScalar,
         q_r: BlsScalar,
         q_o: BlsScalar,
         q_c: BlsScalar,
         pi: Option<BlsScalar>,
-    ) -> Variable {
+    ) -> AllocatedScalar {
         self.big_add_gate(
             a,
             b,
@@ -46,27 +44,27 @@ impl TurboComposer {
     /// as scaling value on the gate eq.
     pub fn big_add_gate(
         &mut self,
-        a: Variable,
-        b: Variable,
-        c: Variable,
-        d: Option<Variable>,
+        a: AllocatedScalar,
+        b: AllocatedScalar,
+        c: AllocatedScalar,
+        d: Option<AllocatedScalar>,
         q_l: BlsScalar,
         q_r: BlsScalar,
         q_o: BlsScalar,
         q_4: BlsScalar,
         q_c: BlsScalar,
         pi: Option<BlsScalar>,
-    ) -> Variable {
+    ) -> AllocatedScalar {
         // Check if advice wire has a value
         let d = match d {
-            Some(var) => var,
-            None => self.zero_var,
+            Some(alloc_scalar) => alloc_scalar,
+            None => self.allocated_zero(),
         };
 
-        self.w_l.push(a);
-        self.w_r.push(b);
-        self.w_o.push(c);
-        self.w_4.push(d);
+        self.w_l.push(a.into());
+        self.w_r.push(b.into());
+        self.w_o.push(c.into());
+        self.w_4.push(d.into());
 
         // For an add gate, q_m is zero
         self.q_m.push(BlsScalar::zero());
@@ -101,14 +99,14 @@ impl TurboComposer {
     /// (output wire) since it will just add a `mul constraint` to the circuit.
     pub fn mul_gate(
         &mut self,
-        a: Variable,
-        b: Variable,
-        c: Variable,
+        a: AllocatedScalar,
+        b: AllocatedScalar,
+        c: AllocatedScalar,
         q_m: BlsScalar,
         q_o: BlsScalar,
         q_c: BlsScalar,
         pi: Option<BlsScalar>,
-    ) -> Variable {
+    ) -> AllocatedScalar {
         self.big_mul_gate(a, b, c, None, q_m, q_o, q_c, BlsScalar::zero(), pi)
     }
 
@@ -127,26 +125,26 @@ impl TurboComposer {
     // XXX: Maybe make these tuples instead of individual field?
     pub fn big_mul_gate(
         &mut self,
-        a: Variable,
-        b: Variable,
-        c: Variable,
-        d: Option<Variable>,
+        a: AllocatedScalar,
+        b: AllocatedScalar,
+        c: AllocatedScalar,
+        d: Option<AllocatedScalar>,
         q_m: BlsScalar,
         q_o: BlsScalar,
         q_c: BlsScalar,
         q_4: BlsScalar,
         pi: Option<BlsScalar>,
-    ) -> Variable {
+    ) -> AllocatedScalar {
         // Check if advice wire has a value
         let d = match d {
-            Some(var) => var,
-            None => self.zero_var,
+            Some(alloc_scalar) => alloc_scalar,
+            None => self.allocated_zero(),
         };
 
-        self.w_l.push(a);
-        self.w_r.push(b);
-        self.w_o.push(c);
-        self.w_4.push(d);
+        self.w_l.push(a.into());
+        self.w_r.push(b.into());
+        self.w_o.push(c.into());
+        self.w_4.push(d.into());
 
         // For a mul gate q_L and q_R is zero
         self.q_l.push(BlsScalar::zero());
@@ -179,7 +177,7 @@ impl TurboComposer {
 
     /// Adds a [`TurboComposer::big_add_gate`] with the left and right
     /// inputs and it's scaling factors, computing & returning the output
-    /// (result) [`Variable`], and adding the corresponding addition
+    /// (result) [`AllocatedScalar`], and adding the corresponding addition
     /// constraint.
     ///
     /// This type of gate is usually used when we don't need to have
@@ -190,18 +188,18 @@ impl TurboComposer {
     /// Forces `q_l * w_l + q_r * w_r + q_c + PI = w_o(computed by the gate)`.
     pub fn add(
         &mut self,
-        q_l_a: (BlsScalar, Variable),
-        q_r_b: (BlsScalar, Variable),
+        q_l_a: (BlsScalar, AllocatedScalar),
+        q_r_b: (BlsScalar, AllocatedScalar),
         q_c: BlsScalar,
         pi: Option<BlsScalar>,
-    ) -> Variable {
+    ) -> AllocatedScalar {
         self.big_add(q_l_a, q_r_b, None, q_c, pi)
     }
 
     /// Adds a [`TurboComposer::big_add_gate`] with the left, right and
     /// fourth inputs and it's scaling factors, computing & returning the
-    /// output (result) [`Variable`] and adding the corresponding addition
-    /// constraint.
+    /// output (result) [`AllocatedScalar`] and adding the corresponding
+    /// addition constraint.
     ///
     /// This type of gate is usually used when we don't need to have
     /// the largest amount of performance and the minimum circuit-size
@@ -212,16 +210,16 @@ impl TurboComposer {
     /// the gate)`.
     pub fn big_add(
         &mut self,
-        q_l_a: (BlsScalar, Variable),
-        q_r_b: (BlsScalar, Variable),
-        q_4_d: Option<(BlsScalar, Variable)>,
+        q_l_a: (BlsScalar, AllocatedScalar),
+        q_r_b: (BlsScalar, AllocatedScalar),
+        q_4_d: Option<(BlsScalar, AllocatedScalar)>,
         q_c: BlsScalar,
         pi: Option<BlsScalar>,
-    ) -> Variable {
+    ) -> AllocatedScalar {
         // Check if advice wire is available
         let (q_4, d) = match q_4_d {
-            Some((q_4, var)) => (q_4, var),
-            None => (BlsScalar::zero(), self.zero_var),
+            Some((q_4, alloc_scalar)) => (q_4, alloc_scalar),
+            None => (BlsScalar::zero(), self.allocated_zero()),
         };
 
         let (q_l, a) = q_l_a;
@@ -230,22 +228,16 @@ impl TurboComposer {
         let q_o = -BlsScalar::one();
 
         // Compute the output wire
-        let a_eval = self.variables[&a];
-        let b_eval = self.variables[&b];
-        let d_eval = self.variables[&d];
-        let c_eval = (q_l * a_eval)
-            + (q_r * b_eval)
-            + (q_4 * d_eval)
-            + q_c
-            + pi.unwrap_or_default();
-        let c = self.add_input(c_eval);
+        let c: BlsScalar =
+            (q_l * a) + (q_r * b) + (q_4 * d) + q_c + pi.unwrap_or_default();
+        let c = self.add_input(c);
 
         self.big_add_gate(a, b, c, Some(d), q_l, q_r, q_o, q_4, q_c, pi)
     }
 
     /// Adds a [`TurboComposer::big_mul_gate`] with the left, right
     /// and fourth inputs and it's scaling factors, computing & returning
-    /// the output (result) [`Variable`] and adding the corresponding mul
+    /// the output (result) [`AllocatedScalar`] and adding the corresponding mul
     /// constraint.
     ///
     /// This type of gate is usually used when we don't need to have
@@ -260,17 +252,17 @@ impl TurboComposer {
     pub fn mul(
         &mut self,
         q_m: BlsScalar,
-        a: Variable,
-        b: Variable,
+        a: AllocatedScalar,
+        b: AllocatedScalar,
         q_c: BlsScalar,
         pi: Option<BlsScalar>,
-    ) -> Variable {
+    ) -> AllocatedScalar {
         self.big_mul(q_m, a, b, None, q_c, pi)
     }
 
     /// Adds a width-4 [`TurboComposer::big_mul_gate`] with the left, right
     /// and fourth inputs and it's scaling factors, computing & returning
-    /// the output (result) [`Variable`] and adding the corresponding mul
+    /// the output (result) [`AllocatedScalar`] and adding the corresponding mul
     /// constraint.
     ///
     /// This type of gate is usually used when we don't need to have
@@ -285,29 +277,23 @@ impl TurboComposer {
     pub fn big_mul(
         &mut self,
         q_m: BlsScalar,
-        a: Variable,
-        b: Variable,
-        q_4_d: Option<(BlsScalar, Variable)>,
+        a: AllocatedScalar,
+        b: AllocatedScalar,
+        q_4_d: Option<(BlsScalar, AllocatedScalar)>,
         q_c: BlsScalar,
         pi: Option<BlsScalar>,
-    ) -> Variable {
+    ) -> AllocatedScalar {
         let q_o = -BlsScalar::one();
 
         // Check if advice wire is available
         let (q_4, d) = match q_4_d {
-            Some((q_4, var)) => (q_4, var),
-            None => (BlsScalar::zero(), self.zero_var),
+            Some((q_4, alloc_scalar)) => (q_4, alloc_scalar),
+            None => (BlsScalar::zero(), self.allocated_zero()),
         };
 
         // Compute output wire
-        let a_eval = self.variables[&a];
-        let b_eval = self.variables[&b];
-        let d_eval = self.variables[&d];
-        let c_eval = (q_m * a_eval * b_eval)
-            + (q_4 * d_eval)
-            + q_c
-            + pi.unwrap_or_default();
-        let c = self.add_input(c_eval);
+        let c = (q_m * a * b) + (q_4 * d) + q_c + pi.unwrap_or_default();
+        let c = self.add_input(c);
 
         self.big_mul_gate(a, b, c, Some(d), q_m, q_o, q_c, q_4, pi)
     }
@@ -410,7 +396,7 @@ mod tests {
     fn test_correct_add_gate() {
         let res = gadget_tester(
             |composer| {
-                let zero = composer.zero_var();
+                let zero = composer.allocated_zero();
                 let one = composer.add_input(BlsScalar::one());
 
                 let c = composer.add(

--- a/src/constraint_system/boolean.rs
+++ b/src/constraint_system/boolean.rs
@@ -4,22 +4,23 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use crate::constraint_system::AllocatedScalar;
 use crate::constraint_system::TurboComposer;
-use crate::constraint_system::Variable;
 use dusk_bls12_381::BlsScalar;
 
 impl TurboComposer {
     /// Adds a boolean constraint (also known as binary constraint) where
-    /// the gate eq. will enforce that the [`Variable`] received is either `0`
-    /// or `1` by adding a constraint in the circuit.
+    /// the gate eq. will enforce that the
+    /// [`Variable`](crate::constraint_system::variable::Variable) received is
+    /// either `0` or `1` by adding a constraint in the circuit.
     ///
-    /// Note that using this constraint with whatever [`Variable`] that is not
-    /// representing a value equalling 0 or 1, will always force the equation to
-    /// fail.
-    pub fn boolean_gate(&mut self, a: Variable) -> Variable {
-        self.w_l.push(a);
-        self.w_r.push(a);
-        self.w_o.push(a);
+    /// Note that using this constraint with whatever [`AllocatedScalar`] that
+    /// is not representing a value equalling 0 or 1, will always force the
+    /// equation to fail.
+    pub fn boolean_gate(&mut self, a: AllocatedScalar) -> AllocatedScalar {
+        self.w_l.push(a.into());
+        self.w_r.push(a.into());
+        self.w_o.push(a.into());
         self.w_4.push(self.zero_var);
 
         self.q_m.push(BlsScalar::one());
@@ -36,7 +37,7 @@ impl TurboComposer {
         self.q_variable_group_add.push(BlsScalar::zero());
 
         self.perm
-            .add_variables_to_map(a, a, a, self.zero_var, self.n);
+            .add_variables_to_map(a, a, a, self.allocated_zero(), self.n);
 
         self.n += 1;
 
@@ -53,7 +54,7 @@ mod tests {
     fn test_correct_bool_gate() {
         let res = gadget_tester(
             |composer| {
-                let zero = composer.zero_var();
+                let zero = composer.allocated_zero();
                 let one = composer.add_input(BlsScalar::one());
 
                 composer.boolean_gate(zero);

--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -18,7 +18,7 @@
 // it is intended to be like this in order to provide
 // maximum performance and minimum circuit sizes.
 
-use crate::constraint_system::Variable;
+use crate::constraint_system::{AllocatedScalar, Variable};
 use crate::permutation::Permutation;
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
@@ -36,8 +36,9 @@ use hashbrown::HashMap;
 /// basically the Permutation argument etc..).
 ///
 /// The TurboComposer also grants us a way to introduce our secret
-/// witnesses in a for of a [`Variable`] into the circuit description as well as
-/// the public inputs. We can do this with methods like
+/// witnesses in a for of a
+/// [`Variable`](crate::constraint_system::variable::Variable) into the circuit
+/// description as well as the public inputs. We can do this with methods like
 /// [`TurboComposer::add_input`].
 ///
 /// The TurboComposer also contains as associated functions all the
@@ -107,9 +108,23 @@ pub struct TurboComposer {
 }
 
 impl TurboComposer {
+    /// Returns [`AllocatedScalar`] representing zero.
+    pub const fn allocated_zero(&self) -> AllocatedScalar {
+        AllocatedScalar::new(BlsScalar::zero(), self.zero_var)
+    }
+
     /// Returns the number of gates in the circuit
     pub fn circuit_size(&self) -> usize {
         self.n
+    }
+
+    /// Construct an [`AllocatedScalar`] from a
+    /// [`Variable`](crate::constraint_system::variable::Variable).
+    pub(crate) fn alloc_scalar_from_variable(
+        &self,
+        var: Variable,
+    ) -> AllocatedScalar {
+        AllocatedScalar::new(self.variables[&var], var)
     }
 
     /// Constructs a dense vector of the Public Inputs from the positions and
@@ -155,12 +170,12 @@ impl TurboComposer {
         TurboComposer::with_expected_size(0)
     }
 
-    /// Fixes a [`Variable`] in the witness to be a part of the circuit
-    /// description.
+    /// Fixes a [`Variable`](crate::constraint_system::variable::Variable) in
+    /// the witness to be a part of the circuit description.
     pub fn add_witness_to_circuit_description(
         &mut self,
         value: BlsScalar,
-    ) -> Variable {
+    ) -> AllocatedScalar {
         let var = self.add_input(value);
         self.constrain_to_constant(var, value, None);
         var
@@ -200,8 +215,9 @@ impl TurboComposer {
         };
 
         // Reserve the first variable to be zero
-        composer.zero_var =
-            composer.add_witness_to_circuit_description(BlsScalar::zero());
+        composer.zero_var = composer
+            .add_witness_to_circuit_description(BlsScalar::zero())
+            .into();
 
         // Add dummy constraints
         composer.add_dummy_constraints();
@@ -209,24 +225,24 @@ impl TurboComposer {
         composer
     }
 
-    /// Witness representation of zero of the first variable of any circuit
-    pub const fn zero_var(&self) -> Variable {
-        self.zero_var
-    }
-
     /// Add Input first calls the Permutation
-    /// to generate and allocate a new [`Variable`] `var`.
+    /// to generate and allocate a new
+    /// [`Variable`](crate::constraint_system::variable::Variable) `var`.
     ///
     /// The Composer then links the variable to the [`BlsScalar`]
-    /// and returns it for its use in the system.
-    pub fn add_input(&mut self, s: BlsScalar) -> Variable {
+    /// and returns it for its use in the system in a form of
+    /// [`AllocatedScalar`].
+    pub fn add_input<T: Into<BlsScalar> + Copy>(
+        &mut self,
+        s: T,
+    ) -> AllocatedScalar {
         // Get a new Variable from the permutation
         let var = self.perm.new_variable();
         // The composer now links the BlsScalar to the Variable returned from
         // the Permutation
-        self.variables.insert(var, s);
+        self.variables.insert(var, s.into());
 
-        var
+        AllocatedScalar::new(s.into(), var)
     }
 
     /// Adds a width-3 poly gate.
@@ -240,19 +256,19 @@ impl TurboComposer {
     /// `(a * b) * q_m + a * q_l + b * q_r + q_c + PI + q_o * c = 0`.
     pub fn poly_gate(
         &mut self,
-        a: Variable,
-        b: Variable,
-        c: Variable,
+        a: AllocatedScalar,
+        b: AllocatedScalar,
+        c: AllocatedScalar,
         q_m: BlsScalar,
         q_l: BlsScalar,
         q_r: BlsScalar,
         q_o: BlsScalar,
         q_c: BlsScalar,
         pi: Option<BlsScalar>,
-    ) -> (Variable, Variable, Variable) {
-        self.w_l.push(a);
-        self.w_r.push(b);
-        self.w_o.push(c);
+    ) -> (AllocatedScalar, AllocatedScalar, AllocatedScalar) {
+        self.w_l.push(a.into());
+        self.w_r.push(b.into());
+        self.w_o.push(c.into());
         self.w_4.push(self.zero_var);
         self.q_l.push(q_l);
         self.q_r.push(q_r);
@@ -276,27 +292,33 @@ impl TurboComposer {
                 .is_none());
         }
 
-        self.perm
-            .add_variables_to_map(a, b, c, self.zero_var, self.n);
+        self.perm.add_variables_to_map(
+            a.into(),
+            b.into(),
+            c.into(),
+            self.zero_var,
+            self.n,
+        );
         self.n += 1;
 
         (a, b, c)
     }
 
-    /// Constrain a [`Variable`] to be equal to
-    /// a specific constant value which is part of the circuit description and
-    /// **NOT** a Public Input. ie. this value will be the same for all of the
-    /// circuit instances and [`Proof`](crate::proof_system::Proof)s generated.
+    /// Constrain a [`Variable`](crate::constraint_system::variable::Variable)
+    /// to be equal to a specific constant value which is part of the
+    /// circuit description and **NOT** a Public Input. ie. this value will
+    /// be the same for all of the circuit instances and
+    /// [`Proof`](crate::proof_system::Proof)s generated.
     pub fn constrain_to_constant(
         &mut self,
-        a: Variable,
+        a: AllocatedScalar,
         constant: BlsScalar,
         pi: Option<BlsScalar>,
     ) {
         self.poly_gate(
-            a,
-            a,
-            a,
+            a.into(),
+            a.into(),
+            a.into(),
             BlsScalar::zero(),
             BlsScalar::one(),
             BlsScalar::zero(),
@@ -307,12 +329,12 @@ impl TurboComposer {
     }
 
     /// Add a constraint into the circuit description that states that two
-    /// [`Variable`]s are equal.
-    pub fn assert_equal(&mut self, a: Variable, b: Variable) {
+    /// [`Variable`](crate::constraint_system::variable::Variable)s are equal.
+    pub fn assert_equal(&mut self, a: AllocatedScalar, b: AllocatedScalar) {
         self.poly_gate(
-            a,
-            b,
-            self.zero_var,
+            a.into(),
+            b.into(),
+            self.allocated_zero(),
             BlsScalar::zero(),
             BlsScalar::one(),
             -BlsScalar::one(),
@@ -322,30 +344,38 @@ impl TurboComposer {
         );
     }
 
-    /// Conditionally selects a [`Variable`] based on an input bit.
+    /// Conditionally selects a
+    /// [`Variable`](crate::constraint_system::variable::Variable) based on an
+    /// input bit.
     ///
     /// If:
     /// bit == 1 => choice_a,
     /// bit == 0 => choice_b,
     ///
     /// # Note
-    /// The `bit` used as input which is a [`Variable`] should had previously
-    /// been constrained to be either 1 or 0 using a bool constrain. See:
-    /// [`TurboComposer::boolean_gate`].
+    /// The `bit` used as input which is a
+    /// [`Variable`](crate::constraint_system::variable::Variable) should had
+    /// previously been constrained to be either 1 or 0 using a bool
+    /// constrain. See: [`TurboComposer::boolean_gate`].
     pub fn conditional_select(
         &mut self,
-        bit: Variable,
-        choice_a: Variable,
-        choice_b: Variable,
-    ) -> Variable {
+        bit: AllocatedScalar,
+        choice_a: AllocatedScalar,
+        choice_b: AllocatedScalar,
+    ) -> AllocatedScalar {
         // bit * choice_a
-        let bit_times_a =
-            self.mul(BlsScalar::one(), bit, choice_a, BlsScalar::zero(), None);
+        let bit_times_a = self.mul(
+            BlsScalar::one(),
+            bit.into(),
+            choice_a.into(),
+            BlsScalar::zero(),
+            None,
+        );
 
         // 1 - bit
         let one_min_bit = self.add(
-            (-BlsScalar::one(), bit),
-            (BlsScalar::zero(), self.zero_var),
+            (-BlsScalar::one(), bit.into()),
+            (BlsScalar::zero(), self.allocated_zero()),
             BlsScalar::one(),
             None,
         );
@@ -354,7 +384,7 @@ impl TurboComposer {
         let one_min_bit_choice_b = self.mul(
             BlsScalar::one(),
             one_min_bit,
-            choice_b,
+            choice_b.into(),
             BlsScalar::zero(),
             None,
         );
@@ -374,14 +404,15 @@ impl TurboComposer {
     /// bit == 0 => 0,
     ///
     /// # Note
-    /// The `bit` used as input which is a [`Variable`] should had previously
-    /// been constrained to be either 1 or 0 using a bool constrain. See:
-    /// [`TurboComposer::boolean_gate`].
+    /// The `bit` used as input which is a
+    /// [`Variable`](crate::constraint_system::variable::Variable) should had
+    /// previously been constrained to be either 1 or 0 using a bool
+    /// constrain. See: [`TurboComposer::boolean_gate`].
     pub fn conditional_select_zero(
         &mut self,
-        bit: Variable,
-        value: Variable,
-    ) -> Variable {
+        bit: AllocatedScalar,
+        value: AllocatedScalar,
+    ) -> AllocatedScalar {
         // returns bit * value
         self.mul(BlsScalar::one(), bit, value, BlsScalar::zero(), None)
     }
@@ -392,25 +423,22 @@ impl TurboComposer {
     /// bit == 0 => 1,
     ///
     /// # Note
-    /// The `bit` used as input which is a [`Variable`] should had previously
-    /// been constrained to be either 1 or 0 using a bool constrain. See:
-    /// [`TurboComposer::boolean_gate`].
+    /// The `bit` used as input which is a
+    /// [`Variable`](crate::constraint_system::variable::Variable) should had
+    /// previously been constrained to be either 1 or 0 using a bool
+    /// constrain. See: [`TurboComposer::boolean_gate`].
     pub fn conditional_select_one(
         &mut self,
-        bit: Variable,
-        value: Variable,
-    ) -> Variable {
-        let value_scalar = self.variables.get(&value).unwrap();
-        let bit_scalar = self.variables.get(&bit).unwrap();
-
-        let f_x_scalar =
-            BlsScalar::one() - bit_scalar + (bit_scalar * value_scalar);
+        bit: AllocatedScalar,
+        value: AllocatedScalar,
+    ) -> AllocatedScalar {
+        let f_x_scalar = BlsScalar::one() - bit + (bit * value);
         let f_x = self.add_input(f_x_scalar);
 
         self.poly_gate(
-            bit,
-            value,
-            f_x,
+            bit.into(),
+            value.into(),
+            f_x.into(),
             BlsScalar::one(),
             -BlsScalar::one(),
             BlsScalar::zero(),
@@ -442,10 +470,10 @@ impl TurboComposer {
         let var_one = self.add_input(BlsScalar::from(1));
         let var_seven = self.add_input(BlsScalar::from(7));
         let var_min_twenty = self.add_input(-BlsScalar::from(20));
-        self.w_l.push(var_six);
-        self.w_r.push(var_seven);
-        self.w_o.push(var_min_twenty);
-        self.w_4.push(var_one);
+        self.w_l.push(var_six.into());
+        self.w_r.push(var_seven.into());
+        self.w_o.push(var_min_twenty.into());
+        self.w_4.push(var_one.into());
         self.perm.add_variables_to_map(
             var_six,
             var_seven,
@@ -467,14 +495,14 @@ impl TurboComposer {
         self.q_logic.push(BlsScalar::zero());
         self.q_fixed_group_add.push(BlsScalar::zero());
         self.q_variable_group_add.push(BlsScalar::zero());
-        self.w_l.push(var_min_twenty);
-        self.w_r.push(var_six);
-        self.w_o.push(var_seven);
+        self.w_l.push(var_min_twenty.into());
+        self.w_r.push(var_six.into());
+        self.w_o.push(var_seven.into());
         self.w_4.push(self.zero_var);
         self.perm.add_variables_to_map(
-            var_min_twenty,
-            var_six,
-            var_seven,
+            var_min_twenty.into(),
+            var_six.into(),
+            var_seven.into(),
             self.zero_var,
             self.n,
         );
@@ -660,7 +688,7 @@ mod tests {
         let res = gadget_tester(
             |composer| {
                 let bit_1 = composer.add_input(BlsScalar::one());
-                let bit_0 = composer.zero_var();
+                let bit_0 = composer.allocated_zero();
 
                 let choice_a = composer.add_input(BlsScalar::from(10u64));
                 let choice_b = composer.add_input(BlsScalar::from(20u64));

--- a/src/constraint_system/ecc/curve_addition/fixed_base_gate.rs
+++ b/src/constraint_system/ecc/curve_addition/fixed_base_gate.rs
@@ -4,29 +4,28 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::constraint_system::TurboComposer;
-use crate::constraint_system::Variable;
+use crate::constraint_system::{TurboComposer, Variable};
 use dusk_bls12_381::BlsScalar;
 
 #[derive(Debug, Clone, Copy)]
 /// Contains all of the components needed to verify that a bit scalar
 /// multiplication was computed correctly
-pub(crate) struct WnafRound {
+pub(crate) struct WnafRound<T: Into<Variable>> {
     /// This is the accumulated x coordinate point that we wish to add (so
     /// far.. depends on where you are in the scalar mul) it is linked to
     /// the wnaf entry, so must not be revealed
-    pub acc_x: Variable,
+    pub acc_x: T,
     /// This is the accumulated y coordinate
-    pub acc_y: Variable,
+    pub acc_y: T,
 
     /// This is the wnaf accumulated entry
     /// For all intents and purposes, you can think of this as the secret bit
-    pub accumulated_bit: Variable,
+    pub accumulated_bit: T,
 
     /// This is the multiplication of x_\alpha * y_\alpha
     /// we need this as a distinct wire, so that the degree of the polynomial
     /// does not go over 4
-    pub xy_alpha: Variable,
+    pub xy_alpha: T,
     /// This is the possible x co-ordinate of the wnaf point we are going to
     /// add Actual x-co-ordinate = b_i * x_\beta
     pub x_beta: BlsScalar,
@@ -39,11 +38,14 @@ pub(crate) struct WnafRound {
 
 impl TurboComposer {
     /// Fixed group addition of a jubjub point
-    pub(crate) fn fixed_group_add(&mut self, wnaf_round: WnafRound) {
-        self.w_l.push(wnaf_round.acc_x);
-        self.w_r.push(wnaf_round.acc_y);
-        self.w_o.push(wnaf_round.xy_alpha);
-        self.w_4.push(wnaf_round.accumulated_bit);
+    pub(crate) fn fixed_group_add<T: Into<Variable> + Copy>(
+        &mut self,
+        wnaf_round: WnafRound<T>,
+    ) {
+        self.w_l.push(wnaf_round.acc_x.into());
+        self.w_r.push(wnaf_round.acc_y.into());
+        self.w_o.push(wnaf_round.xy_alpha.into());
+        self.w_4.push(wnaf_round.accumulated_bit.into());
 
         self.q_l.push(wnaf_round.x_beta);
         self.q_r.push(wnaf_round.y_beta);

--- a/src/constraint_system/ecc/mod.rs
+++ b/src/constraint_system/ecc/mod.rs
@@ -11,6 +11,7 @@ pub mod scalar_mul;
 
 use crate::constraint_system::{AllocatedScalar, TurboComposer};
 use dusk_bls12_381::BlsScalar;
+use dusk_jubjub::JubJubAffine;
 
 /// Represents a JubJub point in the circuit
 #[derive(Debug, Clone, Copy)]
@@ -29,23 +30,25 @@ impl AllocatedPoint {
         }
     }
     /// Return the X coordinate of the point
-    pub fn x(&self) -> &AllocatedScalar {
+    pub const fn x(&self) -> &AllocatedScalar {
         &self.x
     }
 
     /// Return the Y coordinate of the point
-    pub fn y(&self) -> &AllocatedScalar {
+    pub const fn y(&self) -> &AllocatedScalar {
         &self.y
+    }
+
+    /// Return the underlying point representation as [`JubJubAffine`].
+    pub fn point(&self) -> JubJubAffine {
+        JubJubAffine::from_raw_unchecked(self.x().scalar(), self.y().scalar())
     }
 }
 
 impl TurboComposer {
     /// Converts an JubJubAffine into a constraint system AllocatedPoint
     /// without constraining the values
-    pub fn add_affine(
-        &mut self,
-        affine: dusk_jubjub::JubJubAffine,
-    ) -> AllocatedPoint {
+    pub fn add_affine(&mut self, affine: JubJubAffine) -> AllocatedPoint {
         let x = self.add_input(affine.get_x());
         let y = self.add_input(affine.get_y());
         AllocatedPoint { x, y }

--- a/src/constraint_system/mod.rs
+++ b/src/constraint_system/mod.rs
@@ -27,6 +27,6 @@ pub mod logic;
 pub mod range;
 
 pub use composer::TurboComposer;
-pub use ecc::Point;
-pub use variable::Variable;
+pub use ecc::AllocatedPoint;
 pub(crate) use variable::WireData;
+pub use variable::{AllocatedScalar, Variable};

--- a/src/constraint_system/variable.rs
+++ b/src/constraint_system/variable.rs
@@ -5,7 +5,9 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 //! This module holds the components needed in the Constraint System.
-//! The two components used are Variables and Wires.
+//! The components used are Variables, AllocatedScalars and Wires.
+use core::ops::{Add, Mul, Sub};
+use dusk_bls12_381::BlsScalar;
 
 /// The value is a reference to the actual value that was added to the
 /// constraint system
@@ -17,7 +19,7 @@ pub struct Variable(pub(crate) usize);
 /// Left(1) signifies that this wire belongs to the first gate and is the left
 /// wire
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub enum WireData {
+pub(crate) enum WireData {
     /// Left Wire of n'th gate
     Left(usize),
     /// Right Wire of n'th gate
@@ -26,4 +28,161 @@ pub enum WireData {
     Output(usize),
     /// Fourth Wire of n'th gate
     Fourth(usize),
+}
+
+/// A struct which pairs a
+/// [`Variable`](crate::constraint_system::variable::Variable) and the
+/// underlying [`BlsScalar`] it's linked to in the `ConstraintSystem`.
+///
+/// An allocated scalar holds the underlying witness assignment for the Prover
+/// and a dummy value for the verifier.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct AllocatedScalar {
+    /// Variable linked to the `Scalar` in the `ConstraintSystem`.
+    var: Variable,
+    /// Scalar associated to the `Variable`
+    scalar: BlsScalar,
+}
+
+impl From<AllocatedScalar> for Variable {
+    fn from(alloc: AllocatedScalar) -> Self {
+        alloc.var
+    }
+}
+
+impl From<&AllocatedScalar> for BlsScalar {
+    fn from(alloc: &AllocatedScalar) -> Self {
+        alloc.scalar
+    }
+}
+
+impl From<AllocatedScalar> for BlsScalar {
+    fn from(alloc: AllocatedScalar) -> Self {
+        alloc.scalar
+    }
+}
+
+impl From<&AllocatedScalar> for Variable {
+    fn from(alloc: &AllocatedScalar) -> Self {
+        alloc.var
+    }
+}
+
+impl AllocatedScalar {
+    /// Generate a new [`AllocatedScalar`] from a
+    /// [`Variable`](crate::constraint_system::variable::Variable) &
+    /// [`BlsScalar`].
+    pub(crate) const fn new(scalar: BlsScalar, var: Variable) -> Self {
+        Self { var, scalar }
+    }
+    /// Return the underlying [`BlsScalar`] tight to this `AllocatedScalar`
+    /// instance.
+    pub fn scalar(&self) -> BlsScalar {
+        self.scalar
+    }
+}
+
+impl Add<BlsScalar> for AllocatedScalar {
+    type Output = BlsScalar;
+    fn add(self, rhs: BlsScalar) -> Self::Output {
+        self.scalar() + rhs
+    }
+}
+
+impl Add<&BlsScalar> for &AllocatedScalar {
+    type Output = BlsScalar;
+    fn add(self, rhs: &BlsScalar) -> Self::Output {
+        self.scalar() + rhs
+    }
+}
+
+impl Add<AllocatedScalar> for BlsScalar {
+    type Output = BlsScalar;
+    fn add(self, rhs: AllocatedScalar) -> Self::Output {
+        self + rhs.scalar()
+    }
+}
+
+impl Add<&AllocatedScalar> for &BlsScalar {
+    type Output = BlsScalar;
+    fn add(self, rhs: &AllocatedScalar) -> Self::Output {
+        self + rhs.scalar()
+    }
+}
+
+impl Sub<BlsScalar> for AllocatedScalar {
+    type Output = BlsScalar;
+    fn sub(self, rhs: BlsScalar) -> Self::Output {
+        self.scalar() - rhs
+    }
+}
+
+impl Sub<&BlsScalar> for &AllocatedScalar {
+    type Output = BlsScalar;
+    fn sub(self, rhs: &BlsScalar) -> Self::Output {
+        self.scalar() - rhs
+    }
+}
+
+impl Sub<AllocatedScalar> for BlsScalar {
+    type Output = BlsScalar;
+    fn sub(self, rhs: AllocatedScalar) -> Self::Output {
+        self - rhs.scalar()
+    }
+}
+
+impl Sub<&AllocatedScalar> for &BlsScalar {
+    type Output = BlsScalar;
+    fn sub(self, rhs: &AllocatedScalar) -> Self::Output {
+        self - rhs.scalar()
+    }
+}
+
+impl Mul<BlsScalar> for AllocatedScalar {
+    type Output = BlsScalar;
+    fn mul(self, rhs: BlsScalar) -> Self::Output {
+        self.scalar() * rhs
+    }
+}
+
+impl Mul<&BlsScalar> for &AllocatedScalar {
+    type Output = BlsScalar;
+    fn mul(self, rhs: &BlsScalar) -> Self::Output {
+        self.scalar() * rhs
+    }
+}
+
+impl Mul<AllocatedScalar> for BlsScalar {
+    type Output = BlsScalar;
+    fn mul(self, rhs: AllocatedScalar) -> Self::Output {
+        self * rhs.scalar()
+    }
+}
+
+impl Mul<&AllocatedScalar> for &BlsScalar {
+    type Output = BlsScalar;
+    fn mul(self, rhs: &AllocatedScalar) -> Self::Output {
+        self * rhs.scalar()
+    }
+}
+
+impl Add<AllocatedScalar> for AllocatedScalar {
+    type Output = BlsScalar;
+    fn add(self, rhs: AllocatedScalar) -> Self::Output {
+        self.scalar() + rhs.scalar()
+    }
+}
+
+impl Sub<AllocatedScalar> for AllocatedScalar {
+    type Output = BlsScalar;
+    fn sub(self, rhs: AllocatedScalar) -> Self::Output {
+        self.scalar() - rhs.scalar()
+    }
+}
+
+impl Mul<AllocatedScalar> for AllocatedScalar {
+    type Output = BlsScalar;
+    fn mul(self, rhs: AllocatedScalar) -> Self::Output {
+        self.scalar() * rhs.scalar()
+    }
 }

--- a/src/permutation/permutation.rs
+++ b/src/permutation/permutation.rs
@@ -34,8 +34,10 @@ impl Permutation {
         }
     }
 
-    /// Creates a new [`Variable`] by incrementing the index of the
-    /// `variable_map`. This is correct as whenever we add a new [`Variable`]
+    /// Creates a new [`Variable`](crate::constraint_system::variable::Variable)
+    /// by incrementing the index of the `variable_map`. This is correct as
+    /// whenever we add a new
+    /// [`Variable`](crate::constraint_system::variable::Variable)
     /// into the system It is always allocated in the `variable_map`.
     pub(crate) fn new_variable(&mut self) -> Variable {
         // Generate the Variable
@@ -49,8 +51,9 @@ impl Permutation {
         var
     }
 
-    /// Checks that the [`Variable`]s are valid by determining if they have been
-    /// added to the system
+    /// Checks that the
+    /// [`Variable`](crate::constraint_system::variable::Variable)s are valid by
+    /// determining if they have been added to the system
     fn valid_variables(&self, variables: &[Variable]) -> bool {
         let results: Vec<bool> = variables
             .iter()
@@ -61,14 +64,16 @@ impl Permutation {
         results.is_empty()
     }
 
-    /// Maps a set of [`Variable`]s (a,b,c,d) to a set of [`Wire`](WireData)s
-    /// (left, right, out, fourth) with the corresponding gate index
-    pub fn add_variables_to_map(
+    /// Maps a set of
+    /// [`Variable`](crate::constraint_system::variable::Variable)s (a,b,c,d) to
+    /// a set of [`Wire`](WireData)s (left, right, out, fourth) with the
+    /// corresponding gate index
+    pub fn add_variables_to_map<T: Into<Variable>>(
         &mut self,
-        a: Variable,
-        b: Variable,
-        c: Variable,
-        d: Variable,
+        a: T,
+        b: T,
+        c: T,
+        d: T,
         gate_index: usize,
     ) {
         let left: WireData = WireData::Left(gate_index);
@@ -78,22 +83,22 @@ impl Permutation {
 
         // Map each variable to the wire it is associated with
         // This essentially tells us that:
-        self.add_variable_to_map(a, left);
-        self.add_variable_to_map(b, right);
-        self.add_variable_to_map(c, output);
-        self.add_variable_to_map(d, fourth);
+        self.add_variable_to_map(a.into(), left);
+        self.add_variable_to_map(b.into(), right);
+        self.add_variable_to_map(c.into(), output);
+        self.add_variable_to_map(d.into(), fourth);
     }
 
-    pub(crate) fn add_variable_to_map(
+    pub(crate) fn add_variable_to_map<T: Into<Variable> + Copy>(
         &mut self,
-        var: Variable,
+        var: T,
         wire_data: WireData,
     ) {
-        assert!(self.valid_variables(&[var]));
+        assert!(self.valid_variables(&[var.into()]));
 
         // Since we always allocate space for the Vec of WireData when a
         // Variable is added to the variable_map, this should never fail
-        let vec_wire_data = self.variable_map.get_mut(&var).unwrap();
+        let vec_wire_data = self.variable_map.get_mut(&var.into()).unwrap();
         vec_wire_data.push(wire_data);
     }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -16,7 +16,7 @@ pub use crate::{
         key::{CommitKey, OpeningKey},
         PublicParameters,
     },
-    constraint_system::{Point, TurboComposer, Variable},
+    constraint_system::{AllocatedPoint, AllocatedScalar, TurboComposer},
     proof_system::{Prover, ProverKey, Verifier},
 };
 

--- a/src/proof_system/preprocess.rs
+++ b/src/proof_system/preprocess.rs
@@ -43,7 +43,7 @@ impl TurboComposer {
     fn pad(&mut self, diff: usize) {
         // Add a zero variable to circuit
         let zero_scalar = BlsScalar::zero();
-        let zero_var = self.zero_var();
+        let zero_var = self.zero_var;
 
         let zeroes_scalar = vec![zero_scalar; diff];
         let zeroes_var = vec![zero_var; diff];


### PR DESCRIPTION
Add `AllocatedScalar` as part of PLONK's external API
    
Now instead of mangling with `Variable`s, users will use
`AllocatedScalar` instead which includes a reference to the
Scalar a `Variable` references.
    
- Make all pub fn's get and return `AllocatedScalar` in their
signatures.
    
Now the `Variable` type is something more internal to the crate and
there should not be any uses for it outside of the crate internals.

This is required in order to be able to externalized some gadgets added into this lib in `modularized_plookup` branch which should have never been included here and need this API change in order to be a thing outside of the lib itself.

Resolves: #565