### PR TITLE
Add `From` extended point to `PublicInputValue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Added
+
+- Add `From` extended point to `PublicInputValue` [#573](https://github.com/dusk-network/plonk/issues/574)
+
 ### Fixed
 
 - Fix the document references and typos [#533](https://github.com/dusk-network/plonk/pull/533)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 17-09-21
+
 ### Added
 
 - Add `From` extended point to `PublicInputValue` [#573](https://github.com/dusk-network/plonk/issues/574)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-plonk"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>",
            "Luke Pearson <luke@dusk.network>", 
            "CPerezz <carlos@dusk.network>"] 

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -15,7 +15,7 @@ use alloc::vec::Vec;
 use canonical_derive::Canon;
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Serializable, Write};
-use dusk_jubjub::{JubJubAffine, JubJubScalar};
+use dusk_jubjub::{JubJubAffine, JubJubExtended, JubJubScalar};
 
 #[derive(Default, Debug, Clone)]
 #[cfg_attr(feature = "canon", derive(Canon))]
@@ -38,6 +38,12 @@ impl From<JubJubScalar> for PublicInputValue {
 impl From<JubJubAffine> for PublicInputValue {
     fn from(point: JubJubAffine) -> Self {
         Self(vec![point.get_x(), point.get_y()])
+    }
+}
+
+impl From<JubJubExtended> for PublicInputValue {
+    fn from(point: JubJubExtended) -> Self {
+        JubJubAffine::from(point).into()
     }
 }
 


### PR DESCRIPTION
`PublicInputValue` implements `From<JubJubAffine>`.

Since `JubJubExtended` implements `Into<JubJubAffine>`, the
implementation of `From<JubJubExtended>` for `PublicInputValue` is
trivial.

This will save the consumers of the API some additional and unnecessary
conversions.

Resolves #573