### PR TITLE
Remove `rkyv` validation feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove manual implementation of `CheckBytes` for `ArchivedProverKey`. This
+  is necessary since `rkyv/validation` was required as a bound.
+
 ## [0.13.0] - 2022-10-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ dusk-cdf = {version = "0.5", optional = true}
 criterion = "0.3"
 tempdir = "0.3"
 rand = "0.8"
+rkyv = {version = "0.7", default-features = false, features = ["size_32"]}
 
 [[bench]]
 name = "plonk"

--- a/src/proof_system/widget.rs
+++ b/src/proof_system/widget.rs
@@ -248,7 +248,8 @@ pub(crate) mod alloc {
     #[cfg_attr(
         feature = "rkyv-impl",
         derive(Archive, Deserialize, Serialize),
-        archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+        archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+        archive_attr(derive(CheckBytes))
     )]
     pub struct ProverKey {
         /// Circuit size
@@ -279,31 +280,6 @@ pub(crate) mod alloc {
         // polynomial without having to perform IFFT
         #[cfg_attr(feature = "rkyv-impl", omit_bounds)]
         pub(crate) v_h_coset_8n: Evaluations,
-    }
-
-    #[cfg(feature = "rkyv-impl")]
-    impl<C> CheckBytes<C> for ArchivedProverKey
-    where
-        C: rkyv::validation::ArchiveContext,
-        C::Error: bytecheck::Error,
-    {
-        type Error = StructCheckError;
-
-        unsafe fn check_bytes<'a>(
-            value: *const Self,
-            context: &mut C,
-        ) -> Result<&'a Self, Self::Error> {
-            check_field(&(*value).n, context, "n")?;
-            check_field(&(*value).arithmetic, context, "arithmetic")?;
-            check_field(&(*value).logic, context, "logic")?;
-            check_field(&(*value).range, context, "range")?;
-            check_field(&(*value).fixed_base, context, "fixed_base")?;
-            check_field(&(*value).variable_base, context, "variable_base")?;
-            check_field(&(*value).permutation, context, "permutation")?;
-            check_field(&(*value).v_h_coset_8n, context, "v_h_coset_8n")?;
-
-            Ok(&*value)
-        }
     }
 
     impl ProverKey {


### PR DESCRIPTION
This errant manual implementation of `CheckBytes` was using the `rkyv` `validation` feature which bring in `std`. This is not desirable for smart contract development, and would break compilation of the crate with only the `alloc` and `rkyv-impl` features enabled.