### PR TITLE
Refactor integration tests

### DIFF
--- a/tests/assert_equal.rs
+++ b/tests/assert_equal.rs
@@ -1,0 +1,193 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_plonk::prelude::*;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+mod common;
+use common::{check_satisfied_circuit, check_unsatisfied_circuit, setup};
+
+#[test]
+fn assert_equal_point() {
+    pub struct TestCircuit {
+        p1: JubJubAffine,
+        p2: JubJubAffine,
+    }
+
+    impl TestCircuit {
+        pub fn new(p1: JubJubAffine, p2: JubJubAffine) -> Self {
+            Self { p1, p2 }
+        }
+    }
+
+    impl Default for TestCircuit {
+        fn default() -> Self {
+            Self {
+                p1: dusk_jubjub::GENERATOR,
+                p2: dusk_jubjub::GENERATOR,
+            }
+        }
+    }
+
+    impl Circuit for TestCircuit {
+        fn circuit<C>(&self, composer: &mut C) -> Result<(), Error>
+        where
+            C: Composer,
+        {
+            let w_p1 = composer.append_point(self.p1);
+            let w_p2 = composer.append_point(self.p2);
+            composer.assert_equal_point(w_p1, w_p2);
+
+            Ok(())
+        }
+    }
+
+    // Compile common circuit descriptions for the prover and verifier to be
+    // used by all tests
+    let label = b"assert_equal_point";
+    let rng = &mut StdRng::seed_from_u64(0xdecaf);
+    let capacity = 1 << 4;
+    let (prover, verifier) = setup(capacity, rng, label);
+
+    // Test default works:
+    // GENERATOR = GENERATOR
+    let msg = "Default circuit verification should pass";
+    let circuit = TestCircuit::default();
+    let pi = vec![];
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test sanity:
+    // 42 * GENERATOR = 42 * GENERATOR
+    let msg = "Circuit verification with equal points should pass";
+    let scalar = JubJubScalar::from(42u64);
+    let p1 = dusk_jubjub::GENERATOR_EXTENDED * &scalar;
+    let p2 = dusk_jubjub::GENERATOR_EXTENDED * &scalar;
+    let circuit = TestCircuit::new(p1.into(), p2.into());
+    let pi = vec![];
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test:
+    // GENERATOR != 42 * GENERATOR
+    let msg = "prover should fail because the points are not equal";
+    let scalar = JubJubScalar::from(42u64);
+    let p1 = dusk_jubjub::GENERATOR;
+    let p2 = dusk_jubjub::GENERATOR_EXTENDED * &scalar;
+    let circuit = TestCircuit::new(p1, p2.into());
+    check_unsatisfied_circuit(&prover, &circuit, rng, &msg);
+
+    // Test:
+    // assertion of points with different x-coordinates fails
+    let msg = "prover should fail because the x-coordinates of the points are not equal";
+    let p1 =
+        JubJubAffine::from_raw_unchecked(BlsScalar::one(), BlsScalar::one());
+    let p2 =
+        JubJubAffine::from_raw_unchecked(BlsScalar::zero(), BlsScalar::one());
+    let circuit = TestCircuit::new(p1, p2);
+    check_unsatisfied_circuit(&prover, &circuit, rng, &msg);
+
+    // Test:
+    // assertion of points with different y-coordinates fails
+    let msg = "prover should fail because the y-coordinates of the points are not equal";
+    let p1 =
+        JubJubAffine::from_raw_unchecked(BlsScalar::one(), BlsScalar::one());
+    let p2 =
+        JubJubAffine::from_raw_unchecked(BlsScalar::one(), BlsScalar::zero());
+    let circuit = TestCircuit::new(p1, p2);
+    check_unsatisfied_circuit(&prover, &circuit, rng, &msg);
+}
+
+#[test]
+fn assert_equal_public_point() {
+    pub struct TestCircuit {
+        point: JubJubAffine,
+        public: JubJubAffine,
+    }
+
+    impl TestCircuit {
+        pub fn new(point: JubJubAffine, public: JubJubAffine) -> Self {
+            Self { point, public }
+        }
+    }
+
+    impl Default for TestCircuit {
+        fn default() -> Self {
+            Self {
+                point: dusk_jubjub::GENERATOR,
+                public: dusk_jubjub::GENERATOR,
+            }
+        }
+    }
+
+    impl Circuit for TestCircuit {
+        fn circuit<C>(&self, composer: &mut C) -> Result<(), Error>
+        where
+            C: Composer,
+        {
+            let w_point = composer.append_point(self.point);
+            composer.assert_equal_public_point(w_point, self.public);
+
+            Ok(())
+        }
+    }
+
+    // Compile common circuit descriptions for the prover and verifier to be
+    // used by all tests
+    let label = b"assert_equal_public_point";
+    let rng = &mut StdRng::seed_from_u64(0xfeed);
+    let capacity = 1 << 4;
+    let (prover, verifier) = setup(capacity, rng, label);
+
+    // Test default works:
+    // GENERATOR = GENERATOR
+    let msg = "Default circuit verification should pass";
+    let circuit = TestCircuit::default();
+    let pi = vec![
+        dusk_jubjub::GENERATOR.get_x(),
+        dusk_jubjub::GENERATOR.get_y(),
+    ];
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test sanity:
+    // 42 * GENERATOR = 42 * GENERATOR
+    let msg = "Circuit verification with equal points should pass";
+    let scalar = JubJubScalar::from(42u64);
+    let point = dusk_jubjub::GENERATOR_EXTENDED * &scalar;
+    let public = dusk_jubjub::GENERATOR_EXTENDED * &scalar;
+    let circuit = TestCircuit::new(point.into(), public.into());
+    let public_affine: JubJubAffine = public.into();
+    let pi = vec![public_affine.get_x(), public_affine.get_y()];
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test:
+    // GENERATOR != 42 * GENERATOR
+    let msg = "prover should fail because the points are not equal";
+    let scalar = JubJubScalar::from(42u64);
+    let point = dusk_jubjub::GENERATOR;
+    let public = dusk_jubjub::GENERATOR_EXTENDED * &scalar;
+    let circuit = TestCircuit::new(point, public.into());
+    check_unsatisfied_circuit(&prover, &circuit, rng, &msg);
+
+    // Test:
+    // assertion of points with different x-coordinates fails
+    let msg = "prover should fail because the x-coordinates of the points are not equal";
+    let point =
+        JubJubAffine::from_raw_unchecked(BlsScalar::one(), BlsScalar::one());
+    let public =
+        JubJubAffine::from_raw_unchecked(BlsScalar::zero(), BlsScalar::one());
+    let circuit = TestCircuit::new(point, public);
+    check_unsatisfied_circuit(&prover, &circuit, rng, &msg);
+
+    // Test:
+    // assertion of points with different y-coordinates fails
+    let msg = "prover should fail because the y-coordinates of the points are not equal";
+    let point =
+        JubJubAffine::from_raw_unchecked(BlsScalar::one(), BlsScalar::one());
+    let public =
+        JubJubAffine::from_raw_unchecked(BlsScalar::one(), BlsScalar::zero());
+    let circuit = TestCircuit::new(point, public);
+    check_unsatisfied_circuit(&prover, &circuit, rng, &msg);
+}

