### PR TITLE
Update `Constraint` to take witness value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `StandardComposer` to `TurboComposer`. [#288](https://github.com/dusk-network/plonk/issue/288)
 - Change `TurboComposer` to consistent API. [#587](https://github.com/dusk-network/plonk/issue/587)
 - Change `plonkup_gate` to use public inputs. [#584](https://github.com/dusk-network/plonk/issue/584)
+- Change `Constraint` to accept witness args. [#624](https://github.com/dusk-network/plonk/issue/624)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -43,15 +43,11 @@ impl Circuit for TestCircuit {
         let constraint = Constraint::new()
             .left(1)
             .right(1)
-            .public(-self.c);
+            .public(-self.c)
+            .a(a)
+            .b(b);
 
-        composer.append_gate(
-            a,
-            b,
-            composer.constant_zero(),
-            composer.constant_zero(),
-            constraint,
-        );
+        composer.append_gate(constraint);
 
         // Check that a and b are in range
         composer.component_range(a, 1 << 6);
@@ -59,17 +55,13 @@ impl Circuit for TestCircuit {
 
         // Make second constraint a * b = d
         let constraint = Constraint::new()
-            .mul(1)
+            .mult(1)
             .output(1)
-            .public(-self.d);
+            .public(-self.d)
+            .a(a)
+            .b(b);
 
-        composer.append_gate(
-            a,
-            b,
-            composer.constant_zero(),
-            composer.constant_zero(),
-            constraint,
-        );
+        composer.append_gate(constraint);
 
         let e = composer.append_witness(self.e);
         let scalar_mul_result = composer

--- a/benches/plonk.rs
+++ b/benches/plonk.rs
@@ -33,7 +33,7 @@ impl Circuit for BenchCircuit {
         let mut b = BlsScalar::from(3u64);
         let mut c;
 
-        let zero = composer.constant_zero();
+        let zero = TurboComposer::constant_zero();
 
         while composer.gates() < self.padded_gates() {
             a += BlsScalar::one();
@@ -45,13 +45,16 @@ impl Circuit for BenchCircuit {
             let z = composer.append_witness(c);
 
             let constraint = Constraint::new()
-                .mul(1)
+                .mult(1)
                 .left(1)
                 .right(1)
                 .output(-BlsScalar::one())
-                .constant(1);
+                .constant(1)
+                .a(x)
+                .b(y)
+                .o(z);
 
-            composer.append_gate(x, y, z, zero, constraint);
+            composer.append_gate(constraint);
         }
 
         Ok(())

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -152,7 +152,7 @@ impl VerifierData {
 ///         composer: &mut TurboComposer,
 ///     ) -> Result<(), Error> {
 ///         // Add fixed witness zero
-///         let zero = composer.constant_zero();
+///         let zero = TurboComposer::constant_zero();
 ///         let a = composer.append_witness(self.a);
 ///         let b = composer.append_witness(self.b);
 ///
@@ -160,15 +160,11 @@ impl VerifierData {
 ///         let constraint = Constraint::new()
 ///             .left(1)
 ///             .right(1)
-///             .public(-self.c);
+///             .public(-self.c)
+///             .a(a)
+///             .b(b);
 ///
-///         composer.append_gate(
-///             a,
-///             b,
-///             zero,
-///             zero,
-///             constraint,
-///         );
+///         composer.append_gate(constraint);
 ///
 ///         // Check that a and b are in range
 ///         composer.component_range(a, 1 << 6);
@@ -176,17 +172,13 @@ impl VerifierData {
 ///
 ///         // Make second constraint a * b = d
 ///         let constraint = Constraint::new()
-///             .mul(1)
+///             .mult(1)
 ///             .output(1)
-///             .public(-self.d);
+///             .public(-self.d)
+///             .a(a)
+///             .b(b);
 ///
-///         composer.append_gate(
-///             a,
-///             b,
-///             zero,
-///             zero,
-///             constraint,
-///         );
+///         composer.append_gate(constraint);
 ///
 ///         let e = composer.append_witness(self.e);
 ///         let scalar_mul_result =

--- a/src/constraint_system.rs
+++ b/src/constraint_system.rs
@@ -16,7 +16,7 @@ pub(crate) mod logic;
 pub(crate) mod range;
 pub(crate) mod witness;
 
-pub(crate) use constraint::Selector;
+pub(crate) use constraint::{Selector, WiredWitness};
 pub(crate) use witness::WireData;
 
 mod arithmetic;

--- a/src/constraint_system/arithmetic.rs
+++ b/src/constraint_system/arithmetic.rs
@@ -10,36 +10,30 @@ use dusk_bls12_381::BlsScalar;
 impl TurboComposer {
     /// Evaluate and return `o` by appending a new constraint into the circuit.
     ///
+    /// The output of the constraint will be overwritten with
     /// `o := q_l · a + q_r · b + q_4 · d + q_c + PI`
-    pub fn gate_add(
-        &mut self,
-        a: Witness,
-        b: Witness,
-        d: Witness,
-        s: Constraint,
-    ) -> Witness {
+    pub fn gate_add(&mut self, s: Constraint) -> Witness {
         let s = Constraint::arithmetic(&s).output(-BlsScalar::one());
-        let o = self.append_output_witness(a, b, d, s);
 
-        self.append_gate(a, b, o, d, s);
+        let o = self.append_output_witness(s);
+        let s = s.o(o);
+
+        self.append_gate(s);
 
         o
     }
 
     /// Evaluate and return `o` by appending a new constraint into the circuit.
     ///
+    /// The output of the constraint will be overwritten with
     /// `o := q_m · a · b + q_4 · d + q_c + PI`
-    pub fn gate_mul(
-        &mut self,
-        a: Witness,
-        b: Witness,
-        d: Witness,
-        s: Constraint,
-    ) -> Witness {
+    pub fn gate_mul(&mut self, s: Constraint) -> Witness {
         let s = Constraint::arithmetic(&s).output(-BlsScalar::one());
-        let o = self.append_output_witness(a, b, d, s);
 
-        self.append_gate(a, b, o, d, s);
+        let o = self.append_output_witness(s);
+        let s = s.o(o);
+
+        self.append_gate(s);
 
         o
     }
@@ -48,22 +42,20 @@ impl TurboComposer {
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
-    use crate::constraint_system::helper::*;
-    use crate::constraint_system::Constraint;
+    use crate::constraint_system::{helper, Constraint};
     use dusk_bls12_381::BlsScalar;
 
     #[test]
     fn test_public_inputs() {
-        gadget_tester(
+        helper::gadget_tester(
             |composer| {
                 let one = composer.append_witness(BlsScalar::one());
-                let zero = composer.constant_zero();
 
                 composer.append_dummy_gates();
 
-                let constraint = Constraint::new().left(1).right(1).public(1);
-                let should_be_three =
-                    composer.gate_add(one, one, zero, constraint);
+                let constraint =
+                    Constraint::new().left(1).right(1).public(1).a(one).b(one);
+                let should_be_three = composer.gate_add(constraint);
 
                 composer.assert_equal_constant(
                     should_be_three,
@@ -71,9 +63,9 @@ mod tests {
                     None,
                 );
 
-                let constraint = Constraint::new().left(1).right(1).public(2);
-                let should_be_four =
-                    composer.gate_add(one, one, zero, constraint);
+                let constraint =
+                    Constraint::new().left(1).right(1).public(2).a(one).b(one);
+                let should_be_four = composer.gate_add(constraint);
 
                 composer.assert_equal_constant(
                     should_be_four,
@@ -88,19 +80,31 @@ mod tests {
 
     #[test]
     fn test_correct_add_mul_gate() {
-        let res = gadget_tester(
+        let res = helper::gadget_tester(
             |composer| {
                 // Verify that (4+5+5) * (6+7+7) = 280
                 let four = composer.append_witness(BlsScalar::from(4));
                 let five = composer.append_witness(BlsScalar::from(5));
                 let six = composer.append_witness(BlsScalar::from(6));
                 let seven = composer.append_witness(BlsScalar::from(7));
-                let zero = composer.constant_zero();
 
-                let constraint = Constraint::new().left(1).right(1).fourth(1);
+                let constraint = Constraint::new()
+                    .left(1)
+                    .right(1)
+                    .fourth(1)
+                    .a(four)
+                    .b(five)
+                    .d(five);
+                let fourteen = composer.gate_add(constraint);
 
-                let fourteen = composer.gate_add(four, five, five, constraint);
-                let twenty = composer.gate_add(six, seven, seven, constraint);
+                let constraint = Constraint::new()
+                    .left(1)
+                    .right(1)
+                    .fourth(1)
+                    .a(six)
+                    .b(seven)
+                    .d(seven);
+                let twenty = composer.gate_add(constraint);
 
                 // There are quite a few ways to check the equation is correct,
                 // depending on your circumstance If we already
@@ -109,9 +113,9 @@ mod tests {
                 // can compute it using the `mul` If the output
                 // is public, we can also constrain the output wire of the mul
                 // gate to it. This is what this test does
-                let constraint = Constraint::new().mul(1);
-                let output =
-                    composer.gate_mul(fourteen, twenty, zero, constraint);
+                let constraint =
+                    Constraint::new().mult(1).a(fourteen).b(twenty);
+                let output = composer.gate_mul(constraint);
 
                 composer.assert_equal_constant(
                     output,
@@ -126,24 +130,23 @@ mod tests {
 
     #[test]
     fn test_correct_add_gate() {
-        let res = gadget_tester(
+        helper::gadget_tester(
             |composer| {
-                let zero = composer.constant_zero();
                 let one = composer.append_witness(BlsScalar::one());
 
-                let constraint = Constraint::new().left(1).constant(2);
-                let c = composer.gate_add(one, zero, zero, constraint);
+                let constraint = Constraint::new().left(1).constant(2).a(one);
+                let c = composer.gate_add(constraint);
 
                 composer.assert_equal_constant(c, BlsScalar::from(3), None);
             },
             32,
-        );
-        assert!(res.is_ok())
+        )
+        .expect("Circuit consistency failed");
     }
 
     #[test]
     fn test_correct_big_add_mul_gate() {
-        let res = gadget_tester(
+        let res = helper::gadget_tester(
             |composer| {
                 // Verify that (4+5+5) * (6+7+7) + (8*9) = 352
                 let four = composer.append_witness(BlsScalar::from(4));
@@ -152,14 +155,31 @@ mod tests {
                 let seven = composer.append_witness(BlsScalar::from(7));
                 let nine = composer.append_witness(BlsScalar::from(9));
 
-                let constraint = Constraint::new().left(1).right(1).fourth(1);
+                let constraint = Constraint::new()
+                    .left(1)
+                    .right(1)
+                    .fourth(1)
+                    .a(four)
+                    .b(five)
+                    .d(five);
+                let fourteen = composer.gate_add(constraint);
 
-                let fourteen = composer.gate_add(four, five, five, constraint);
-                let twenty = composer.gate_add(six, seven, seven, constraint);
+                let constraint = Constraint::new()
+                    .left(1)
+                    .right(1)
+                    .fourth(1)
+                    .a(six)
+                    .b(seven)
+                    .d(seven);
+                let twenty = composer.gate_add(constraint);
 
-                let constraint = Constraint::new().mul(1).fourth(8);
-                let output =
-                    composer.gate_mul(fourteen, twenty, nine, constraint);
+                let constraint = Constraint::new()
+                    .mult(1)
+                    .fourth(8)
+                    .a(fourteen)
+                    .b(twenty)
+                    .d(nine);
+                let output = composer.gate_mul(constraint);
 
                 composer.assert_equal_constant(
                     output,
@@ -174,28 +194,26 @@ mod tests {
 
     #[test]
     fn test_incorrect_add_mul_gate() {
-        let res = gadget_tester(
+        let res = helper::gadget_tester(
             |composer| {
                 // Verify that (5+5) * (6+7) != 117
                 let five = composer.append_witness(BlsScalar::from(5));
                 let six = composer.append_witness(BlsScalar::from(6));
                 let seven = composer.append_witness(BlsScalar::from(7));
-                let zero = composer.constant_zero();
 
-                let constraint = Constraint::new().left(1).right(1);
-                let five_plus_five =
-                    composer.gate_add(five, five, zero, constraint);
+                let constraint =
+                    Constraint::new().left(1).right(1).a(five).b(five);
+                let five_plus_five = composer.gate_add(constraint);
 
-                let six_plus_seven =
-                    composer.gate_add(six, seven, zero, constraint);
+                let constraint =
+                    Constraint::new().left(1).right(1).a(six).b(seven);
+                let six_plus_seven = composer.gate_add(constraint);
 
-                let constraint = Constraint::new().mul(1);
-                let output = composer.gate_mul(
-                    five_plus_five,
-                    six_plus_seven,
-                    zero,
-                    constraint,
-                );
+                let constraint = Constraint::new()
+                    .mult(1)
+                    .a(five_plus_five)
+                    .b(six_plus_seven);
+                let output = composer.gate_mul(constraint);
 
                 composer.assert_equal_constant(
                     output,

--- a/src/constraint_system/boolean.rs
+++ b/src/constraint_system/boolean.rs
@@ -15,28 +15,35 @@ impl TurboComposer {
     /// Note that using this constraint with whatever [`Witness`] that
     /// is not representing a value equalling 0 or 1, will always force the
     /// equation to fail.
-    pub fn gate_boolean(&mut self, a: Witness) {
-        let zero = self.constant_zero();
-        let constraint = Constraint::new().mul(1).output(-BlsScalar::one());
+    pub fn component_boolean(&mut self, a: Witness) {
+        let zero = Self::constant_zero();
+        let constraint = Constraint::new()
+            .mult(1)
+            .output(-BlsScalar::one())
+            .a(a)
+            .b(a)
+            .o(a)
+            .d(zero);
 
-        self.append_gate(a, a, a, zero, constraint);
+        self.append_gate(constraint);
     }
 }
 
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
-    use super::super::helper::*;
+    use crate::constraint_system::{helper, TurboComposer};
     use dusk_bls12_381::BlsScalar;
+
     #[test]
     fn test_correct_bool_gate() {
-        let res = gadget_tester(
+        let res = helper::gadget_tester(
             |composer| {
-                let zero = composer.constant_zero();
+                let zero = TurboComposer::constant_zero();
                 let one = composer.append_witness(BlsScalar::one());
 
-                composer.gate_boolean(zero);
-                composer.gate_boolean(one);
+                composer.component_boolean(zero);
+                composer.component_boolean(one);
             },
             32,
         );
@@ -45,13 +52,13 @@ mod tests {
 
     #[test]
     fn test_incorrect_bool_gate() {
-        let res = gadget_tester(
+        let res = helper::gadget_tester(
             |composer| {
                 let zero = composer.append_witness(BlsScalar::from(5));
                 let one = composer.append_witness(BlsScalar::one());
 
-                composer.gate_boolean(zero);
-                composer.gate_boolean(one);
+                composer.component_boolean(zero);
+                composer.component_boolean(one);
             },
             32,
         );

--- a/src/constraint_system/ecc/scalar_mul/fixed_base.rs
+++ b/src/constraint_system/ecc/scalar_mul/fixed_base.rs
@@ -140,14 +140,9 @@ impl TurboComposer {
 
         // FIXME this gate isn't verifying anything because all the selectors
         // are zeroed. Validate what was the intent
-        let constraint = Constraint::new();
-        self.append_gate(
-            acc_x,
-            acc_y,
-            self.constant_zero(),
-            last_accumulated_bit,
-            constraint,
-        );
+        let constraint =
+            Constraint::new().a(acc_x).b(acc_y).d(last_accumulated_bit);
+        self.append_gate(constraint);
 
         // Constrain the last element in the accumulator to be equal to the
         // input jubjub scalar

--- a/src/constraint_system/ecc/scalar_mul/variable_base.rs
+++ b/src/constraint_system/ecc/scalar_mul/variable_base.rs
@@ -28,43 +28,6 @@ impl TurboComposer {
 
         result
     }
-
-    /*
-    fn scalar_decomposition(&mut self, witness: Witness) -> Vec<Witness> {
-        // Decompose the bits
-        let scalar_bits = self.gate_decomposition(witness);
-
-        // Take the first 252 bits
-        let scalar_bits_witness = scalar_bits[..252].to_vec();
-
-        // Now ensure that the bits correctly accumulate to the witness given
-        let mut accumulator_witness = self.constant_zero();
-        let mut accumulator_scalar = BlsScalar::zero();
-
-        for (power, bit) in scalar_bits_witness.iter().enumerate() {
-            self.gate_boolean(*bit);
-
-            let two_pow = BlsScalar::pow_of_2(power as u64);
-
-            accumulator_witness = self.gate_add(
-                *bit,
-                accumulator_witness,
-                self.constant_zero(),
-                two_pow,
-                BlsScalar::one(),
-                BlsScalar::zero(),
-                BlsScalar::zero(),
-                None,
-            );
-
-            accumulator_scalar += two_pow * self.witnesses[&scalar_bits[power]];
-        }
-
-        self.assert_equal(accumulator_witness, witness);
-
-        scalar_bits_witness
-    }
-    */
 }
 
 #[cfg(feature = "std")]

--- a/src/constraint_system/helper.rs
+++ b/src/constraint_system/helper.rs
@@ -17,12 +17,12 @@ use rand_core::OsRng;
 pub(crate) fn dummy_gadget(n: usize, composer: &mut TurboComposer) {
     let one = BlsScalar::one();
     let one = composer.append_witness(one);
-    let zero = composer.constant_zero();
 
     for _ in 0..n {
         // FIXME dummy gates with zeroed selectors doesn't make sense
-        let constraint = Constraint::new().left(1).right(1);
-        composer.gate_add(one, one, zero, constraint);
+        let constraint = Constraint::new().left(1).right(1).a(one).b(one);
+
+        composer.gate_add(constraint);
     }
 }
 
@@ -31,11 +31,11 @@ pub(crate) fn dummy_gadget_plonkup(n: usize, composer: &mut TurboComposer) {
     // FIXME duplicate of `dummy_gadget` for no clear reason
     let one = BlsScalar::one();
     let one = composer.append_witness(one);
-    let zero = composer.constant_zero();
 
     for _ in 0..n {
-        let constraint = Constraint::new().left(1).right(1);
-        composer.gate_add(one, one, zero, constraint);
+        let constraint = Constraint::new().left(1).right(1).a(one).b(one);
+
+        composer.gate_add(constraint);
     }
 }
 

--- a/src/constraint_system/logic.rs
+++ b/src/constraint_system/logic.rs
@@ -74,16 +74,18 @@ impl TurboComposer {
         // Now we can add the first row as: `| 0 | 0 | -- | 0 |`.
         // Note that `w_1` will be set on the first loop iteration.
         self.perm
-            .add_variable_to_map(self.constant_zero(), WireData::Left(self.n));
-        self.perm
-            .add_variable_to_map(self.constant_zero(), WireData::Right(self.n));
+            .add_variable_to_map(Self::constant_zero(), WireData::Left(self.n));
         self.perm.add_variable_to_map(
-            self.constant_zero(),
+            Self::constant_zero(),
+            WireData::Right(self.n),
+        );
+        self.perm.add_variable_to_map(
+            Self::constant_zero(),
             WireData::Fourth(self.n),
         );
-        self.w_l.push(self.constant_zero());
-        self.w_r.push(self.constant_zero());
-        self.w_4.push(self.constant_zero());
+        self.w_l.push(Self::constant_zero());
+        self.w_r.push(Self::constant_zero());
+        self.w_4.push(Self::constant_zero());
         // Increase the gate index so we can add the following rows in the
         // correct order.
         self.n += 1;
@@ -221,10 +223,10 @@ impl TurboComposer {
         // the program memory will look like this:
         // | an  | bn  | --- | cn  |
         self.perm.add_variable_to_map(
-            self.constant_zero(),
+            Self::constant_zero(),
             WireData::Output(self.n - 1),
         );
-        self.w_o.push(self.constant_zero());
+        self.w_o.push(Self::constant_zero());
 
         // Now the wire values are set for each gate, indexed and mapped in the
         // `variable_map` inside of the `Permutation` struct.

--- a/src/constraint_system/range.rs
+++ b/src/constraint_system/range.rs
@@ -139,7 +139,7 @@ impl TurboComposer {
 
         // First we pad our gates by the necessary amount
         for i in 0..pad {
-            add_wire(self, i, self.constant_zero());
+            add_wire(self, i, Self::constant_zero());
         }
 
         for i in pad..=num_quads {
@@ -182,9 +182,9 @@ impl TurboComposer {
         // wire, which will be used in the gate before it
         // Furthermore, we set the left, right and output wires to zero
         *self.q_range.last_mut().unwrap() = BlsScalar::zero();
-        self.w_l.push(self.constant_zero());
-        self.w_r.push(self.constant_zero());
-        self.w_o.push(self.constant_zero());
+        self.w_l.push(Self::constant_zero());
+        self.w_r.push(Self::constant_zero());
+        self.w_o.push(Self::constant_zero());
 
         // Lastly, we must link the last accumulator value to the initial
         // witness This last constraint will pass as long as

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -815,23 +815,36 @@ mod test {
 
         let one = BlsScalar::one();
         let two = BlsScalar::from_raw([2, 0, 0, 0]);
-        let z = cs.constant_zero();
 
         // x1 * x4 = x2
-        let constraint = Constraint::new().mul(1).output(-one);
-        cs.append_gate(x1, x4, x2, z, constraint);
+        let constraint =
+            Constraint::new().mult(1).output(-one).a(x1).b(x4).o(x2);
+        cs.append_gate(constraint);
 
         // x1 + x3 = x2
-        let constraint = Constraint::new().left(1).right(1).output(-one);
-        cs.append_gate(x1, x3, x2, z, constraint);
+        let constraint = Constraint::new()
+            .left(1)
+            .right(1)
+            .output(-one)
+            .a(x1)
+            .b(x3)
+            .o(x2);
+        cs.append_gate(constraint);
 
         // x1 + x2 = 2*x3
-        let constraint = Constraint::new().left(1).right(1).output(-two);
-        cs.append_gate(x1, x2, x3, z, constraint);
+        let constraint = Constraint::new()
+            .left(1)
+            .right(1)
+            .output(-two)
+            .a(x1)
+            .b(x2)
+            .o(x3);
+        cs.append_gate(constraint);
 
         // x3 * x4 = 2*x2
-        let constraint = Constraint::new().mul(1).output(-two);
-        cs.append_gate(x3, x4, x2, z, constraint);
+        let constraint =
+            Constraint::new().mult(1).output(-two).a(x3).b(x4).o(x2);
+        cs.append_gate(constraint);
 
         let domain = EvaluationDomain::new(cs.gates()).unwrap();
         let pad = vec![BlsScalar::zero(); domain.size() - cs.w_l.len()];

--- a/src/proof_system/preprocess.rs
+++ b/src/proof_system/preprocess.rs
@@ -46,7 +46,7 @@ impl TurboComposer {
     fn pad(&mut self, diff: usize) {
         // Add a zero variable to circuit
         let zero_scalar = BlsScalar::zero();
-        let zero_var = self.constant_zero();
+        let zero_var = Self::constant_zero();
 
         let zeroes_scalar = vec![zero_scalar; diff];
         let zeroes_var = vec![zero_var; diff];

--- a/tests/circuit.rs
+++ b/tests/circuit.rs
@@ -36,28 +36,22 @@ impl Circuit for TestCircuit {
         let b = composer.append_witness(self.b);
 
         // Make first constraint a + b = c
-        let constraint = Constraint::new().left(1).right(1).public(-self.c);
-        composer.append_gate(
-            a,
-            b,
-            composer.constant_zero(),
-            composer.constant_zero(),
-            constraint,
-        );
+        let constraint =
+            Constraint::new().left(1).right(1).public(-self.c).a(a).b(b);
+        composer.append_gate(constraint);
 
         // Check that a and b are in range
         composer.component_range(a, 1 << 6);
         composer.component_range(b, 1 << 5);
 
         // Make second constraint a * b = d
-        let constraint = Constraint::new().mul(1).output(1).public(-self.d);
-        composer.append_gate(
-            a,
-            b,
-            composer.constant_zero(),
-            composer.constant_zero(),
-            constraint,
-        );
+        let constraint = Constraint::new()
+            .mult(1)
+            .output(1)
+            .public(-self.d)
+            .a(a)
+            .b(b);
+        composer.append_gate(constraint);
 
         let e = composer.append_witness(self.e);
         let scalar_mul_result = composer


### PR DESCRIPTION
Constraints contains also witness indexes. The `gate` functions are
supposed to take plain `Constraint`s while `component` functions can
receive witnesses and build internal constraints.

Resolves #624 
See also: #587 