### PR TITLE
Add `Constraint` and `Selector` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add back benchmarks to the crate. [#555](https://github.com/dusk-network/plonk/issue/555)
 - Add `Witness` by removing `AllocatedScalar`. [#588](https://github.com/dusk-network/plonk/issue/588)
+- Add `Constraint` for circuit description. [#608](https://github.com/dusk-network/plonk/issue/608)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -38,36 +38,37 @@ impl Circuit for TestCircuit {
     ) -> Result<(), Error> {
         let a = composer.append_witness(self.a);
         let b = composer.append_witness(self.b);
+
         // Make first constraint a + b = c
+        let constraint = Constraint::new()
+            .left(1)
+            .right(1)
+            .public(-self.c);
+
         composer.append_gate(
             a,
             b,
             composer.constant_zero(),
             composer.constant_zero(),
-            BlsScalar::zero(),
-            BlsScalar::one(),
-            BlsScalar::one(),
-            BlsScalar::zero(),
-            BlsScalar::zero(),
-            BlsScalar::zero(),
-            Some(-self.c),
+            constraint,
         );
+
         // Check that a and b are in range
         composer.component_range(a, 1 << 6);
         composer.component_range(b, 1 << 5);
+
         // Make second constraint a * b = d
+        let constraint = Constraint::new()
+            .mul(1)
+            .output(1)
+            .public(-self.d);
+
         composer.append_gate(
             a,
             b,
             composer.constant_zero(),
             composer.constant_zero(),
-            BlsScalar::one(),
-            BlsScalar::zero(),
-            BlsScalar::zero(),
-            BlsScalar::one(),
-            BlsScalar::zero(),
-            BlsScalar::zero(),
-            Some(-self.d),
+            constraint,
         );
 
         let e = composer.append_witness(self.e);

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -155,36 +155,37 @@ impl VerifierData {
 ///         let zero = composer.constant_zero();
 ///         let a = composer.append_witness(self.a);
 ///         let b = composer.append_witness(self.b);
+///
 ///         // Make first constraint a + b = c
+///         let constraint = Constraint::new()
+///             .left(1)
+///             .right(1)
+///             .public(-self.c);
+///
 ///         composer.append_gate(
 ///             a,
 ///             b,
 ///             zero,
 ///             zero,
-///             BlsScalar::zero(),
-///             BlsScalar::one(),
-///             BlsScalar::one(),
-///             BlsScalar::zero(),
-///             BlsScalar::zero(),
-///             BlsScalar::zero(),
-///             Some(-self.c),
+///             constraint,
 ///         );
+///
 ///         // Check that a and b are in range
 ///         composer.component_range(a, 1 << 6);
 ///         composer.component_range(b, 1 << 5);
+///
 ///         // Make second constraint a * b = d
+///         let constraint = Constraint::new()
+///             .mul(1)
+///             .output(1)
+///             .public(-self.d);
+///
 ///         composer.append_gate(
 ///             a,
 ///             b,
 ///             zero,
 ///             zero,
-///             BlsScalar::one(),
-///             BlsScalar::zero(),
-///             BlsScalar::zero(),
-///             BlsScalar::one(),
-///             BlsScalar::zero(),
-///             BlsScalar::zero(),
-///             Some(-self.d),
+///             constraint,
 ///         );
 ///
 ///         let e = composer.append_witness(self.e);
@@ -359,7 +360,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::constraint_system::TurboComposer;
+    use crate::constraint_system::{Constraint, TurboComposer};
     use crate::proof_system::ProverKey;
 
     type Result<T> = std::result::Result<T, TestError>;
@@ -406,36 +407,29 @@ mod tests {
         ) -> std::result::Result<(), Error> {
             let a = composer.append_witness(self.a);
             let b = composer.append_witness(self.b);
+
             // Make first constraint a + b = c
+            let constraint = Constraint::new().left(1).right(1).public(-self.c);
             composer.append_gate(
                 a,
                 b,
                 composer.constant_zero(),
                 composer.constant_zero(),
-                BlsScalar::zero(),
-                BlsScalar::one(),
-                BlsScalar::one(),
-                BlsScalar::zero(),
-                BlsScalar::zero(),
-                BlsScalar::zero(),
-                Some(-self.c),
+                constraint,
             );
+
             // Check that a and b are in range
             composer.component_range(a, 1 << 6);
             composer.component_range(b, 1 << 5);
+
             // Make second constraint a * b = d
+            let constraint = Constraint::new().mul(1).output(1).public(-self.d);
             composer.append_gate(
                 a,
                 b,
                 composer.constant_zero(),
                 composer.constant_zero(),
-                BlsScalar::one(),
-                BlsScalar::zero(),
-                BlsScalar::zero(),
-                BlsScalar::one(),
-                BlsScalar::zero(),
-                BlsScalar::zero(),
-                Some(-self.d),
+                constraint,
             );
 
             let e = composer.append_witness(self.e);

--- a/src/constraint_system.rs
+++ b/src/constraint_system.rs
@@ -10,11 +10,13 @@
 //! build, preprocess circuits.
 
 pub(crate) mod composer;
+pub(crate) mod constraint;
 pub(crate) mod ecc;
 pub(crate) mod logic;
 pub(crate) mod range;
 pub(crate) mod witness;
 
+pub(crate) use constraint::Selector;
 pub(crate) use witness::WireData;
 
 mod arithmetic;
@@ -25,5 +27,6 @@ mod boolean;
 pub(crate) mod helper;
 
 pub use composer::TurboComposer;
+pub use constraint::Constraint;
 pub use ecc::WitnessPoint;
 pub use witness::Witness;

--- a/src/constraint_system/arithmetic.rs
+++ b/src/constraint_system/arithmetic.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::constraint_system::{TurboComposer, Witness};
+use crate::constraint_system::{Constraint, TurboComposer, Witness};
 use dusk_bls12_381::BlsScalar;
 
 impl TurboComposer {
@@ -16,35 +16,12 @@ impl TurboComposer {
         a: Witness,
         b: Witness,
         d: Witness,
-        q_l: BlsScalar,
-        q_r: BlsScalar,
-        q_4: BlsScalar,
-        q_c: BlsScalar,
-        pi: Option<BlsScalar>,
+        s: Constraint,
     ) -> Witness {
-        // Compute the output wire
-        let o = q_l * self.witnesses[&a]
-            + q_r * self.witnesses[&b]
-            + q_4 * self.witnesses[&d]
-            + q_c
-            + pi.unwrap_or_default();
+        let s = Constraint::arithmetic(&s).output(-BlsScalar::one());
+        let o = self.append_output_witness(a, b, d, s);
 
-        let o = self.append_witness(o);
-        let q_o = -BlsScalar::one();
-
-        self.append_gate(
-            a,
-            b,
-            o,
-            d,
-            BlsScalar::zero(),
-            q_l,
-            q_r,
-            q_o,
-            q_4,
-            q_c,
-            pi,
-        );
+        self.append_gate(a, b, o, d, s);
 
         o
     }
@@ -57,33 +34,12 @@ impl TurboComposer {
         a: Witness,
         b: Witness,
         d: Witness,
-        q_m: BlsScalar,
-        q_4: BlsScalar,
-        q_c: BlsScalar,
-        pi: Option<BlsScalar>,
+        s: Constraint,
     ) -> Witness {
-        // Compute the output wire
-        let o = q_m * self.witnesses[&a] * self.witnesses[&b]
-            + q_4 * self.witnesses[&d]
-            + q_c
-            + pi.unwrap_or_default();
+        let s = Constraint::arithmetic(&s).output(-BlsScalar::one());
+        let o = self.append_output_witness(a, b, d, s);
 
-        let o = self.append_witness(o);
-        let q_o = -BlsScalar::one();
-
-        self.append_gate(
-            a,
-            b,
-            o,
-            d,
-            q_m,
-            BlsScalar::zero(),
-            BlsScalar::zero(),
-            q_o,
-            q_4,
-            q_c,
-            pi,
-        );
+        self.append_gate(a, b, o, d, s);
 
         o
     }
@@ -93,25 +49,21 @@ impl TurboComposer {
 #[cfg(test)]
 mod tests {
     use crate::constraint_system::helper::*;
+    use crate::constraint_system::Constraint;
     use dusk_bls12_381::BlsScalar;
 
     #[test]
     fn test_public_inputs() {
-        let res = gadget_tester(
+        gadget_tester(
             |composer| {
                 let one = composer.append_witness(BlsScalar::one());
                 let zero = composer.constant_zero();
 
-                let should_be_three = composer.gate_add(
-                    one,
-                    one,
-                    zero,
-                    BlsScalar::one(),
-                    BlsScalar::one(),
-                    BlsScalar::zero(),
-                    BlsScalar::zero(),
-                    Some(BlsScalar::one()),
-                );
+                composer.append_dummy_gates();
+
+                let constraint = Constraint::new().left(1).right(1).public(1);
+                let should_be_three =
+                    composer.gate_add(one, one, zero, constraint);
 
                 composer.assert_equal_constant(
                     should_be_three,
@@ -119,16 +71,9 @@ mod tests {
                     None,
                 );
 
-                let should_be_four = composer.gate_add(
-                    one,
-                    one,
-                    zero,
-                    BlsScalar::one(),
-                    BlsScalar::one(),
-                    BlsScalar::zero(),
-                    BlsScalar::zero(),
-                    Some(BlsScalar::from(2)),
-                );
+                let constraint = Constraint::new().left(1).right(1).public(2);
+                let should_be_four =
+                    composer.gate_add(one, one, zero, constraint);
 
                 composer.assert_equal_constant(
                     should_be_four,
@@ -137,8 +82,8 @@ mod tests {
                 );
             },
             200,
-        );
-        assert!(res.is_ok());
+        )
+        .expect("Failed to test circuit public inputs");
     }
 
     #[test]
@@ -152,27 +97,10 @@ mod tests {
                 let seven = composer.append_witness(BlsScalar::from(7));
                 let zero = composer.constant_zero();
 
-                let fourteen = composer.gate_add(
-                    four,
-                    five,
-                    five,
-                    BlsScalar::one(),
-                    BlsScalar::one(),
-                    BlsScalar::one(),
-                    BlsScalar::zero(),
-                    None,
-                );
+                let constraint = Constraint::new().left(1).right(1).fourth(1);
 
-                let twenty = composer.gate_add(
-                    six,
-                    seven,
-                    seven,
-                    BlsScalar::one(),
-                    BlsScalar::one(),
-                    BlsScalar::one(),
-                    BlsScalar::zero(),
-                    None,
-                );
+                let fourteen = composer.gate_add(four, five, five, constraint);
+                let twenty = composer.gate_add(six, seven, seven, constraint);
 
                 // There are quite a few ways to check the equation is correct,
                 // depending on your circumstance If we already
@@ -181,15 +109,9 @@ mod tests {
                 // can compute it using the `mul` If the output
                 // is public, we can also constrain the output wire of the mul
                 // gate to it. This is what this test does
-                let output = composer.gate_mul(
-                    fourteen,
-                    twenty,
-                    zero,
-                    BlsScalar::one(),
-                    BlsScalar::zero(),
-                    BlsScalar::zero(),
-                    None,
-                );
+                let constraint = Constraint::new().mul(1);
+                let output =
+                    composer.gate_mul(fourteen, twenty, zero, constraint);
 
                 composer.assert_equal_constant(
                     output,
@@ -209,16 +131,8 @@ mod tests {
                 let zero = composer.constant_zero();
                 let one = composer.append_witness(BlsScalar::one());
 
-                let c = composer.gate_add(
-                    one,
-                    zero,
-                    zero,
-                    BlsScalar::one(),
-                    BlsScalar::zero(),
-                    BlsScalar::zero(),
-                    BlsScalar::from(2u64),
-                    None,
-                );
+                let constraint = Constraint::new().left(1).constant(2);
+                let c = composer.gate_add(one, zero, zero, constraint);
 
                 composer.assert_equal_constant(c, BlsScalar::from(3), None);
             },
@@ -238,37 +152,14 @@ mod tests {
                 let seven = composer.append_witness(BlsScalar::from(7));
                 let nine = composer.append_witness(BlsScalar::from(9));
 
-                let fourteen = composer.gate_add(
-                    four,
-                    five,
-                    five,
-                    BlsScalar::one(),
-                    BlsScalar::one(),
-                    BlsScalar::one(),
-                    BlsScalar::zero(),
-                    None,
-                );
+                let constraint = Constraint::new().left(1).right(1).fourth(1);
 
-                let twenty = composer.gate_add(
-                    six,
-                    seven,
-                    seven,
-                    BlsScalar::one(),
-                    BlsScalar::one(),
-                    BlsScalar::one(),
-                    BlsScalar::zero(),
-                    None,
-                );
+                let fourteen = composer.gate_add(four, five, five, constraint);
+                let twenty = composer.gate_add(six, seven, seven, constraint);
 
-                let output = composer.gate_mul(
-                    fourteen,
-                    twenty,
-                    nine,
-                    BlsScalar::one(),
-                    BlsScalar::from(8),
-                    BlsScalar::zero(),
-                    None,
-                );
+                let constraint = Constraint::new().mul(1).fourth(8);
+                let output =
+                    composer.gate_mul(fourteen, twenty, nine, constraint);
 
                 composer.assert_equal_constant(
                     output,
@@ -291,36 +182,19 @@ mod tests {
                 let seven = composer.append_witness(BlsScalar::from(7));
                 let zero = composer.constant_zero();
 
-                let five_plus_five = composer.gate_add(
-                    five,
-                    five,
-                    zero,
-                    BlsScalar::one(),
-                    BlsScalar::one(),
-                    BlsScalar::zero(),
-                    BlsScalar::zero(),
-                    None,
-                );
+                let constraint = Constraint::new().left(1).right(1);
+                let five_plus_five =
+                    composer.gate_add(five, five, zero, constraint);
 
-                let six_plus_seven = composer.gate_add(
-                    six,
-                    seven,
-                    zero,
-                    BlsScalar::one(),
-                    BlsScalar::one(),
-                    BlsScalar::zero(),
-                    BlsScalar::zero(),
-                    None,
-                );
+                let six_plus_seven =
+                    composer.gate_add(six, seven, zero, constraint);
 
+                let constraint = Constraint::new().mul(1);
                 let output = composer.gate_mul(
                     five_plus_five,
                     six_plus_seven,
                     zero,
-                    BlsScalar::one(),
-                    BlsScalar::zero(),
-                    BlsScalar::zero(),
-                    None,
+                    constraint,
                 );
 
                 composer.assert_equal_constant(

--- a/src/constraint_system/boolean.rs
+++ b/src/constraint_system/boolean.rs
@@ -4,8 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::constraint_system::TurboComposer;
-use crate::constraint_system::Witness;
+use crate::constraint_system::{Constraint, TurboComposer, Witness};
 use dusk_bls12_381::BlsScalar;
 
 impl TurboComposer {
@@ -17,19 +16,10 @@ impl TurboComposer {
     /// is not representing a value equalling 0 or 1, will always force the
     /// equation to fail.
     pub fn gate_boolean(&mut self, a: Witness) {
-        self.append_gate(
-            a,
-            a,
-            a,
-            self.constant_zero(),
-            BlsScalar::one(),
-            BlsScalar::zero(),
-            BlsScalar::zero(),
-            -BlsScalar::one(),
-            BlsScalar::zero(),
-            BlsScalar::zero(),
-            None,
-        );
+        let zero = self.constant_zero();
+        let constraint = Constraint::new().mul(1).output(-BlsScalar::one());
+
+        self.append_gate(a, a, a, zero, constraint);
     }
 }
 

--- a/src/constraint_system/constraint.rs
+++ b/src/constraint_system/constraint.rs
@@ -1,0 +1,211 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_bls12_381::BlsScalar;
+
+/// Index the coefficients in a polynomial description of the circuit
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Selector {
+    /// Multiplication coefficient index `q_m`
+    Multiplication = 0x00,
+    /// Left coefficient index `q_l`
+    Left = 0x01,
+    /// Right coefficient index `q_r`
+    Right = 0x02,
+    /// Output coefficient index `q_o`
+    Output = 0x03,
+    /// Fourth advice coefficient index `q_4`
+    Fourth = 0x04,
+    /// Constant expression `q_c`
+    Constant = 0x05,
+    /// Public input `pi`
+    PublicInput = 0x06,
+
+    /// Arithmetic coefficient (internal use)
+    Arithmetic = 0x07,
+    /// Range coefficient (internal use)
+    Range = 0x08,
+    /// Logic coefficient (internal use)
+    Logic = 0x09,
+    /// Curve addition with fixed base coefficient (internal use)
+    GroupAddFixedBase = 0x0a,
+    /// Curve addition with variable base coefficient (internal use)
+    GroupAddVariableBase = 0x0b,
+    /// Lookup coefficient (internal use)
+    Lookup = 0x0c,
+}
+
+/// Constraint representation containing the coefficients of a polynomial
+/// evaluation
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct Constraint {
+    coefficients: [BlsScalar; 13],
+
+    // TODO Workaround solution to keep the sparse public input indexes in the
+    // composer
+    //
+    // The indexes are needed to build the `VerifierData` so it won't contain
+    // all the constraints of the circuit.
+    //
+    // However, the composer uses a dense instance of the public inputs to
+    // prove statements. This way, it will need to keep the vector of
+    // indexes internally so the `VerifierData` can be properly generated.
+    //
+    // Whenever `Constraint::public` is called and appended to a composer, the
+    // composer must include this constraint index into the sparse set of
+    // public input indexes.
+    //
+    // This workaround can be removed only after the composer replaces the
+    // internal `Vec<BlsScalar>` of the selectors by a single
+    // `Vec<Constraint>`.
+    //
+    // Related issue: https://github.com/dusk-network/plonk/issues/607
+    has_public_input: bool,
+}
+
+impl AsRef<[BlsScalar]> for Constraint {
+    fn as_ref(&self) -> &[BlsScalar] {
+        &self.coefficients
+    }
+}
+
+impl Constraint {
+    /// Initiate the composition of a new selector description of a circuit.
+    pub const fn new() -> Self {
+        Self {
+            coefficients: [BlsScalar::zero(); 13],
+            has_public_input: false,
+        }
+    }
+
+    fn set<T: Into<BlsScalar>>(mut self, r: Selector, s: T) -> Self {
+        self.coefficients[r as usize] = s.into();
+
+        self
+    }
+
+    fn copy_public_selectors(mut self, rhs: &Self) -> Self {
+        const EXTERNAL: usize = Selector::Arithmetic as usize;
+
+        let src = &rhs.coefficients[..EXTERNAL];
+        let dst = &mut self.coefficients[..EXTERNAL];
+
+        dst.copy_from_slice(src);
+        self.has_public_input = rhs.has_public_input();
+
+        self
+    }
+
+    /// Return a reference to the specified selector of a circuit constraint.
+    pub(crate) const fn coeff(&self, r: Selector) -> &BlsScalar {
+        &self.coefficients[r as usize]
+    }
+
+    /// Set `s` as the polynomial selector for the multiplication coefficient
+    /// index.
+    pub fn mul<T: Into<BlsScalar>>(self, s: T) -> Self {
+        self.set(Selector::Multiplication, s)
+    }
+
+    /// Set `s` as the polynomial selector for the left coefficient index.
+    pub fn left<T: Into<BlsScalar>>(self, s: T) -> Self {
+        self.set(Selector::Left, s)
+    }
+
+    /// Set `s` as the polynomial selector for the right coefficient index.
+    pub fn right<T: Into<BlsScalar>>(self, s: T) -> Self {
+        self.set(Selector::Right, s)
+    }
+
+    /// Set `s` as the polynomial selector for the output coefficient index.
+    pub fn output<T: Into<BlsScalar>>(self, s: T) -> Self {
+        self.set(Selector::Output, s)
+    }
+
+    /// Set `s` as the polynomial selector for the fourth (advice) coefficient
+    /// index.
+    pub fn fourth<T: Into<BlsScalar>>(self, s: T) -> Self {
+        self.set(Selector::Fourth, s)
+    }
+
+    /// Set `s` as the polynomial selector for the constant of the constraint.
+    pub fn constant<T: Into<BlsScalar>>(self, s: T) -> Self {
+        self.set(Selector::Constant, s)
+    }
+
+    /// Set `s` as the public input of the constraint evaluation.
+    pub fn public<T: Into<BlsScalar>>(mut self, s: T) -> Self {
+        self.has_public_input = true;
+
+        self.set(Selector::PublicInput, s)
+    }
+
+    pub(crate) const fn has_public_input(&self) -> bool {
+        self.has_public_input
+    }
+
+    pub(crate) fn arithmetic(s: &Self) -> Self {
+        Self::default()
+            .copy_public_selectors(s)
+            .set(Selector::Arithmetic, 1)
+    }
+
+    #[allow(dead_code)]
+    // TODO to be used when `TurboComposer` replaces internal selectors with
+    // this struct
+    pub(crate) fn range(s: &Self) -> Self {
+        Self::default()
+            .copy_public_selectors(s)
+            .set(Selector::Range, 1)
+    }
+
+    #[allow(dead_code)]
+    // TODO to be used when `TurboComposer` replaces internal selectors with
+    // this struct
+    pub(crate) fn logic(s: &Self) -> Self {
+        Self::default()
+            .copy_public_selectors(s)
+            .set(Selector::Constant, 1)
+            .set(Selector::Logic, 1)
+    }
+
+    #[allow(dead_code)]
+    // TODO to be used when `TurboComposer` replaces internal selectors with
+    // this struct
+    pub(crate) fn logic_xor(s: &Self) -> Self {
+        Self::default()
+            .copy_public_selectors(s)
+            .set(Selector::Constant, -BlsScalar::one())
+            .set(Selector::Logic, -BlsScalar::one())
+    }
+
+    #[allow(dead_code)]
+    // TODO to be used when `TurboComposer` replaces internal selectors with
+    // this struct
+    pub(crate) fn group_add_fixed_base(s: &Self) -> Self {
+        Self::default()
+            .copy_public_selectors(s)
+            .set(Selector::GroupAddFixedBase, 1)
+    }
+
+    #[allow(dead_code)]
+    // TODO to be used when `TurboComposer` replaces internal selectors with
+    // this struct
+    pub(crate) fn group_add_variable_base(s: &Self) -> Self {
+        Self::default()
+            .copy_public_selectors(s)
+            .set(Selector::GroupAddVariableBase, 1)
+    }
+
+    #[allow(dead_code)]
+    // TODO to be used when `TurboComposer` replaces internal selectors with
+    // this struct
+    pub(crate) fn lookup(s: &Self) -> Self {
+        Self::default()
+            .copy_public_selectors(s)
+            .set(Selector::Lookup, 1)
+    }
+}

--- a/src/constraint_system/ecc/scalar_mul/fixed_base.rs
+++ b/src/constraint_system/ecc/scalar_mul/fixed_base.rs
@@ -5,7 +5,9 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::constraint_system::ecc::curve_addition::fixed_base_gate::WnafRound;
-use crate::constraint_system::{TurboComposer, Witness, WitnessPoint};
+use crate::constraint_system::{
+    Constraint, TurboComposer, Witness, WitnessPoint,
+};
 use alloc::vec::Vec;
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::Serializable;
@@ -138,18 +140,13 @@ impl TurboComposer {
 
         // FIXME this gate isn't verifying anything because all the selectors
         // are zeroed. Validate what was the intent
+        let constraint = Constraint::new();
         self.append_gate(
             acc_x,
             acc_y,
             self.constant_zero(),
             last_accumulated_bit,
-            BlsScalar::zero(),
-            BlsScalar::zero(),
-            BlsScalar::zero(),
-            BlsScalar::zero(),
-            BlsScalar::zero(),
-            BlsScalar::zero(),
-            None,
+            constraint,
         );
 
         // Constrain the last element in the accumulator to be equal to the

--- a/src/constraint_system/helper.rs
+++ b/src/constraint_system/helper.rs
@@ -6,6 +6,7 @@
 
 use super::TurboComposer;
 use crate::commitment_scheme::PublicParameters;
+use crate::constraint_system::Constraint;
 use crate::error::Error;
 use crate::plonkup::PlonkupTable4Arity;
 use crate::proof_system::{Prover, Verifier};
@@ -20,16 +21,8 @@ pub(crate) fn dummy_gadget(n: usize, composer: &mut TurboComposer) {
 
     for _ in 0..n {
         // FIXME dummy gates with zeroed selectors doesn't make sense
-        composer.gate_add(
-            one,
-            one,
-            zero,
-            BlsScalar::one(),
-            BlsScalar::one(),
-            BlsScalar::zero(),
-            BlsScalar::zero(),
-            None,
-        );
+        let constraint = Constraint::new().left(1).right(1);
+        composer.gate_add(one, one, zero, constraint);
     }
 }
 
@@ -41,16 +34,8 @@ pub(crate) fn dummy_gadget_plonkup(n: usize, composer: &mut TurboComposer) {
     let zero = composer.constant_zero();
 
     for _ in 0..n {
-        composer.gate_add(
-            one,
-            one,
-            zero,
-            BlsScalar::one(),
-            BlsScalar::one(),
-            BlsScalar::zero(),
-            BlsScalar::zero(),
-            None,
-        );
+        let constraint = Constraint::new().left(1).right(1);
+        composer.gate_add(one, one, zero, constraint);
     }
 }
 

--- a/src/constraint_system/logic.rs
+++ b/src/constraint_system/logic.rs
@@ -18,7 +18,7 @@ impl TurboComposer {
     /// Each logic gate adds `(num_bits / 2) + 1` gates to the circuit to
     /// perform the whole operation.
     ///
-    /// ## Selector
+    /// ## Constraint
     /// - is_component_xor = 1 -> Performs XOR between the first `num_bits` for
     ///   `a` and `b`.
     /// - is_component_xor = 0 -> Performs AND between the first `num_bits` for

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -417,7 +417,7 @@ fn plonkup_denominator_irreducible(
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::constraint_system::TurboComposer;
+    use crate::constraint_system::{Constraint, TurboComposer};
     use crate::fft::Polynomial;
     use dusk_bls12_381::BlsScalar;
     use rand_core::OsRng;
@@ -817,22 +817,25 @@ mod test {
         let x3 = cs.append_witness(BlsScalar::from_raw([8, 0, 0, 0]));
         let x4 = cs.append_witness(BlsScalar::from_raw([3, 0, 0, 0]));
 
-        let zero = BlsScalar::zero();
         let one = BlsScalar::one();
         let two = BlsScalar::from_raw([2, 0, 0, 0]);
         let z = cs.constant_zero();
 
         // x1 * x4 = x2
-        cs.append_gate(x1, x4, x2, z, one, zero, zero, -one, zero, zero, None);
+        let constraint = Constraint::new().mul(1).output(-one);
+        cs.append_gate(x1, x4, x2, z, constraint);
 
         // x1 + x3 = x2
-        cs.append_gate(x1, x3, x2, z, zero, one, one, -one, zero, zero, None);
+        let constraint = Constraint::new().left(1).right(1).output(-one);
+        cs.append_gate(x1, x3, x2, z, constraint);
 
         // x1 + x2 = 2*x3
-        cs.append_gate(x1, x2, x3, z, zero, one, one, -two, zero, zero, None);
+        let constraint = Constraint::new().left(1).right(1).output(-two);
+        cs.append_gate(x1, x2, x3, z, constraint);
 
         // x3 * x4 = 2*x2
-        cs.append_gate(x3, x4, x2, z, one, zero, zero, -two, zero, zero, None);
+        let constraint = Constraint::new().mul(1).output(-two);
+        cs.append_gate(x3, x4, x2, z, constraint);
 
         let domain = EvaluationDomain::new(cs.gates()).unwrap();
         let pad = vec![BlsScalar::zero(); domain.size() - cs.w_l.len()];

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -13,7 +13,7 @@
 pub use crate::{
     circuit::{self, Circuit, PublicInputValue, VerifierData},
     commitment_scheme::{CommitKey, OpeningKey, PublicParameters},
-    constraint_system::{TurboComposer, Witness, WitnessPoint},
+    constraint_system::{Constraint, TurboComposer, Witness, WitnessPoint},
     proof_system::{Prover, ProverKey, Verifier},
 };
 


### PR DESCRIPTION
`Constraint` will introduce a fail-safe type that can be used to
describe a circuit. It will replace any composer argument that takes the
circuit description/selector polynomials.

`Selector` will allow the user to extract specific coefficients from the
constraint representation.

Resolves #608