--- a/tests/boolean.rs
+++ b/tests/boolean.rs
@@ -8,419 +8,82 @@ use dusk_plonk::prelude::*;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 
-#[test]
-fn boolean_works() {
-    let rng = &mut StdRng::seed_from_u64(8349u64);
-
-    let n = 1 << 4;
-    let label = b"demo";
-    let pp = PublicParameters::setup(n, rng).expect("failed to create pp");
-
-    pub struct DummyCircuit {
-        a: BlsScalar,
-    }
-
-    impl DummyCircuit {
-        pub fn new(a: BlsScalar) -> Self {
-            Self { a }
-        }
-    }
-
-    impl Default for DummyCircuit {
-        fn default() -> Self {
-            Self::new(1u64.into())
-        }
-    }
-
-    impl Circuit for DummyCircuit {
-        fn circuit<C>(&self, composer: &mut C) -> Result<(), Error>
-        where
-            C: Composer,
-        {
-            let w_a = composer.append_witness(self.a);
-
-            composer.component_boolean(w_a);
-
-            Ok(())
-        }
-    }
-
-    let (prover, verifier) = Compiler::compile::<DummyCircuit>(&pp, label)
-        .expect("failed to compile circuit");
-
-    // default works
-    {
-        let a = BlsScalar::one();
-
-        let (proof, public_inputs) = prover
-            .prove(rng, &DummyCircuit::new(a))
-            .expect("failed to prove");
-
-        verifier
-            .verify(&proof, &public_inputs)
-            .expect("failed to verify proof");
-
-        let a = BlsScalar::zero();
-
-        let (proof, public_inputs) = prover
-            .prove(rng, &DummyCircuit::new(a))
-            .expect("failed to prove");
-
-        verifier
-            .verify(&proof, &public_inputs)
-            .expect("failed to verify proof");
-    }
-
-    // negative works
-    {
-        let a = BlsScalar::from(2u64);
-
-        prover
-            .prove(rng, &DummyCircuit::new(a))
-            .expect_err("invalid circuit");
-    }
-}
+mod common;
+use common::{check_satisfied_circuit, check_unsatisfied_circuit, setup};
 
 #[test]
