### PR TITLE
Add `append_public_witness` to `TurboComposer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support for rendering LaTeX in the docs [#630](https://github.com/dusk-network/plonk/pull/630)
+- Add `append_public_witness` to `TurboComposer`. [#654](https://github.com/dusk-network/plonk/issues/654)
 
 ## [0.9.0] - 10-11-21
 

--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -242,6 +242,21 @@ impl TurboComposer {
         var
     }
 
+    /// Allocate a witness value into the composer and return its index.
+    ///
+    /// Create a public input with the scalar
+    pub fn append_public_witness<T: Into<BlsScalar>>(
+        &mut self,
+        scalar: T,
+    ) -> Witness {
+        let scalar = scalar.into();
+        let witness = self.append_witness(scalar);
+
+        self.assert_equal_constant(witness, 0, Some(-scalar));
+
+        witness
+    }
+
     /// Adds a width-4 poly gate.
     ///
     /// The final constraint added will enforce the following:
@@ -301,12 +316,13 @@ impl TurboComposer {
     /// Constrain `a` to be equal to `constant + pi`.
     ///
     /// `constant` will be defined as part of the public circuit description.
-    pub fn assert_equal_constant(
+    pub fn assert_equal_constant<C: Into<BlsScalar>>(
         &mut self,
         a: Witness,
-        constant: BlsScalar,
+        constant: C,
         pi: Option<BlsScalar>,
     ) {
+        let constant = constant.into();
         let constraint = Constraint::new().left(1).constant(-constant).a(a);
 
         // TODO maybe accept `Constraint` instead of `Option<Scalar>`?


### PR DESCRIPTION
We have available `append_public_point` for points, but we don't have
such method for witnesses. These will avoid unnecessary constraints for
the users.

It is desirable to have API consistency - the methods to append points
should reflect the ones to append public inputs.

Resolves #654