### PR TITLE
Fix several small nits and unnecessary operations

### DIFF
--- a/src/commitment_scheme/kzg10/srs.rs
+++ b/src/commitment_scheme/kzg10/srs.rs
@@ -149,7 +149,7 @@ impl PublicParameters {
         }
         let mut buf = bytes;
         let opening_key = OpeningKey::from_reader(&mut buf)?;
-        let commit_key = CommitKey::from_slice(&buf)?;
+        let commit_key = CommitKey::from_slice(buf)?;
 
         let pp = PublicParameters {
             commit_key,

--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -129,7 +129,7 @@ impl TurboComposer {
     /// Evaluate the runtime value of a witness
     #[allow(dead_code)]
     pub(crate) fn evaluate_witness(&self, witness: &Witness) -> &BlsScalar {
-        &self.witnesses[&witness]
+        &self.witnesses[witness]
     }
 
     /// Constructs a dense vector of the Public Inputs from the positions and
@@ -558,9 +558,7 @@ impl TurboComposer {
         let y = -y.expect("Inconsistent internal usage of `Constraint::evaluate_output`: Output selector should not be zero");
 
         let o = x * y;
-        let o = self.append_witness(o);
-
-        o
+        self.append_witness(o)
     }
 
     /// Utility function that allows to check on the "front-end"

--- a/src/constraint_system/constraint.rs
+++ b/src/constraint_system/constraint.rs
@@ -106,6 +106,7 @@ impl Constraint {
 
     /// Set `s` as the polynomial selector for the multiplication coefficient
     /// index.
+    #[allow(clippy::should_implement_trait)]
     pub fn mul<T: Into<BlsScalar>>(self, s: T) -> Self {
         self.set(Selector::Multiplication, s)
     }

--- a/src/constraint_system/logic.rs
+++ b/src/constraint_system/logic.rs
@@ -207,10 +207,10 @@ impl TurboComposer {
             self.perm
                 .add_variable_to_map(var_c, WireData::Output(self.n - 1));
             // Push the variables to it's actual wire vector storage
-            self.w_l.push(var_a.into());
-            self.w_r.push(var_b.into());
-            self.w_o.push(var_c.into());
-            self.w_4.push(var_4.into());
+            self.w_l.push(var_a);
+            self.w_r.push(var_b);
+            self.w_o.push(var_c);
+            self.w_4.push(var_4);
             // Update the gate index
             self.n += 1;
         }

--- a/src/constraint_system/range.rs
+++ b/src/constraint_system/range.rs
@@ -154,7 +154,7 @@ impl TurboComposer {
             accumulator += BlsScalar::from(quad);
 
             let accumulator_var = self.append_witness(accumulator);
-            accumulators.push(accumulator_var.into());
+            accumulators.push(accumulator_var);
 
             add_wire(self, i, accumulator_var);
         }
@@ -191,7 +191,7 @@ impl TurboComposer {
         // - The witness is within the number of bits initially specified
         let last_accumulator = accumulators.len() - 1;
         self.assert_equal(accumulators[last_accumulator], witness);
-        accumulators[last_accumulator] = witness.into();
+        accumulators[last_accumulator] = witness;
     }
 }
 

--- a/src/fft/polynomial.rs
+++ b/src/fft/polynomial.rs
@@ -103,13 +103,10 @@ impl Polynomial {
         // Compute powers of points
         let powers = util::powers_of(point, self.len());
 
-        let p_evals: Vec<_> = self
-            .iter()
-            .zip(powers.into_iter())
-            .map(|(c, p)| p * c)
-            .collect();
+        let p_evals = self.iter().zip(powers.into_iter()).map(|(c, p)| p * c);
+
         let mut sum = BlsScalar::zero();
-        for eval in p_evals.into_iter() {
+        for eval in p_evals {
             sum += &eval;
         }
         sum

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -59,13 +59,9 @@ impl Permutation {
     /// Checks that the [`Witness`]s are valid by determining if they have been
     /// added to the system
     fn valid_variables(&self, variables: &[Witness]) -> bool {
-        let results: Vec<bool> = variables
+        variables
             .iter()
-            .map(|var| self.variable_map.contains_key(&var))
-            .filter(|boolean| boolean == &false)
-            .collect();
-
-        results.is_empty()
+            .all(|var| self.variable_map.contains_key(var))
     }
 
     /// Maps a set of [`Witness`]s (a,b,c,d) to a set of [`Wire`](WireData)s
@@ -334,10 +330,10 @@ impl Permutation {
                 .map(|(f, t, t_next, h_1, h_1_next, h_2)| {
                     (
                         plonkup_numerator_irreducible(
-                            delta, epsilon, &f, &t, t_next,
+                            delta, epsilon, f, t, t_next,
                         ),
                         plonkup_denominator_irreducible(
-                            delta, epsilon, &h_1, &h_1_next, &h_2,
+                            delta, epsilon, h_1, &h_1_next, h_2,
                         ),
                     )
                 })

--- a/src/plonkup/table/lookup_table.rs
+++ b/src/plonkup/table/lookup_table.rs
@@ -537,24 +537,16 @@ impl PlonkupTable4Arity {
             if k == 26 {
                 // v_1 = 678
                 for j in 659..(v_rev_k + 1) {
+                    let first = BlsScalar::from(j);
+
                     // Fourth column is 1, unless j=v_i, in which case it is 0
-                    if j == v_rev_k {
-                        let first = BlsScalar::from(j);
-                        table.push([
-                            first,
-                            BlsScalar::one(),
-                            first,
-                            BlsScalar::zero(),
-                        ]);
+                    let fourth = if j == v_rev_k {
+                        BlsScalar::zero()
                     } else {
-                        let first = BlsScalar::from(j);
-                        table.push([
-                            first,
-                            BlsScalar::one(),
-                            first,
-                            BlsScalar::one(),
-                        ]);
-                    }
+                        BlsScalar::one()
+                    };
+
+                    table.push([first, BlsScalar::one(), first, fourth]);
                 }
             } else {
                 // When j is between p' and v_i the fourth column is always 1

--- a/src/proof_system/linearisation_poly.rs
+++ b/src/proof_system/linearisation_poly.rs
@@ -186,6 +186,8 @@ impl Serializable<{ 24 * BlsScalar::SIZE }> for ProofEvaluations {
 #[cfg(feature = "alloc")]
 
 /// Compute the linearisation polynomial.
+// TODO: Improve the method signature
+#[allow(clippy::type_complexity)]
 pub(crate) fn compute(
     domain: &EvaluationDomain,
     prover_key: &ProverKey,
@@ -285,8 +287,8 @@ pub(crate) fn compute(
         &h_2_eval,
         &lookup_perm_eval,
         &l1_eval,
-        &p_poly,
-        &h_2_poly,
+        p_poly,
+        h_2_poly,
         (delta, epsilon),
         zeta,
         &q_c_eval,
@@ -390,7 +392,7 @@ fn compute_circuit_satisfiability(
         b_eval,
         c_eval,
         d_eval,
-        &d_next_eval,
+        d_next_eval,
     );
 
     let c = prover_key.logic.compute_linearisation(

--- a/src/proof_system/preprocess.rs
+++ b/src/proof_system/preprocess.rs
@@ -395,7 +395,7 @@ impl TurboComposer {
         // Preprocess the lookup table
         let preprocessed_table = PreprocessedTable4Arity::preprocess(
             &self.lookup_table,
-            &commit_key,
+            commit_key,
             domain.size() as u32,
         )?;
 

--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -335,7 +335,7 @@ pub(crate) mod alloc {
                 l1_eval,
                 self.evaluations.table_eval,
                 self.evaluations.table_next_eval,
-                &verifier_key,
+                verifier_key,
             );
 
             // Commitment Scheme
@@ -407,7 +407,7 @@ pub(crate) mod alloc {
                 )
                 .is_err()
             {
-                return Err(Error::ProofVerificationError.into());
+                return Err(Error::ProofVerificationError);
             }
 
             Ok(())
@@ -538,28 +538,28 @@ pub(crate) mod alloc {
             );
 
             verifier_key.range.compute_linearisation_commitment(
-                &range_sep_challenge,
+                range_sep_challenge,
                 &mut scalars,
                 &mut points,
                 &self.evaluations,
             );
 
             verifier_key.logic.compute_linearisation_commitment(
-                &logic_sep_challenge,
+                logic_sep_challenge,
                 &mut scalars,
                 &mut points,
                 &self.evaluations,
             );
 
             verifier_key.fixed_base.compute_linearisation_commitment(
-                &fixed_base_sep_challenge,
+                fixed_base_sep_challenge,
                 &mut scalars,
                 &mut points,
                 &self.evaluations,
             );
 
             verifier_key.variable_base.compute_linearisation_commitment(
-                &var_base_sep_challenge,
+                var_base_sep_challenge,
                 &mut scalars,
                 &mut points,
                 &self.evaluations,
@@ -570,8 +570,8 @@ pub(crate) mod alloc {
                 &mut scalars,
                 &mut points,
                 &self.evaluations,
-                (&delta, &epsilon),
-                &zeta,
+                (delta, epsilon),
+                zeta,
                 &l1_eval,
                 &t_eval,
                 &t_next_eval,

--- a/src/proof_system/prover.rs
+++ b/src/proof_system/prover.rs
@@ -220,7 +220,7 @@ impl Prover {
 
         // Compute table poly
         let table_poly = Polynomial::from_coefficients_vec(
-            domain.ifft(&compressed_t_multiset.0.as_slice()),
+            domain.ifft(&compressed_t_multiset.0),
         );
 
         // Compute table f
@@ -263,7 +263,7 @@ impl Prover {
 
         // Compute long query poly
         let f_poly = Polynomial::from_coefficients_vec(
-            domain.ifft(&compressed_f_multiset.0.as_slice()),
+            domain.ifft(&compressed_f_multiset.0),
         );
 
         // Commit to query polynomial
@@ -286,7 +286,7 @@ impl Prover {
         let z_poly = Polynomial::from_coefficients_slice(
             &self.cs.perm.compute_permutation_poly(
                 &domain,
-                [&w_l_scalar, &w_r_scalar, &w_o_scalar, &w_4_scalar],
+                [w_l_scalar, w_r_scalar, w_o_scalar, w_4_scalar],
                 &beta,
                 &gamma,
                 [
@@ -322,10 +322,8 @@ impl Prover {
         let (h_1, h_2) = s.halve_alternating();
 
         // Compute h polys
-        let h_1_poly =
-            Polynomial::from_coefficients_vec(domain.ifft(&h_1.0.as_slice()));
-        let h_2_poly =
-            Polynomial::from_coefficients_vec(domain.ifft(&h_2.0.as_slice()));
+        let h_1_poly = Polynomial::from_coefficients_vec(domain.ifft(&h_1.0));
+        let h_2_poly = Polynomial::from_coefficients_vec(domain.ifft(&h_2.0));
 
         // Commit to h polys
         let h_1_poly_commit = commit_key.commit(&h_1_poly).unwrap();
@@ -372,7 +370,7 @@ impl Prover {
 
         let t_poly = quotient_poly::compute(
             &domain,
-            &prover_key,
+            prover_key,
             &z_poly,
             &p_poly,
             (&w_l_poly, &w_r_poly, &w_o_poly, &w_4_poly),
@@ -417,7 +415,7 @@ impl Prover {
 
         let (lin_poly, evaluations) = linearisation_poly::compute(
             &domain,
-            &prover_key,
+            prover_key,
             &(
                 alpha,
                 beta,

--- a/src/proof_system/quotient_poly.rs
+++ b/src/proof_system/quotient_poly.rs
@@ -60,64 +60,64 @@ pub(crate) fn compute(
 ) -> Result<Polynomial, Error> {
     // Compute 4n eval of z(X)
     let domain_4n = EvaluationDomain::new(4 * domain.size())?;
-    let mut z_eval_4n = domain_4n.coset_fft(&z_poly);
+    let mut z_eval_4n = domain_4n.coset_fft(z_poly);
     z_eval_4n.push(z_eval_4n[0]);
     z_eval_4n.push(z_eval_4n[1]);
     z_eval_4n.push(z_eval_4n[2]);
     z_eval_4n.push(z_eval_4n[3]);
 
     // Compute 4n eval of p(X)
-    let mut p_eval_4n = domain_4n.coset_fft(&p_poly);
+    let mut p_eval_4n = domain_4n.coset_fft(p_poly);
     p_eval_4n.push(p_eval_4n[0]);
     p_eval_4n.push(p_eval_4n[1]);
     p_eval_4n.push(p_eval_4n[2]);
     p_eval_4n.push(p_eval_4n[3]);
 
     // Compute 4n evals of table poly, t(x)
-    let mut t_eval_4n = domain_4n.coset_fft(&t_poly);
+    let mut t_eval_4n = domain_4n.coset_fft(t_poly);
     t_eval_4n.push(t_eval_4n[0]);
     t_eval_4n.push(t_eval_4n[1]);
     t_eval_4n.push(t_eval_4n[2]);
     t_eval_4n.push(t_eval_4n[3]);
 
     // Compute f(x)
-    let f_eval_4n = domain_4n.coset_fft(&f_poly);
+    let f_eval_4n = domain_4n.coset_fft(f_poly);
 
     // Compute 4n eval of h_1
-    let mut h_1_eval_4n = domain_4n.coset_fft(&h_1_poly);
+    let mut h_1_eval_4n = domain_4n.coset_fft(h_1_poly);
     h_1_eval_4n.push(h_1_eval_4n[0]);
     h_1_eval_4n.push(h_1_eval_4n[1]);
     h_1_eval_4n.push(h_1_eval_4n[2]);
     h_1_eval_4n.push(h_1_eval_4n[3]);
 
     // Compute 4n eval of h_2
-    let mut h_2_eval_4n = domain_4n.coset_fft(&h_2_poly);
+    let mut h_2_eval_4n = domain_4n.coset_fft(h_2_poly);
     h_2_eval_4n.push(h_2_eval_4n[0]);
     h_2_eval_4n.push(h_2_eval_4n[1]);
     h_2_eval_4n.push(h_2_eval_4n[2]);
     h_2_eval_4n.push(h_2_eval_4n[3]);
 
     // Compute 4n evaluations of the wire polynomials
-    let mut wl_eval_4n = domain_4n.coset_fft(&w_l_poly);
+    let mut wl_eval_4n = domain_4n.coset_fft(w_l_poly);
     wl_eval_4n.push(wl_eval_4n[0]);
     wl_eval_4n.push(wl_eval_4n[1]);
     wl_eval_4n.push(wl_eval_4n[2]);
     wl_eval_4n.push(wl_eval_4n[3]);
-    let mut wr_eval_4n = domain_4n.coset_fft(&w_r_poly);
+    let mut wr_eval_4n = domain_4n.coset_fft(w_r_poly);
     wr_eval_4n.push(wr_eval_4n[0]);
     wr_eval_4n.push(wr_eval_4n[1]);
     wr_eval_4n.push(wr_eval_4n[2]);
     wr_eval_4n.push(wr_eval_4n[3]);
-    let wo_eval_4n = domain_4n.coset_fft(&w_o_poly);
+    let wo_eval_4n = domain_4n.coset_fft(w_o_poly);
 
-    let mut w4_eval_4n = domain_4n.coset_fft(&w_4_poly);
+    let mut w4_eval_4n = domain_4n.coset_fft(w_4_poly);
     w4_eval_4n.push(w4_eval_4n[0]);
     w4_eval_4n.push(w4_eval_4n[1]);
     w4_eval_4n.push(w4_eval_4n[2]);
     w4_eval_4n.push(w4_eval_4n[3]);
 
     let t_1 = compute_circuit_satisfiability_equation(
-        &domain,
+        domain,
         (
             range_challenge,
             logic_challenge,
@@ -195,7 +195,7 @@ fn compute_circuit_satisfiability_equation(
     let public_eval_4n = domain_4n.coset_fft(pi_poly);
 
     let l1_eval_4n = domain_4n.coset_fft(&compute_first_lagrange_poly_scaled(
-        &domain,
+        domain,
         BlsScalar::one(),
     ));
 
@@ -240,57 +240,57 @@ fn compute_circuit_satisfiability_equation(
             let c = prover_key.logic.compute_quotient_i(
                 i,
                 logic_challenge,
-                &wl,
-                &wl_next,
-                &wr,
-                &wr_next,
-                &wo,
-                &w4,
-                &w4_next,
+                wl,
+                wl_next,
+                wr,
+                wr_next,
+                wo,
+                w4,
+                w4_next,
             );
 
             let d = prover_key.fixed_base.compute_quotient_i(
                 i,
                 fixed_base_challenge,
-                &wl,
-                &wl_next,
-                &wr,
-                &wr_next,
-                &wo,
-                &w4,
-                &w4_next,
+                wl,
+                wl_next,
+                wr,
+                wr_next,
+                wo,
+                w4,
+                w4_next,
             );
 
             let e = prover_key.variable_base.compute_quotient_i(
                 i,
                 var_base_challenge,
-                &wl,
-                &wl_next,
-                &wr,
-                &wr_next,
-                &wo,
-                &w4,
-                &w4_next,
+                wl,
+                wl_next,
+                wr,
+                wr_next,
+                wo,
+                w4,
+                w4_next,
             );
 
             let f = prover_key.lookup.compute_quotient_i(
                 i,
                 lookup_challenge,
-                &wl,
-                &wr,
-                &wo,
-                &w4,
-                &fi,
-                &p,
-                &p_next,
-                &ti,
-                &ti_next,
-                &h1,
-                &h1_next,
-                &h2,
-                &l1i,
-                (&delta, &epsilon),
-                &zeta,
+                wl,
+                wr,
+                wo,
+                w4,
+                fi,
+                p,
+                p_next,
+                ti,
+                ti_next,
+                h1,
+                h1_next,
+                h2,
+                l1i,
+                (delta, epsilon),
+                zeta,
             );
 
             (a + pi) + b + c + d + e + f
@@ -332,10 +332,10 @@ fn compute_permutation_checks(
                 &w4_eval_4n[i],
                 &z_eval_4n[i],
                 &z_eval_4n[i + 4],
-                &alpha,
+                alpha,
                 &l1_alpha_sq_evals[i],
-                &beta,
-                &gamma,
+                beta,
+                gamma,
             )
         })
         .collect();

--- a/src/proof_system/widget/logic/proverkey.rs
+++ b/src/proof_system/widget/logic/proverkey.rs
@@ -49,7 +49,7 @@ impl ProverKey {
         let w = w_o_i;
         let c_3 = (w - a * b) * kappa_cu;
 
-        let c_4 = delta_xor_and(&a, &b, w, &d, &q_c_i) * kappa_qu;
+        let c_4 = delta_xor_and(&a, &b, w, &d, q_c_i) * kappa_qu;
 
         q_logic_i * (c_3 + c_0 + c_1 + c_2 + c_4) * logic_separation_challenge
     }
@@ -86,7 +86,7 @@ impl ProverKey {
         let w = c_eval;
         let c_3 = (w - a * b) * kappa_cu;
 
-        let c_4 = delta_xor_and(&a, &b, w, &d, &q_c_eval) * kappa_qu;
+        let c_4 = delta_xor_and(&a, &b, w, &d, q_c_eval) * kappa_qu;
 
         let t = (c_0 + c_1 + c_2 + c_3 + c_4) * logic_separation_challenge;
 

--- a/src/proof_system/widget/lookup/verifierkey.rs
+++ b/src/proof_system/widget/lookup/verifierkey.rs
@@ -64,8 +64,8 @@ mod alloc {
                 let c_0 = &evaluations.lookup_perm_eval;
 
                 let c_1 = epsilon * (BlsScalar::one() + delta)
-                    + &evaluations.h_1_eval
-                    + delta * &evaluations.h_2_eval;
+                    + evaluations.h_1_eval
+                    + delta * evaluations.h_2_eval;
 
                 -c_0 * c_1 * l_sep_3
             };

--- a/src/proof_system/widget/permutation/proverkey.rs
+++ b/src/proof_system/widget/permutation/proverkey.rs
@@ -127,17 +127,17 @@ impl ProverKey {
         z_poly: &Polynomial,
     ) -> Polynomial {
         let a = self.compute_lineariser_identity_range_check(
-            (&a_eval, &b_eval, &c_eval, &d_eval),
+            (a_eval, b_eval, c_eval, d_eval),
             z_challenge,
             (alpha, beta, gamma),
             z_poly,
         );
         let b = self.compute_lineariser_copy_range_check(
-            (&a_eval, &b_eval, &c_eval),
+            (a_eval, b_eval, c_eval),
             z_eval,
-            &sigma_1_eval,
-            &sigma_2_eval,
-            &sigma_3_eval,
+            sigma_1_eval,
+            sigma_2_eval,
+            sigma_3_eval,
             (alpha, beta, gamma),
             &self.fourth_sigma.0,
         );


### PR DESCRIPTION
**Note**: with `Constraint::mul` we introduced an ambiguity that I didn't think matter, since usually the `Mul` trait is used via `*` operator.
However, people seeing a `mul(...)` method may expect `*` to work equally, as stated [here](https://rust-lang.github.io/rust-clippy/master/index.html#should_implement_trait), so maybe we should change the name of the method (such as `multi`, to keep it short, or fall back to the original `multiplication`).

Resolves: #611