-fn select_works() {
-    let rng = &mut StdRng::seed_from_u64(8349u64);
-
-    let n = 1 << 6;
-    let label = b"demo";
-    let pp = PublicParameters::setup(n, rng).expect("failed to create pp");
-
-    #[derive(Clone)]
-    pub struct DummyCircuit {
+fn component_boolean() {
+    pub struct TestCircuit {
         bit: BlsScalar,
-        a: BlsScalar,
-        b: BlsScalar,
-        res: BlsScalar,
-
-        zero_bit: BlsScalar,
-        zero_a: BlsScalar,
-        zero_res: BlsScalar,
-
-        one_bit: BlsScalar,
-        one_a: BlsScalar,
-        one_res: BlsScalar,
-
-        point_bit: BlsScalar,
-        point_a: JubJubExtended,
-        point_b: JubJubExtended,
-        point_res: JubJubExtended,
-
-        identity_bit: BlsScalar,
-        identity_a: JubJubExtended,
-        identity_res: JubJubExtended,
     }
 
-    impl DummyCircuit {
-        pub fn new(
-            bit: BlsScalar,
-            a: BlsScalar,
-            b: BlsScalar,
-            zero_bit: BlsScalar,
-            zero_a: BlsScalar,
-            one_bit: BlsScalar,
-            one_a: BlsScalar,
-            point_bit: BlsScalar,
-            point_a: JubJubExtended,
-            point_b: JubJubExtended,
-            identity_bit: BlsScalar,
-            identity_a: JubJubExtended,
-        ) -> Self {
-            let res = if bit == BlsScalar::one() { a } else { b };
-
-            let zero_res = if zero_bit == BlsScalar::one() {
-                zero_a
-            } else {
-                BlsScalar::zero()
-            };
-
-            let one_res = if one_bit == BlsScalar::one() {
-                one_a
-            } else {
-                BlsScalar::one()
-            };
-
-            let point_res = if one_bit == BlsScalar::one() {
-                point_a
-            } else {
-                point_b
-            };
-
-            let identity_res = if identity_bit == BlsScalar::one() {
-                identity_a
-            } else {
-                JubJubExtended::identity()
-            };
-
-            Self {
-                bit,
-                a,
-                b,
-                res,
-                zero_bit,
-                zero_a,
-                zero_res,
-                one_bit,
-                one_a,
-                one_res,
-                point_bit,
-                point_a,
-                point_b,
-                point_res,
-                identity_bit,
-                identity_a,
-                identity_res,
-            }
+    impl TestCircuit {
+        pub fn new(bit: BlsScalar) -> Self {
+            Self { bit }
         }
     }
 
-    impl Default for DummyCircuit {
+    impl Default for TestCircuit {
         fn default() -> Self {
-            let bit = BlsScalar::one();
-            let a = BlsScalar::from(3u64);
-            let b = BlsScalar::from(5u64);
-            let zero_bit = BlsScalar::zero();
-            let zero_a = BlsScalar::from(7u64);
-            let one_bit = BlsScalar::one();
-            let one_a = BlsScalar::from(11u64);
-            let point_bit = BlsScalar::zero();
-            let point_a =
-                dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::from(13u64);
-            let point_b =
-                dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::from(17u64);
-            let identity_bit = BlsScalar::one();
-            let identity_a =
-                dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::from(19u64);
-
-            Self::new(
-                bit,
-                a,
-                b,
-                zero_bit,
-                zero_a,
-                one_bit,
-                one_a,
-                point_bit,
-                point_a,
-                point_b,
-                identity_bit,
-                identity_a,
-            )
+            Self::new(0u64.into())
         }
     }
 
-    impl Circuit for DummyCircuit {
+    impl Circuit for TestCircuit {
         fn circuit<C>(&self, composer: &mut C) -> Result<(), Error>
         where
             C: Composer,
         {
             let w_bit = composer.append_witness(self.bit);
-            let w_a = composer.append_witness(self.a);
-            let w_b = composer.append_witness(self.b);
-            let w_res = composer.append_witness(self.res);
-            let w_zero_bit = composer.append_witness(self.zero_bit);
-            let w_zero_a = composer.append_witness(self.zero_a);
-            let w_zero_res = composer.append_witness(self.zero_res);
-            let w_one_bit = composer.append_witness(self.one_bit);
-            let w_one_a = composer.append_witness(self.one_a);
-            let w_one_res = composer.append_witness(self.one_res);
-            let w_point_bit = composer.append_witness(self.point_bit);
-            let w_point_a = composer.append_point(self.point_a);
-            let w_point_b = composer.append_point(self.point_b);
-            let w_point_res = composer.append_point(self.point_res);
-            let w_identity_bit = composer.append_witness(self.identity_bit);
-            let w_identity_a = composer.append_point(self.identity_a);
-            let w_identity_res = composer.append_point(self.identity_res);
 
-            let w_x = composer.component_select(w_bit, w_a, w_b);
-            composer.assert_equal(w_x, w_res);
-
-            let w_zero_x = composer.component_select_zero(w_zero_bit, w_zero_a);
-            composer.assert_equal(w_zero_x, w_zero_res);
-
-            let w_one_x = composer.component_select_one(w_one_bit, w_one_a);
-            composer.assert_equal(w_one_x, w_one_res);
-
-            let w_point_x = composer.component_select_point(
-                w_point_bit,
-                w_point_a,
-                w_point_b,
-            );
-            composer.assert_equal_point(w_point_x, w_point_res);
-
-            let w_identity_x = composer
-                .component_select_identity(w_identity_bit, w_identity_a);
-            composer.assert_equal_point(w_identity_x, w_identity_res);
+            composer.component_boolean(w_bit);
 
             Ok(())
         }
     }
 
-    let (prover, verifier) = Compiler::compile::<DummyCircuit>(&pp, label)
-        .expect("failed to compile circuit");
+    // Compile common circuit descriptions for the prover and verifier to be
+    // used by all tests
+    let label = b"component_boolean";
+    let rng = &mut StdRng::seed_from_u64(0xfade);
+    let capacity = 1 << 4;
+    let (prover, verifier) = setup(capacity, rng, label);
 
-    // default works
-    {
-        let bit = BlsScalar::one();
+    // public inputs to be used by all tests
+    let pi = vec![];
 
-        let a = BlsScalar::random(rng);
-        let b = BlsScalar::random(rng);
-        let zero_bit = bit;
-        let zero_a = BlsScalar::random(rng);
-        let one_bit = bit;
-        let one_a = BlsScalar::random(rng);
-        let point_bit = bit;
-        let point_a = JubJubScalar::random(rng);
-        let point_a = dusk_jubjub::GENERATOR_EXTENDED * &point_a;
-        let point_b = JubJubScalar::random(rng);
-        let point_b = dusk_jubjub::GENERATOR_EXTENDED * &point_b;
-        let identity_bit = bit;
-        let identity_a = JubJubScalar::random(rng);
-        let identity_a = dusk_jubjub::GENERATOR_EXTENDED * &identity_a;
+    // Test default works:
+    let msg = "Default circuit verification should pass";
+    let circuit = TestCircuit::default();
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
 
-        let circuit = DummyCircuit::new(
-            bit,
-            a,
-            b,
-            zero_bit,
-            zero_a,
-            one_bit,
-            one_a,
-            point_bit,
-            point_a,
-            point_b,
-            identity_bit,
-            identity_a,
-        );
-
-        let (proof, public_inputs) =
-            prover.prove(rng, &circuit).expect("failed to prove");
-
-        verifier
-            .verify(&proof, &public_inputs)
-            .expect("failed to verify proof");
-
-        let bit = BlsScalar::zero();
-
-        let a = BlsScalar::random(rng);
-        let b = BlsScalar::random(rng);
-        let zero_bit = bit;
-        let zero_a = BlsScalar::random(rng);
-        let one_bit = bit;
-        let one_a = BlsScalar::random(rng);
-        let point_bit = bit;
-        let point_a = JubJubScalar::random(rng);
-        let point_a = dusk_jubjub::GENERATOR_EXTENDED * &point_a;
-        let point_b = JubJubScalar::random(rng);
-        let point_b = dusk_jubjub::GENERATOR_EXTENDED * &point_b;
-        let identity_bit = bit;
-        let identity_a = JubJubScalar::random(rng);
-        let identity_a = dusk_jubjub::GENERATOR_EXTENDED * &identity_a;
-
-        let circuit = DummyCircuit::new(
-            bit,
-            a,
-            b,
-            zero_bit,
-            zero_a,
-            one_bit,
-            one_a,
-            point_bit,
-            point_a,
-            point_b,
-            identity_bit,
-            identity_a,
-        );
-
-        let (proof, public_inputs) =
-            prover.prove(rng, &circuit).expect("failed to prove");
-
-        verifier
-            .verify(&proof, &public_inputs)
-            .expect("failed to verify proof");
-    }
-
+    // Test one works
+    let msg = "Circuit with bit = 1 should pass";
     let bit = BlsScalar::one();
+    let circuit = TestCircuit::new(bit);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
 
-    let a = BlsScalar::random(rng);
-    let b = BlsScalar::random(rng);
-    let zero_bit = bit;
-    let zero_a = BlsScalar::random(rng);
-    let one_bit = bit;
-    let one_a = BlsScalar::random(rng);
-    let point_bit = bit;
-    let point_a = JubJubScalar::random(rng);
-    let point_a = dusk_jubjub::GENERATOR_EXTENDED * &point_a;
-    let point_b = JubJubScalar::random(rng);
-    let point_b = dusk_jubjub::GENERATOR_EXTENDED * &point_b;
-    let identity_bit = bit;
-    let identity_a = JubJubScalar::random(rng);
-    let identity_a = dusk_jubjub::GENERATOR_EXTENDED * &identity_a;
+    // Test zero works
+    let msg = "Circuit with bit = 0 should pass";
+    let bit = BlsScalar::zero();
+    let circuit = TestCircuit::new(bit);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
 
-    let base = DummyCircuit::new(
-        bit,
-        a,
-        b,
-        zero_bit,
-        zero_a,
-        one_bit,
-        one_a,
-        point_bit,
-        point_a,
-        point_b,
-        identity_bit,
-        identity_a,
-    );
+    // Test -zero works
+    let msg = "Circuit with bit = -0 should pass";
+    let bit = -BlsScalar::zero();
+    let circuit = TestCircuit::new(bit);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
 
-    // negative select works
-    {
-        let mut circuit = base.clone();
+    // Test -one fails
+    let msg = "Circuit with bit = -1 shouldn't pass";
+    let bit = -BlsScalar::one();
+    let circuit = TestCircuit::new(bit);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
 
-        circuit.res = -circuit.res;
-
-        prover.prove(rng, &circuit).expect_err("invalid proof");
-    }
-
-    // negative select zero works
-    {
-        let mut circuit = base.clone();
-
-        circuit.zero_res = -circuit.zero_res;
-
-        prover.prove(rng, &circuit).expect_err("invalid proof");
-    }
-
-    // negative select one works
-    {
-        let mut circuit = base.clone();
-
-        circuit.one_res = -circuit.one_res;
-
-        prover.prove(rng, &circuit).expect_err("invalid proof");
-    }
-
-    // negative select point works
-    {
-        let mut circuit = base.clone();
-
-        let x = dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::one();
-
-        circuit.point_res = circuit.point_res + x;
-
-        prover.prove(rng, &circuit).expect_err("invalid proof");
-    }
-
-    // negative select identity works
-    {
-        let mut circuit = base.clone();
-
-        let x = dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::one();
-
-        circuit.identity_res = circuit.identity_res + x;
-
-        prover.prove(rng, &circuit).expect_err("invalid proof");
-    }
+    // Test random fails
+    let msg = "Circuit with bit = -1 shouldn't pass";
+    let bit = BlsScalar::random(rng);
+    let circuit = TestCircuit::new(bit);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
 }

--- a/tests/select_bls.rs
+++ b/tests/select_bls.rs
@@ -1,0 +1,479 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_plonk::prelude::*;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+mod common;
+use common::{check_satisfied_circuit, check_unsatisfied_circuit, setup};
+
+#[test]
+fn component_select() {
+    pub struct TestCircuit {
+        bit: BlsScalar,
+        value_a: BlsScalar,
+        value_b: BlsScalar,
+        result: BlsScalar,
+    }
+
+    impl TestCircuit {
+        pub fn new(
+            bit: BlsScalar,
+            value_a: BlsScalar,
+            value_b: BlsScalar,
+            result: BlsScalar,
+        ) -> Self {
+            Self {
+                bit,
+                value_a,
+                value_b,
+                result,
+            }
+        }
+    }
+
+    impl Default for TestCircuit {
+        fn default() -> Self {
+            Self::new(
+                BlsScalar::one(),
+                BlsScalar::one(),
+                BlsScalar::one(),
+                BlsScalar::one(),
+            )
+        }
+    }
+
+    impl Circuit for TestCircuit {
+        fn circuit<C>(&self, composer: &mut C) -> Result<(), Error>
+        where
+            C: Composer,
+        {
+            let w_bit = composer.append_witness(self.bit);
+            let w_value_a = composer.append_witness(self.value_a);
+            let w_value_b = composer.append_witness(self.value_b);
+            let w_result = composer.append_witness(self.result);
+
+            let result_circuit =
+                composer.component_select(w_bit, w_value_a, w_value_b);
+
+            composer.assert_equal(w_result, result_circuit);
+
+            Ok(())
+        }
+    }
+
+    // Compile common circuit descriptions for the prover and verifier to be
+    // used by all tests
+    let label = b"component_select";
+    let rng = &mut StdRng::seed_from_u64(0xbeef);
+    let capacity = 1 << 5;
+    let (prover, verifier) = setup(capacity, rng, label);
+
+    // public inputs to be used by all tests
+    let pi = vec![];
+
+    // Test default works:
+    let msg = "Default circuit verification should pass";
+    let circuit = TestCircuit::default();
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test one works
+    let msg = "Circuit with bit = 1 that selects value_a should pass";
+    let bit = BlsScalar::one();
+    let value_a = BlsScalar::one();
+    let value_b = BlsScalar::zero();
+    let result = value_a.clone();
+    let circuit = TestCircuit::new(bit, value_a, value_b, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test one works with random
+    let msg = "Circuit with bit = 1 that selects value_a should pass";
+    let bit = BlsScalar::one();
+    let value_a = BlsScalar::random(rng);
+    let value_b = BlsScalar::random(rng);
+    let result = value_a.clone();
+    let circuit = TestCircuit::new(bit, value_a, value_b, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test zero works
+    let msg = "Circuit with bit = 0 that selects value_b should pass";
+    let bit = BlsScalar::zero();
+    let value_a = BlsScalar::one();
+    let value_b = BlsScalar::zero();
+    let result = value_b.clone();
+    let circuit = TestCircuit::new(bit, value_a, value_b, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test zero works with random
+    let msg = "Circuit with bit = 0 that selects value_b should pass";
+    let bit = BlsScalar::zero();
+    let value_a = BlsScalar::random(rng);
+    let value_b = BlsScalar::random(rng);
+    let result = value_b.clone();
+    let circuit = TestCircuit::new(bit, value_a, value_b, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test invalid bit passes (bit should be constrained outside of the
+    // `select` component)
+    let msg = "Circuit with invalid bit shouldn't pass";
+    let bit = BlsScalar::random(rng);
+    let value_a = BlsScalar::zero();
+    let value_b = BlsScalar::zero();
+    let result = BlsScalar::zero();
+    let circuit = TestCircuit::new(bit, value_a, value_b, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test one fails
+    let msg = "Circuit with bit = 1 that selects value_b shouldn't pass";
+    let bit = BlsScalar::one();
+    let value_a = BlsScalar::one();
+    let value_b = BlsScalar::zero();
+    let result = value_b.clone();
+    let circuit = TestCircuit::new(bit, value_a, value_b, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test one fails with random
+    let msg = "Circuit with bit = 1 that selects value_b shouldn't pass";
+    let bit = BlsScalar::one();
+    let value_a = BlsScalar::random(rng);
+    let value_b = BlsScalar::random(rng);
+    let result = value_b.clone();
+    let circuit = TestCircuit::new(bit, value_a, value_b, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test zero fails
+    let msg = "Circuit with bit = 0 that selects value_a shouldn't pass";
+    let bit = BlsScalar::zero();
+    let value_a = BlsScalar::one();
+    let value_b = BlsScalar::zero();
+    let result = value_a.clone();
+    let circuit = TestCircuit::new(bit, value_a, value_b, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test zero fails with random
+    let msg = "Circuit with bit = 0 that selects value_a shouldn't pass";
+    let bit = BlsScalar::zero();
+    let value_a = BlsScalar::random(rng);
+    let value_b = BlsScalar::random(rng);
+    let result = value_a.clone();
+    let circuit = TestCircuit::new(bit, value_a, value_b, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test random fails
+    let msg =
+        "Circuit with random result shouldn't pass no matter the selector bit";
+    let bit = BlsScalar::one();
+    let value_a = BlsScalar::random(rng);
+    let value_b = BlsScalar::random(rng);
+    let result = BlsScalar::random(rng);
+    let circuit = TestCircuit::new(bit, value_a, value_b, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test random fails
+    let msg =
+        "Circuit with random result shouldn't pass no matter the selector bit";
+    let bit = BlsScalar::zero();
+    let value_a = BlsScalar::random(rng);
+    let value_b = BlsScalar::random(rng);
+    let result = BlsScalar::random(rng);
+    let circuit = TestCircuit::new(bit, value_a, value_b, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+}
+
+#[test]
+fn component_select_one() {
+    pub struct TestCircuit {
+        bit: BlsScalar,
+        value: BlsScalar,
+        result: BlsScalar,
+    }
+
+    impl TestCircuit {
+        pub fn new(
+            bit: BlsScalar,
+            value: BlsScalar,
+            result: BlsScalar,
+        ) -> Self {
+            Self { bit, value, result }
+        }
+    }
+
+    impl Default for TestCircuit {
+        fn default() -> Self {
+            Self::new(BlsScalar::one(), BlsScalar::one(), BlsScalar::one())
+        }
+    }
+    impl Circuit for TestCircuit {
+        fn circuit<C>(&self, composer: &mut C) -> Result<(), Error>
+        where
+            C: Composer,
+        {
+            let w_bit = composer.append_witness(self.bit);
+            let w_value = composer.append_witness(self.value);
+            let w_result = composer.append_witness(self.result);
+
+            let result_circuit = composer.component_select_one(w_bit, w_value);
+
+            composer.assert_equal(w_result, result_circuit);
+
+            Ok(())
+        }
+    }
+
+    // Compile common circuit descriptions for the prover and verifier to be
+    // used by all tests
+    let label = b"component_select_one";
+    let rng = &mut StdRng::seed_from_u64(0xfee);
+    let capacity = 1 << 5;
+    let (prover, verifier) = setup(capacity, rng, label);
+
+    // public inputs to be used by all tests
+    let pi = vec![];
+
+    // Test default works:
+    let msg = "Default circuit verification should pass";
+    let circuit = TestCircuit::default();
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test one works
+    let msg = "Circuit with bit = 1 that selects value should pass";
+    let bit = BlsScalar::one();
+    let value = BlsScalar::one();
+    let result = value.clone();
+    let circuit = TestCircuit::new(bit, value, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test one works with random
+    let msg = "Circuit with bit = 1 that selects value should pass";
+    let bit = BlsScalar::one();
+    let value = BlsScalar::random(rng);
+    let result = value.clone();
+    let circuit = TestCircuit::new(bit, value, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test zero works
+    let msg = "Circuit with bit = 0 that selects 1 should pass";
+    let bit = BlsScalar::zero();
+    let value = BlsScalar::zero();
+    let result = BlsScalar::one();
+    let circuit = TestCircuit::new(bit, value, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test zero works with random
+    let msg = "Circuit with bit = 0 that selects 1 should pass";
+    let bit = BlsScalar::zero();
+    let value = BlsScalar::random(rng);
+    let result = BlsScalar::one();
+    let circuit = TestCircuit::new(bit, value, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test invalid bit passes (bit should be constrained outside of the
+    // `select` component)
+    let msg = "Circuit with invalid bit can pass";
+    let bit = BlsScalar::random(rng);
+    let value = BlsScalar::one();
+    let result = BlsScalar::one();
+    let circuit = TestCircuit::new(bit, value, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test one fails
+    let msg = "Circuit with bit = 1 that selects 1 shouldn't pass";
+    let bit = BlsScalar::one();
+    let value = BlsScalar::zero();
+    let result = BlsScalar::one();
+    let circuit = TestCircuit::new(bit, value, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test one fails with random
+    let msg = "Circuit with bit = 1 that selects 1 shouldn't pass";
+    let bit = BlsScalar::one();
+    let value = BlsScalar::random(rng);
+    let result = BlsScalar::one();
+    let circuit = TestCircuit::new(bit, value, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test zero fails
+    let msg = "Circuit with bit = 0 that selects value shouldn't pass";
+    let bit = BlsScalar::zero();
+    let value = BlsScalar::zero();
+    let result = BlsScalar::zero();
+    let circuit = TestCircuit::new(bit, value, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test zero fails with random
+    let msg = "Circuit with bit = 0 that selects value shouldn't pass";
+    let bit = BlsScalar::zero();
+    let value = BlsScalar::random(rng);
+    let result = value.clone();
+    let circuit = TestCircuit::new(bit, value, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test random fails
+    let msg =
+        "Circuit with random result shouldn't pass no matter the selector bit";
+    let bit = BlsScalar::one();
+    let value = BlsScalar::random(rng);
+    let result = BlsScalar::random(rng);
+    let circuit = TestCircuit::new(bit, value, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test random fails
+    let msg =
+        "Circuit with random result shouldn't pass no matter the selector bit";
+    let bit = BlsScalar::zero();
+    let value = BlsScalar::random(rng);
+    let result = BlsScalar::random(rng);
+    let circuit = TestCircuit::new(bit, value, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+}
+
+#[test]
+fn component_select_zero() {
+    pub struct TestCircuit {
+        bit: BlsScalar,
+        value: BlsScalar,
+        result: BlsScalar,
+    }
+
+    impl TestCircuit {
+        pub fn new(
+            bit: BlsScalar,
+            value: BlsScalar,
+            result: BlsScalar,
+        ) -> Self {
+            Self { bit, value, result }
+        }
+    }
+
+    impl Default for TestCircuit {
+        fn default() -> Self {
+            Self::new(BlsScalar::zero(), BlsScalar::zero(), BlsScalar::zero())
+        }
+    }
+    impl Circuit for TestCircuit {
+        fn circuit<C>(&self, composer: &mut C) -> Result<(), Error>
+        where
+            C: Composer,
+        {
+            let w_bit = composer.append_witness(self.bit);
+            let w_value = composer.append_witness(self.value);
+            let w_result = composer.append_witness(self.result);
+
+            let result_circuit = composer.component_select_zero(w_bit, w_value);
+
+            composer.assert_equal(w_result, result_circuit);
+
+            Ok(())
+        }
+    }
+
+    // Compile common circuit descriptions for the prover and verifier to be
+    // used by all tests
+    let label = b"component_select_zero";
+    let rng = &mut StdRng::seed_from_u64(0xca11);
+    let capacity = 1 << 5;
+    let (prover, verifier) = setup(capacity, rng, label);
+
+    // public inputs to be used by all tests
+    let pi = vec![];
+
+    // Test default works:
+    let msg = "Default circuit verification should pass";
+    let circuit = TestCircuit::default();
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test one works
+    let msg = "Circuit with bit = 1 that selects value should pass";
+    let bit = BlsScalar::one();
+    let value = BlsScalar::one();
+    let result = value.clone();
+    let circuit = TestCircuit::new(bit, value, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test one works with random
+    let msg = "Circuit with bit = 1 that selects value should pass";
+    let bit = BlsScalar::one();
+    let value = BlsScalar::random(rng);
+    let result = value.clone();
+    let circuit = TestCircuit::new(bit, value, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test zero works
+    let msg = "Circuit with bit = 0 that selects 0 should pass";
+    let bit = BlsScalar::zero();
+    let value = BlsScalar::one();
+    let result = BlsScalar::zero();
+    let circuit = TestCircuit::new(bit, value, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test zero works with random
+    let msg = "Circuit with bit = 0 that selects 0 should pass";
+    let bit = BlsScalar::zero();
+    let value = BlsScalar::random(rng);
+    let result = BlsScalar::zero();
+    let circuit = TestCircuit::new(bit, value, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test invalid bit passes (bit should be constrained outside of the
+    // `select` component)
+    let msg = "Circuit with invalid bit can pass";
+    let bit = BlsScalar::random(rng);
+    let value = BlsScalar::zero();
+    let result = BlsScalar::zero();
+    let circuit = TestCircuit::new(bit, value, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test one fails
+    let msg = "Circuit with bit = 1 that selects 1 shouldn't pass";
+    let bit = BlsScalar::one();
+    let value = BlsScalar::zero();
+    let result = BlsScalar::one();
+    let circuit = TestCircuit::new(bit, value, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test one fails with random
+    let msg = "Circuit with bit = 1 that selects 0 shouldn't pass";
+    let bit = BlsScalar::one();
+    let value = BlsScalar::random(rng);
+    let result = BlsScalar::zero();
+    let circuit = TestCircuit::new(bit, value, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test zero fails
+    let msg = "Circuit with bit = 0 that selects value shouldn't pass";
+    let bit = BlsScalar::zero();
+    let value = BlsScalar::one();
+    let result = BlsScalar::one();
+    let circuit = TestCircuit::new(bit, value, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test zero fails with random
+    let msg = "Circuit with bit = 0 that selects value shouldn't pass";
+    let bit = BlsScalar::zero();
+    let value = BlsScalar::random(rng);
+    let result = value.clone();
+    let circuit = TestCircuit::new(bit, value, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test random fails
+    let msg =
+        "Circuit with random result shouldn't pass no matter the selector bit";
+    let bit = BlsScalar::one();
+    let value = BlsScalar::random(rng);
+    let result = BlsScalar::random(rng);
+    let circuit = TestCircuit::new(bit, value, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test random fails
+    let msg =
+        "Circuit with random result shouldn't pass no matter the selector bit";
+    let bit = BlsScalar::zero();
+    let value = BlsScalar::random(rng);
+    let result = BlsScalar::random(rng);
+    let circuit = TestCircuit::new(bit, value, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+}

--- a/tests/select_point.rs
+++ b/tests/select_point.rs
@@ -1,0 +1,359 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_plonk::prelude::*;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+mod common;
+use common::{check_satisfied_circuit, check_unsatisfied_circuit, setup};
+
+#[test]
+fn component_select_point() {
+    pub struct TestCircuit {
+        bit: BlsScalar,
+        point_a: JubJubAffine,
+        point_b: JubJubAffine,
+        result: JubJubAffine,
+    }
+
+    impl TestCircuit {
+        pub fn new(
+            bit: BlsScalar,
+            point_a: JubJubAffine,
+            point_b: JubJubAffine,
+            result: JubJubAffine,
+        ) -> Self {
+            Self {
+                bit,
+                point_a,
+                point_b,
+                result,
+            }
+        }
+    }
+
+    impl Default for TestCircuit {
+        fn default() -> Self {
+            Self::new(
+                BlsScalar::zero(),
+                JubJubAffine::identity(),
+                JubJubAffine::identity(),
+                JubJubAffine::identity(),
+            )
+        }
+    }
+
+    impl Circuit for TestCircuit {
+        fn circuit<C>(&self, composer: &mut C) -> Result<(), Error>
+        where
+            C: Composer,
+        {
+            let w_bit = composer.append_witness(self.bit);
+            let w_point_a = composer.append_point(self.point_a);
+            let w_point_b = composer.append_point(self.point_b);
+            let w_result = composer.append_point(self.result);
+
+            let result_circuit =
+                composer.component_select_point(w_bit, w_point_a, w_point_b);
+
+            composer.assert_equal_point(w_result, result_circuit);
+
+            Ok(())
+        }
+    }
+
+    // Compile common circuit descriptions for the prover and verifier to be
+    // used by all tests
+    let label = b"component_select_point";
+    let rng = &mut StdRng::seed_from_u64(0xce11);
+    let capacity = 1 << 5;
+    let (prover, verifier) = setup(capacity, rng, label);
+
+    // public inputs to be used by all tests
+    let pi = vec![];
+
+    // Test default works:
+    let msg = "Default circuit verification should pass";
+    let circuit = TestCircuit::default();
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test one works
+    let msg = "Circuit with bit = 1 that selects point_a should pass";
+    let bit = BlsScalar::one();
+    let point_a = dusk_jubjub::GENERATOR;
+    let point_b = JubJubAffine::identity();
+    let result = point_a.clone();
+    let circuit = TestCircuit::new(bit, point_a, point_b, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test one works with random
+    let msg = "Circuit with bit = 1 that selects point_a should pass";
+    let bit = BlsScalar::one();
+    let point_a: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let point_b: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let result = point_a.clone();
+    let circuit = TestCircuit::new(bit, point_a, point_b, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test zero works
+    let msg = "Circuit with bit = 0 that selects point_b should pass";
+    let bit = BlsScalar::zero();
+    let point_a = dusk_jubjub::GENERATOR;
+    let point_b = JubJubAffine::identity();
+    let result = point_b.clone();
+    let circuit = TestCircuit::new(bit, point_a, point_b, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test zero works with random
+    let msg = "Circuit with bit = 0 that selects point_b should pass";
+    let bit = BlsScalar::zero();
+    let point_a: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let point_b: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let result = point_b.clone();
+    let circuit = TestCircuit::new(bit, point_a, point_b, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test invalid bit passes (bit should be constrained outside of the
+    // `select` component)
+    let msg = "Circuit with invalid bit shouldn't pass";
+    let bit = BlsScalar::random(rng);
+    let point_a = JubJubAffine::identity();
+    let point_b = JubJubAffine::identity();
+    let result = JubJubAffine::identity();
+    let circuit = TestCircuit::new(bit, point_a, point_b, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test one fails
+    let msg = "Circuit with bit = 1 that selects point_b shouldn't pass";
+    let bit = BlsScalar::one();
+    let point_a = dusk_jubjub::GENERATOR;
+    let point_b = JubJubAffine::identity();
+    let result = point_b.clone();
+    let circuit = TestCircuit::new(bit, point_a, point_b, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test one fails with random
+    let msg = "Circuit with bit = 1 that selects point_b shouldn't pass";
+    let bit = BlsScalar::one();
+    let point_a: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let point_b: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let result = point_b.clone();
+    let circuit = TestCircuit::new(bit, point_a, point_b, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test zero fails
+    let msg = "Circuit with bit = 0 that selects point_a shouldn't pass";
+    let bit = BlsScalar::zero();
+    let point_a = dusk_jubjub::GENERATOR;
+    let point_b = JubJubAffine::identity();
+    let result = point_a.clone();
+    let circuit = TestCircuit::new(bit, point_a, point_b, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test zero fails with random
+    let msg = "Circuit with bit = 0 that selects point_a shouldn't pass";
+    let bit = BlsScalar::zero();
+    let point_a: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let point_b: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let result = point_a.clone();
+    let circuit = TestCircuit::new(bit, point_a, point_b, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test random fails
+    let msg =
+        "Circuit with random result shouldn't pass no matter the selector bit";
+    let bit = BlsScalar::one();
+    let point_a: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let point_b: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let result: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let circuit = TestCircuit::new(bit, point_a, point_b, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test random fails
+    let msg =
+        "Circuit with random result shouldn't pass no matter the selector bit";
+    let bit = BlsScalar::zero();
+    let point_a: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let point_b: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let result: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let circuit = TestCircuit::new(bit, point_a, point_b, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+}
+
+#[test]
+fn component_select_identity() {
+    pub struct TestCircuit {
+        bit: BlsScalar,
+        point: JubJubAffine,
+        result: JubJubAffine,
+    }
+
+    impl TestCircuit {
+        pub fn new(
+            bit: BlsScalar,
+            point: JubJubAffine,
+            result: JubJubAffine,
+        ) -> Self {
+            Self { bit, point, result }
+        }
+    }
+
+    impl Default for TestCircuit {
+        fn default() -> Self {
+            Self::new(
+                BlsScalar::zero(),
+                JubJubAffine::identity(),
+                JubJubAffine::identity(),
+            )
+        }
+    }
+    impl Circuit for TestCircuit {
+        fn circuit<C>(&self, composer: &mut C) -> Result<(), Error>
+        where
+            C: Composer,
+        {
+            let w_bit = composer.append_witness(self.bit);
+            let w_point = composer.append_point(self.point);
+            let w_result = composer.append_point(self.result);
+
+            let result_circuit =
+                composer.component_select_identity(w_bit, w_point);
+
+            composer.assert_equal_point(w_result, result_circuit);
+
+            Ok(())
+        }
+    }
+
+    // Compile common circuit descriptions for the prover and verifier to be
+    // used by all tests
+    let label = b"component_select_one";
+    let rng = &mut StdRng::seed_from_u64(0xfee);
+    let capacity = 1 << 5;
+    let (prover, verifier) = setup(capacity, rng, label);
+
+    // public inputs to be used by all tests
+    let pi = vec![];
+
+    // Test default works:
+    let msg = "Default circuit verification should pass";
+    let circuit = TestCircuit::default();
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test one works
+    let msg = "Circuit with bit = 1 that selects point should pass";
+    let bit = BlsScalar::one();
+    let point = dusk_jubjub::GENERATOR;
+    let result = point.clone();
+    let circuit = TestCircuit::new(bit, point, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test one works with random
+    let msg = "Circuit with bit = 1 that selects point should pass";
+    let bit = BlsScalar::one();
+    let point: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let result = point.clone();
+    let circuit = TestCircuit::new(bit, point, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test zero works
+    let msg = "Circuit with bit = 0 that selects identity should pass";
+    let bit = BlsScalar::zero();
+    let point = dusk_jubjub::GENERATOR;
+    let result = JubJubAffine::identity();
+    let circuit = TestCircuit::new(bit, point, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test zero works with random
+    let msg = "Circuit with bit = 0 that selects identity should pass";
+    let bit = BlsScalar::zero();
+    let point: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let result = JubJubAffine::identity();
+    let circuit = TestCircuit::new(bit, point, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test invalid bit passes (bit should be constrained outside of the
+    // `select` component)
+    let msg = "Circuit with invalid bit can pass";
+    let bit = BlsScalar::random(rng);
+    let point = JubJubAffine::identity();
+    let result = JubJubAffine::identity();
+    let circuit = TestCircuit::new(bit, point, result);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, rng, &msg);
+
+    // Test one fails
+    let msg = "Circuit with bit = 1 that selects identity shouldn't pass";
+    let bit = BlsScalar::one();
+    let point = dusk_jubjub::GENERATOR;
+    let result = JubJubAffine::identity();
+    let circuit = TestCircuit::new(bit, point, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test one fails with random
+    let msg = "Circuit with bit = 1 that selects identity shouldn't pass";
+    let bit = BlsScalar::one();
+    let point: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let result = JubJubAffine::identity();
+    let circuit = TestCircuit::new(bit, point, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test zero fails
+    let msg = "Circuit with bit = 0 that selects point shouldn't pass";
+    let bit = BlsScalar::zero();
+    let point = dusk_jubjub::GENERATOR;
+    let result = point.clone();
+    let circuit = TestCircuit::new(bit, point, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test zero fails with random
+    let msg = "Circuit with bit = 0 that selects point shouldn't pass";
+    let bit = BlsScalar::zero();
+    let point: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let result = point.clone();
+    let circuit = TestCircuit::new(bit, point, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test random fails
+    let msg =
+        "Circuit with random result shouldn't pass no matter the selector bit";
+    let bit = BlsScalar::one();
+    let point: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let result: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let circuit = TestCircuit::new(bit, point, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+
+    // Test random fails
+    let msg =
+        "Circuit with random result shouldn't pass no matter the selector bit";
+    let bit = BlsScalar::zero();
+    let point: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let result: JubJubAffine =
+        (dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::random(rng)).into();
+    let circuit = TestCircuit::new(bit, point, result);
+    check_unsatisfied_circuit(&prover, &circuit, rng, msg);
+}


### PR DESCRIPTION
This issue covers:
- add helper functions:
  - `setup`
  - `check_satisfied_circuit`
  - `check_unsatisfied_circuit`
- refactor tests:
  - `assert_equal_point`
  - `assert_equal_public_point`
  - `component_mul_point`
  - `component_add_point`
  - `component_mul_generator`
  - `component_boolean`
  - `component_select`
  - `component_select_one`
  - `component_select_zero`
  - `component_select_point`
  - `component_select_identity`

Resolves #731 