### PR TITLE
Add `CheckBytes` implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fix math latex rendering on docs.rs [#567]
-- Update `dusk-bls12_381` to version `0.10`
+- Update `dusk-bls12_381` to version `0.11`
 - Update `dusk-jubjub` to version `0.12`
 
 ## [0.11.0] - 2022-06-15

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-plonk"
-version = "0.12.0-rc.0"
+version = "0.12.0-rc.1"
 categories =["algorithms", "cryptography", "science", "mathematics"]
 edition = "2021"
 keywords = ["cryptography", "plonk", "zk-snarks", "zero-knowledge", "crypto"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ exclude = [
 merlin = {version = "3.0", default-features = false}
 rand_core = {version="0.6", default-features=false}
 dusk-bytes = "0.1"
-dusk-bls12_381 = {version = "0.10", default-features = false, features = ["groups", "pairings", "endo"]}
-dusk-jubjub = {version = "0.12.0-rc.0", default-features = false}
+dusk-bls12_381 = {version = "0.11.0-rc", default-features = false, features = ["groups", "pairings", "endo"]}
+dusk-jubjub = {version = "0.12.0-rc", default-features = false}
 itertools = {version = "0.9", default-features = false}
 hashbrown = {version = "0.9", default-features=false, features = ["ahash"]}
 rayon = {version = "1.3", optional = true}
@@ -30,6 +30,7 @@ cfg-if = "1.0"
 canonical = {version = "0.7", optional = true}
 canonical_derive = {version = "0.7", optional = true}
 rkyv = {version = "0.7", optional = true}
+bytecheck = {version = "0.6", optional = true}
 
 [dev-dependencies]
 criterion = "0.3"
@@ -54,7 +55,7 @@ alloc = ["dusk-bls12_381/alloc"]
 trace = []
 trace-print = ["trace"]
 canon = ["dusk-bls12_381/canon", "dusk-jubjub/canon", "canonical", "canonical_derive"]
-rkyv-impl = ["dusk-bls12_381/rkyv", "dusk-jubjub/rkyv-impl", "rkyv"]
+rkyv-impl = ["dusk-bls12_381/rkyv-impl", "dusk-jubjub/rkyv-impl", "rkyv", "bytecheck"]
 
 [profile.release]
 panic = "abort"

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -19,6 +19,8 @@ use dusk_jubjub::{JubJubAffine, JubJubExtended, JubJubScalar};
 use rand_core::{CryptoRng, RngCore};
 
 #[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
 use rkyv::{
     ser::{ScratchSpace, Serializer},
     Archive, Deserialize, Serialize,
@@ -31,7 +33,8 @@ use rkyv::{
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub struct PublicInputValue(
     #[cfg_attr(feature = "rkyv-impl", omit_bounds)] pub(crate) Vec<BlsScalar>,
@@ -69,7 +72,8 @@ impl From<JubJubExtended> for PublicInputValue {
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub struct VerifierData {
     #[cfg_attr(feature = "rkyv-impl", omit_bounds)]

--- a/src/commitment_scheme/kzg10/commitment.rs
+++ b/src/commitment_scheme/kzg10/commitment.rs
@@ -9,6 +9,8 @@ use dusk_bls12_381::{G1Affine, G1Projective};
 use dusk_bytes::{DeserializableSlice, Serializable};
 
 #[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
 use rkyv::{
     ser::{ScratchSpace, Serializer},
     Archive, Deserialize, Serialize,
@@ -20,7 +22,8 @@ use rkyv::{
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub(crate) struct Commitment(
     /// The commitment is a group element.

--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -20,6 +20,8 @@ use dusk_bytes::{DeserializableSlice, Serializable};
 use merlin::Transcript;
 
 #[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
 use rkyv::{
     ser::{ScratchSpace, Serializer},
     Archive, Deserialize, Serialize,
@@ -31,7 +33,8 @@ use rkyv::{
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub struct CommitKey {
     /// Group elements of the form `{ \beta^i G }`, where `i` ranges from 0 to
@@ -213,7 +216,8 @@ impl CommitKey {
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Sized + Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Sized + Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 // TODO remove the `Sized` bound on the serializer
 pub struct OpeningKey {

--- a/src/commitment_scheme/kzg10/srs.rs
+++ b/src/commitment_scheme/kzg10/srs.rs
@@ -14,6 +14,8 @@ use dusk_bytes::{DeserializableSlice, Serializable};
 use rand_core::{CryptoRng, RngCore};
 
 #[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
 use rkyv::{
     ser::{ScratchSpace, Serializer},
     Archive, Deserialize, Serialize,
@@ -27,7 +29,8 @@ use rkyv::{
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Sized + Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Sized + Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 // TODO remove the `Sized` bound on the serializer
 pub struct PublicParameters {

--- a/src/fft/domain.rs
+++ b/src/fft/domain.rs
@@ -16,6 +16,8 @@ use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Serializable};
 
 #[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
 use rkyv::{
     ser::{ScratchSpace, Serializer},
     Archive, Deserialize, Serialize,
@@ -28,7 +30,8 @@ use rkyv::{
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub(crate) struct EvaluationDomain {
     /// The size of the domain.

--- a/src/fft/evaluations.rs
+++ b/src/fft/evaluations.rs
@@ -17,6 +17,8 @@ use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Serializable};
 
 #[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
 use rkyv::{
     ser::{ScratchSpace, Serializer},
     Archive, Deserialize, Serialize,
@@ -27,7 +29,8 @@ use rkyv::{
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub(crate) struct Evaluations {
     /// The evaluations of a polynomial over the domain `D`

--- a/src/fft/polynomial.rs
+++ b/src/fft/polynomial.rs
@@ -16,6 +16,8 @@ use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Serializable};
 
 #[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
 use rkyv::{
     ser::{ScratchSpace, Serializer},
     Archive, Deserialize, Serialize,
@@ -26,7 +28,8 @@ use rkyv::{
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub(crate) struct Polynomial {
     /// The coefficient of `x^i` is stored at location `i` in `self.coeffs`.

--- a/src/proof_system/linearization_poly.rs
+++ b/src/proof_system/linearization_poly.rs
@@ -14,6 +14,8 @@ use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Serializable};
 
 #[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
 use rkyv::{
     ser::{ScratchSpace, Serializer},
     Archive, Deserialize, Serialize,
@@ -33,7 +35,8 @@ pub(crate) struct Evaluations {
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub(crate) struct ProofEvaluations {
     // Evaluation of the witness polynomial for the left wire at `z`

--- a/src/proof_system/widget/arithmetic/proverkey.rs
+++ b/src/proof_system/widget/arithmetic/proverkey.rs
@@ -8,6 +8,8 @@ use crate::fft::{Evaluations, Polynomial};
 use dusk_bls12_381::BlsScalar;
 
 #[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
 use rkyv::{
     ser::{ScratchSpace, Serializer},
     Archive, Deserialize, Serialize,
@@ -17,7 +19,8 @@ use rkyv::{
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub(crate) struct ProverKey {
     #[cfg_attr(feature = "rkyv-impl", omit_bounds)]

--- a/src/proof_system/widget/arithmetic/verifierkey.rs
+++ b/src/proof_system/widget/arithmetic/verifierkey.rs
@@ -8,6 +8,8 @@ use crate::commitment_scheme::Commitment;
 use dusk_bytes::{DeserializableSlice, Serializable};
 
 #[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
 use rkyv::{
     ser::{ScratchSpace, Serializer},
     Archive, Deserialize, Serialize,
@@ -17,7 +19,8 @@ use rkyv::{
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub(crate) struct VerifierKey {
     #[cfg_attr(feature = "rkyv-impl", omit_bounds)]

--- a/src/proof_system/widget/ecc/curve_addition/proverkey.rs
+++ b/src/proof_system/widget/ecc/curve_addition/proverkey.rs
@@ -9,6 +9,8 @@ use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::EDWARDS_D;
 
 #[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
 use rkyv::{
     ser::{ScratchSpace, Serializer},
     Archive, Deserialize, Serialize,
@@ -18,7 +20,8 @@ use rkyv::{
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub(crate) struct ProverKey {
     #[cfg_attr(feature = "rkyv-impl", omit_bounds)]

--- a/src/proof_system/widget/ecc/curve_addition/verifierkey.rs
+++ b/src/proof_system/widget/ecc/curve_addition/verifierkey.rs
@@ -7,6 +7,8 @@
 use crate::commitment_scheme::Commitment;
 
 #[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
 use rkyv::{
     ser::{ScratchSpace, Serializer},
     Archive, Deserialize, Serialize,
@@ -16,7 +18,8 @@ use rkyv::{
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub(crate) struct VerifierKey {
     #[cfg_attr(feature = "rkyv-impl", omit_bounds)]

--- a/src/proof_system/widget/ecc/scalar_mul/fixed_base/proverkey.rs
+++ b/src/proof_system/widget/ecc/scalar_mul/fixed_base/proverkey.rs
@@ -9,6 +9,8 @@ use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::EDWARDS_D;
 
 #[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
 use rkyv::{
     ser::{ScratchSpace, Serializer},
     Archive, Deserialize, Serialize,
@@ -18,7 +20,8 @@ use rkyv::{
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub(crate) struct ProverKey {
     #[cfg_attr(feature = "rkyv-impl", omit_bounds)]

--- a/src/proof_system/widget/ecc/scalar_mul/fixed_base/verifierkey.rs
+++ b/src/proof_system/widget/ecc/scalar_mul/fixed_base/verifierkey.rs
@@ -7,6 +7,8 @@
 use crate::commitment_scheme::Commitment;
 
 #[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
 use rkyv::{
     ser::{ScratchSpace, Serializer},
     Archive, Deserialize, Serialize,
@@ -16,7 +18,8 @@ use rkyv::{
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub(crate) struct VerifierKey {
     #[cfg_attr(feature = "rkyv-impl", omit_bounds)]

--- a/src/proof_system/widget/logic/proverkey.rs
+++ b/src/proof_system/widget/logic/proverkey.rs
@@ -9,6 +9,8 @@ use crate::fft::{Evaluations, Polynomial};
 use dusk_bls12_381::BlsScalar;
 
 #[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
 use rkyv::{
     ser::{ScratchSpace, Serializer},
     Archive, Deserialize, Serialize,
@@ -18,7 +20,8 @@ use rkyv::{
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub(crate) struct ProverKey {
     #[cfg_attr(feature = "rkyv-impl", omit_bounds)]

--- a/src/proof_system/widget/logic/verifierkey.rs
+++ b/src/proof_system/widget/logic/verifierkey.rs
@@ -7,6 +7,8 @@
 use crate::commitment_scheme::Commitment;
 
 #[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
 use rkyv::{
     ser::{ScratchSpace, Serializer},
     Archive, Deserialize, Serialize,
@@ -16,7 +18,8 @@ use rkyv::{
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub(crate) struct VerifierKey {
     #[cfg_attr(feature = "rkyv-impl", omit_bounds)]

--- a/src/proof_system/widget/permutation/proverkey.rs
+++ b/src/proof_system/widget/permutation/proverkey.rs
@@ -9,6 +9,8 @@ use crate::permutation::constants::{K1, K2, K3};
 use dusk_bls12_381::BlsScalar;
 
 #[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
 use rkyv::{
     ser::{ScratchSpace, Serializer},
     Archive, Deserialize, Serialize,
@@ -18,7 +20,8 @@ use rkyv::{
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub(crate) struct ProverKey {
     #[cfg_attr(feature = "rkyv-impl", omit_bounds)]

--- a/src/proof_system/widget/permutation/verifierkey.rs
+++ b/src/proof_system/widget/permutation/verifierkey.rs
@@ -7,6 +7,8 @@
 use crate::commitment_scheme::Commitment;
 
 #[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
 use rkyv::{
     ser::{ScratchSpace, Serializer},
     Archive, Deserialize, Serialize,
@@ -16,7 +18,8 @@ use rkyv::{
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub(crate) struct VerifierKey {
     #[cfg_attr(feature = "rkyv-impl", omit_bounds)]

--- a/src/proof_system/widget/range/proverkey.rs
+++ b/src/proof_system/widget/range/proverkey.rs
@@ -8,6 +8,8 @@ use crate::fft::{Evaluations, Polynomial};
 use dusk_bls12_381::BlsScalar;
 
 #[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
 use rkyv::{
     ser::{ScratchSpace, Serializer},
     Archive, Deserialize, Serialize,
@@ -17,7 +19,8 @@ use rkyv::{
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub(crate) struct ProverKey {
     #[cfg_attr(feature = "rkyv-impl", omit_bounds)]

--- a/src/proof_system/widget/range/verifierkey.rs
+++ b/src/proof_system/widget/range/verifierkey.rs
@@ -7,6 +7,8 @@
 use crate::commitment_scheme::Commitment;
 
 #[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
 use rkyv::{
     ser::{ScratchSpace, Serializer},
     Archive, Deserialize, Serialize,
@@ -16,7 +18,8 @@ use rkyv::{
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub(crate) struct VerifierKey {
     #[cfg_attr(feature = "rkyv-impl", omit_bounds)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,6 +10,25 @@ use dusk_bls12_381::{
 };
 use rand_core::{CryptoRng, RngCore};
 
+#[cfg(feature = "rkyv-impl")]
+#[inline(always)]
+pub unsafe fn check_field<F, C>(
+    field: *const F,
+    context: &mut C,
+    field_name: &'static str,
+) -> Result<(), bytecheck::StructCheckError>
+where
+    F: bytecheck::CheckBytes<C>,
+{
+    F::check_bytes(field, context).map_err(|e| {
+        bytecheck::StructCheckError {
+            field_name,
+            inner: bytecheck::ErrorBox::new(e),
+        }
+    })?;
+    Ok(())
+}
+
 /// Returns a vector of BlsScalars of increasing powers of x from x^0 to x^d.
 pub(crate) fn powers_of(
     scalar: &BlsScalar,


### PR DESCRIPTION
This is required to ensure the structures can pass through the VM argument border.

This required some manual implementations due to internal types being exposed otherwise with the `derive`.