### PR TITLE
Fix math latex rendering on docs.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add makefile rule to render docs locally [#567]
 - `rkyv` implementation behind feature gate [#697]
 
 ### Changed
 
+- Fix math latex rendering on docs.rs [#567]
 - Update `dusk-bls12_381` to version `0.10`
 - Update `dusk-jubjub` to version `0.12`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,6 @@ overflow-checks = false
 lto = true
 incremental = false
 codegen-units = 1
+
+[package.metadata.docs.rs]
+rustdoc-args = [ "--html-in-header", "./docs/katex-header.html" ]

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,7 @@ doc: ## Generate documentation
 doc-internal: ## Generate documentation with private items
 	@cargo rustdoc --lib -- --document-private-items -D warnings
 
-.PHONY: help doc doc-internal 
+doc-local: ## Open local documentation
+	@RUSTDOCFLAGS="--html-in-header docs/katex-header.html" cargo doc --no-deps --open
+
+.PHONY: help doc doc-internal doc-local


### PR DESCRIPTION
With this PR the math finally should render on docs.rs. 
There is also the make rule `make docs-local` added that opens the docs from the current branch locally.

Resolves: #567