### PR TITLE
Add support for rendering LaTeX in the docs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[build]
+# Flags needed to render LaTeX in documentation
+# With this, `cargo docs` must be run with the `--no-deps` flag
+rustdocflags =  "--html-in-header ./docs/katex-header.html"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add support for rendering LaTeX in the docs [#630](https://github.com/dusk-network/plonk/pull/630)
+
 ## [0.9.0] - 10-11-21
 
 ### Added


### PR DESCRIPTION
Previously LaTeX wasn't rendered in the official documentation of
our crate. With this change a custom header is inserted in the
html-files for the documentation, allowing LaTeX generated code
to be rendered with KaTeX.

As a side-effect of this change, `cargo doc` needs to be run with
the `--no-deps` flag:
```
$ cargo doc --no-deps
```

Resolves: #567