### PR TITLE
Fix ignored tests

### DIFF
--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -1059,20 +1059,18 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_plonkup_proof() {
         let public_parameters =
-            PublicParameters::setup(2 * 30, &mut OsRng).unwrap();
+            PublicParameters::setup(1 << 8, &mut OsRng).unwrap();
 
         // Create a prover struct
-        let mut prover = Prover::new(b"demo");
+        let mut prover = Prover::new(b"test");
 
         // Add gadgets
         dummy_gadget_plonkup(4, prover.mut_cs());
         prover.cs.lookup_table.insert_multi_mul(0, 3);
-        // prover.cs.
         // Commit Key
-        let (ck, _) = public_parameters.trim(2 * 20).unwrap();
+        let (ck, _) = public_parameters.trim(1 << 7).unwrap();
 
         // Preprocess circuit
         prover.preprocess(&ck).unwrap();
@@ -1082,14 +1080,14 @@ mod tests {
         let proof = prover.prove(&ck).unwrap();
 
         // Verifier
-        //
-        let mut verifier = Verifier::new(b"demo");
+        let mut verifier = Verifier::new(b"test");
 
         // Add gadgets
         dummy_gadget_plonkup(4, verifier.mut_cs());
+        verifier.mut_cs().lookup_table.insert_multi_mul(0, 3);
 
         // Commit and Verifier Key
-        let (ck, vk) = public_parameters.trim(2 * 20).unwrap();
+        let (ck, vk) = public_parameters.trim(1 << 8).unwrap();
 
         // Preprocess
         verifier.preprocess(&ck).unwrap();

--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -808,6 +808,7 @@ mod tests {
     use super::*;
     use crate::commitment_scheme::kzg10::PublicParameters;
     use crate::constraint_system::helper::*;
+    use crate::error::Error;
     use crate::proof_system::{Prover, Verifier};
     use rand_core::OsRng;
 
@@ -1059,39 +1060,33 @@ mod tests {
     }
 
     #[test]
-    fn test_plonkup_proof() {
-        let public_parameters =
-            PublicParameters::setup(1 << 8, &mut OsRng).unwrap();
+    fn test_plonkup_proof() -> Result<(), Error> {
+        let public_parameters = PublicParameters::setup(1 << 8, &mut OsRng)?;
 
         // Create a prover struct
         let mut prover = Prover::new(b"test");
+        let mut verifier = Verifier::new(b"test");
 
         // Add gadgets
         dummy_gadget_plonkup(4, prover.mut_cs());
         prover.cs.lookup_table.insert_multi_mul(0, 3);
-        // Commit Key
-        let (ck, _) = public_parameters.trim(1 << 7).unwrap();
+
+        dummy_gadget_plonkup(4, verifier.mut_cs());
+        verifier.cs.lookup_table.insert_multi_mul(0, 3);
+
+        // Commit and verifier key
+        let (ck, vk) = public_parameters.trim(1 << 7)?;
 
         // Preprocess circuit
-        prover.preprocess(&ck).unwrap();
+        prover.preprocess(&ck)?;
+        verifier.preprocess(&ck)?;
 
         let public_inputs = prover.cs.construct_dense_pi_vec();
 
-        let proof = prover.prove(&ck).unwrap();
-
-        // Verifier
-        let mut verifier = Verifier::new(b"test");
-
-        // Add gadgets
-        dummy_gadget_plonkup(4, verifier.mut_cs());
-        verifier.mut_cs().lookup_table.insert_multi_mul(0, 3);
-
-        // Commit and Verifier Key
-        let (ck, vk) = public_parameters.trim(1 << 8).unwrap();
-
-        // Preprocess
-        verifier.preprocess(&ck).unwrap();
+        let proof = prover.prove(&ck)?;
 
         assert!(verifier.verify(&proof, &vk, &public_inputs).is_ok());
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Addresses issue #590

`test_plonkup_proof` was pretty interesting. Firstly `max_degree` and `truncated_degree` were set far too small, secondly the circuits definitions were set differently for the `Prover` and for the `Verifier`.