### PR TITLE
Add missing dummy constraints in test

### DIFF
--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -827,12 +827,12 @@ mod tests {
 
     #[allow(unused_variables)]
     #[test]
-    #[ignore]
     /// Tests that an empty circuit proof passes
-    fn test_prove_verify() {
+    fn test_empty_circuit() {
         let res = gadget_tester(
             |composer| {
                 // do nothing except add the dummy constraints
+                composer.add_dummy_constraints();
             },
             200,
         );

--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -828,7 +828,7 @@ mod tests {
     #[allow(unused_variables)]
     #[test]
     /// Tests that an empty circuit proof passes
-    fn test_dummy_circuit() {
+    fn test_minimal_circuit() {
         let res = gadget_tester(
             |composer| {
                 // do nothing except add the dummy constraints

--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -828,7 +828,7 @@ mod tests {
     #[allow(unused_variables)]
     #[test]
     /// Tests that an empty circuit proof passes
-    fn test_empty_circuit() {
+    fn test_dummy_circuit() {
         let res = gadget_tester(
             |composer| {
                 // do nothing except add the dummy constraints


### PR DESCRIPTION
Adds missing dummy constraints in test and removes the `#[ignore]` resulting in a passing test.