### PR TITLE
Fix verification time

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -368,5 +368,5 @@ pub fn verify(
 
     let opening_key = pub_params.opening_key();
 
-    verifier.verify(proof, opening_key, &dense_pi)
+    verifier.verify(proof, opening_key, &dense_pi, &pi_indexes)
 }

--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -802,8 +802,12 @@ mod tests {
         // Preprocess
         verifier.preprocess(&ck).unwrap();
 
+        let pi_indexes = verifier.composer_mut().public_input_indexes();
+
         for proof in proofs {
-            assert!(verifier.verify(&proof, &vk, &public_inputs).is_ok());
+            assert!(verifier
+                .verify(&proof, &vk, &public_inputs, &pi_indexes)
+                .is_ok());
         }
     }
 }

--- a/src/constraint_system/helper.rs
+++ b/src/constraint_system/helper.rs
@@ -76,6 +76,8 @@ pub(crate) fn gadget_tester(
     // Preprocess circuit
     verifier.preprocess(&ck)?;
 
+    let pi_indexes = verifier.composer_mut().public_input_indexes();
+
     // Verify proof
-    verifier.verify(&proof, &vk, &public_inputs)
+    verifier.verify(&proof, &vk, &public_inputs, &pi_indexes)
 }

--- a/src/proof_system/prover.rs
+++ b/src/proof_system/prover.rs
@@ -192,15 +192,11 @@ impl Prover {
         let mut transcript = self.preprocessed_transcript.clone();
 
         // PIs have to be part of the transcript
-        for pi in self.cs.to_dense_public_inputs().iter() {
-            transcript.append_scalar(b"pi", pi);
-        }
-
-        // We fill with zeros up to the domain size, in order to match the
-        // length of the vector used by the verifier in his side in the
-        // implementation
-        for _ in 0..(domain.size() - self.cs.to_dense_public_inputs().len()) {
-            transcript.append_scalar(b"pi", &BlsScalar::from(0u64));
+        for pi_index in self.cs.public_input_indexes().iter() {
+            transcript.append_scalar(
+                b"pi",
+                &self.cs.to_dense_public_inputs()[*pi_index],
+            );
         }
 
         //** ROUND 1 **********************************************************

--- a/src/proof_system/verifier.rs
+++ b/src/proof_system/verifier.rs
@@ -88,12 +88,13 @@ impl Verifier {
         proof: &Proof,
         opening_key: &OpeningKey,
         public_inputs: &[BlsScalar],
+        pi_indexes: &[usize],
     ) -> Result<(), Error> {
         let mut cloned_transcript = self.preprocessed_transcript.clone();
 
         // PIs have to be part of the transcript
-        for pi in public_inputs.iter() {
-            cloned_transcript.append_scalar(b"pi", pi);
+        for pi_index in pi_indexes.iter() {
+            cloned_transcript.append_scalar(b"pi", &public_inputs[*pi_index]);
         }
 
         let verifier_key = self.verifier_key.as_ref().unwrap();


### PR DESCRIPTION
The verification time was growing up with the circuit size, because the whole public inputs vector, which is padded with 0s up to the size of the domain, was put all of it into the transcript. We fixed it by putting only the real public inputs.