### PR TITLE
Change to use `From<JubJubScalar>` for BlsScalar

### DIFF
--- a/src/constraint_system/ecc/scalar_mul/fixed_base.rs
+++ b/src/constraint_system/ecc/scalar_mul/fixed_base.rs
@@ -175,8 +175,7 @@ mod tests {
                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                     0, 0,
                 ]);
-                let bls_scalar =
-                    BlsScalar::from_bytes(&scalar.to_bytes()).unwrap();
+                let bls_scalar = BlsScalar::from(scalar);
                 let secret_scalar = composer.append_witness(bls_scalar);
 
                 let expected_point: JubJubAffine =
@@ -198,8 +197,7 @@ mod tests {
         let res = gadget_tester(
             |composer| {
                 let scalar = JubJubScalar::zero();
-                let bls_scalar =
-                    BlsScalar::from_bytes(&scalar.to_bytes()).unwrap();
+                let bls_scalar = BlsScalar::from(scalar);
                 let secret_scalar = composer.append_witness(bls_scalar);
 
                 let expected_point: JubJubAffine =
@@ -221,8 +219,7 @@ mod tests {
         let res = gadget_tester(
             |composer| {
                 let scalar = JubJubScalar::from(100u64);
-                let bls_scalar =
-                    BlsScalar::from_bytes(&scalar.to_bytes()).unwrap();
+                let bls_scalar = BlsScalar::from(scalar);
                 let secret_scalar = composer.append_witness(bls_scalar);
                 // Fails because we are not multiplying by the GENERATOR, it is
                 // double
@@ -291,16 +288,14 @@ mod tests {
             |composer| {
                 // First component
                 let scalar_a = JubJubScalar::from(112233u64);
-                let bls_scalar =
-                    BlsScalar::from_bytes(&scalar_a.to_bytes()).unwrap();
+                let bls_scalar = BlsScalar::from(scalar_a);
                 let secret_scalar_a = composer.append_witness(bls_scalar);
                 let point_a = GENERATOR_EXTENDED;
                 let c_a: JubJubAffine = (point_a * scalar_a).into();
 
                 // Second component
                 let scalar_b = JubJubScalar::from(445566u64);
-                let bls_scalar =
-                    BlsScalar::from_bytes(&scalar_b.to_bytes()).unwrap();
+                let bls_scalar = BlsScalar::from(scalar_b);
                 let secret_scalar_b = composer.append_witness(bls_scalar);
                 let point_b = point_a.double() + point_a;
                 let c_b: JubJubAffine = (point_b * scalar_b).into();
@@ -344,23 +339,19 @@ mod tests {
             |composer| {
                 // First component
                 let scalar_a = JubJubScalar::from(25u64);
-                let bls_scalar_a =
-                    BlsScalar::from_bytes(&scalar_a.to_bytes()).unwrap();
+                let bls_scalar_a = BlsScalar::from(scalar_a);
                 let secret_scalar_a = composer.append_witness(bls_scalar_a);
                 // Second component
                 let scalar_b = JubJubScalar::from(30u64);
-                let bls_scalar_b =
-                    BlsScalar::from_bytes(&scalar_b.to_bytes()).unwrap();
+                let bls_scalar_b = BlsScalar::from(scalar_b);
                 let secret_scalar_b = composer.append_witness(bls_scalar_b);
                 // Third component
                 let scalar_c = JubJubScalar::from(10u64);
-                let bls_scalar_c =
-                    BlsScalar::from_bytes(&scalar_c.to_bytes()).unwrap();
+                let bls_scalar_c = BlsScalar::from(scalar_c);
                 let secret_scalar_c = composer.append_witness(bls_scalar_c);
                 // Fourth component
                 let scalar_d = JubJubScalar::from(45u64);
-                let bls_scalar_d =
-                    BlsScalar::from_bytes(&scalar_d.to_bytes()).unwrap();
+                let bls_scalar_d = BlsScalar::from(scalar_d);
                 let secret_scalar_d = composer.append_witness(bls_scalar_d);
 
                 let gen = GENERATOR_EXTENDED;

--- a/src/constraint_system/ecc/scalar_mul/variable_base.rs
+++ b/src/constraint_system/ecc/scalar_mul/variable_base.rs
@@ -72,9 +72,9 @@ impl TurboComposer {
 mod tests {
     use crate::constraint_system::helper::*;
     use dusk_bls12_381::BlsScalar;
-    use dusk_bytes::Serializable;
     use dusk_jubjub::GENERATOR;
     use dusk_jubjub::{JubJubAffine, JubJubExtended, JubJubScalar};
+
     #[test]
     fn test_var_base_scalar_mul() {
         let res = gadget_tester(
@@ -86,8 +86,7 @@ mod tests {
                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                     0, 0,
                 ]);
-                let bls_scalar =
-                    BlsScalar::from_bytes(&scalar.to_bytes()).unwrap();
+                let bls_scalar = BlsScalar::from(scalar);
                 let secret_scalar = composer.append_witness(bls_scalar);
 
                 let expected_point: JubJubAffine =


### PR DESCRIPTION
Change all conversions to `BlsScalar` from `JubJubScalar` to use the `From`
implementation.

Resolves: #294