### PR TITLE
Fix error with the max degree of the SRS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,23 +10,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add the blinding factors to provide Zero-Knowledge [#650](https://github.com/dusk-network/plonk/issues/650)
-- Add the `public inputs` into the transcript [#676] (https://github.com/dusk-network/plonk/issues/676)
+- Add the `public inputs` into the transcript [#676](https://github.com/dusk-network/plonk/issues/676)
 
 ### Changed
 
 - Change variable names for more consistency with the paper [#631](https://github.com/dusk-network/plonk/issues/631)
 - Change `append_constant` to accept generic input [#672](https://github.com/dusk-network/plonk/issues/672)
 - Change `variable` to `witness` in permutation functions [#681](https://github.com/dusk-network/plonk/issues/681)
-- Change the `prover` and the `verifier` according to the original Plonk implementation [#684] (https://github.com/dusk-network/plonk/issues/684)
+- Change the `prover` and the `verifier` according to the original Plonk implementation [#684](https://github.com/dusk-network/plonk/issues/684)
 
 ### Removed
 
 - Remove `hash_tables` module [#663](https://github.com/dusk-network/plonk/pull/663)
-- Remove all `plonkup` related code [#684] (https://github.com/dusk-network/plonk/issues/684)
+- Remove all `plonkup` related code [#684](https://github.com/dusk-network/plonk/issues/684)
 
 ### Fixed
 
 - Fix `logic_gate` for `bit_num` = 256 [#678](https://github.com/dusk-network/plonk/pull/678)
+- Fix error when compiling some circuits [#690](https://github.com/dusk-network/plonk/issues/690)
 
 ## [0.10.0] - 24-02-22
 

--- a/benches/plonk.rs
+++ b/benches/plonk.rs
@@ -81,7 +81,7 @@ fn constraint_system_prove(
 
 fn constraint_system_benchmark(c: &mut Criterion) {
     let initial_degree = 5;
-    let final_degree = 18;
+    let final_degree = 17;
 
     let rng = &mut rand_core::OsRng;
     let label = b"dusk-network";
@@ -89,7 +89,7 @@ fn constraint_system_benchmark(c: &mut Criterion) {
         .expect("Failed to create PP");
 
     let data: Vec<(BenchCircuit, ProverKey, VerifierData, Proof)> =
-        (initial_degree..final_degree)
+        (initial_degree..=final_degree)
             .map(|degree| {
                 let mut circuit = BenchCircuit::from(degree as usize);
                 let (pk, vd) =

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -246,9 +246,6 @@ where
 {
     /// Circuit identifier associated constant.
     const CIRCUIT_ID: [u8; 32];
-    /// Extra size needed for the circuit parameters. + 6 because adding the
-    /// blinding factors requires some extra elements for the SRS
-    const PARAMS_EXTRA_SIZE: usize = 6;
 
     /// Gadget implementation used to fill the composer.
     fn gadget(&mut self, composer: &mut TurboComposer) -> Result<(), Error>;
@@ -260,8 +257,7 @@ where
         pub_params: &PublicParameters,
     ) -> Result<(ProverKey, VerifierData), Error> {
         // Setup PublicParams
-        let (ck, _) =
-            pub_params.trim(self.padded_gates() + Self::PARAMS_EXTRA_SIZE)?;
+        let (ck, _) = pub_params.trim(self.padded_gates())?;
 
         // Generate & save `ProverKey` with some random values.
         let mut prover = Prover::new(b"CircuitCompilation");
@@ -302,8 +298,7 @@ where
         transcript_init: &'static [u8],
         rng: &mut R,
     ) -> Result<Proof, Error> {
-        let (ck, _) =
-            pub_params.trim(self.padded_gates() + Self::PARAMS_EXTRA_SIZE)?;
+        let (ck, _) = pub_params.trim(self.padded_gates())?;
 
         // New Prover instance
         let mut prover = Prover::new(transcript_init);


### PR DESCRIPTION
Adding the blinding factors required some extra elements for the SRS: `+1` per each wire (we have 4 wires), plus `+2` for the permutation polynomial. There was a bug in the original commit, that caused errors when compiling some circuits. We fix it here by doing:

- In `srs.rs`, the `max_degree` in `setup()` is updated: `+ 6`
- In `srs.rs`, the truncated degree used in `trim()` is updated: `+ 6`.
- The `+ 6` used in `circuit.rs` has been removed as it is no longer required.
- We reverted a change in `benches/plonk.rs`, no longer required.