### PR TITLE
feat: add `compress` to compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add and restructure tests for boolean and select components [#731]
 - Add tests for `gate_add` and `gate_mul` [#736]
 - Add and restructure tests for `component_decomposition` [#738]
+- Add `Compile::compress` and `Compile::decompress` [#752]
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,10 @@ dusk-bls12_381 = {version = "0.11", default-features = false, features = ["group
 dusk-jubjub = {version = "0.12", default-features = false}
 itertools = {version = "0.9", default-features = false}
 hashbrown = {version = "0.9", default-features=false, features = ["ahash"]}
+msgpacker = {version = "0.4", default-features=false, features = ["alloc", "derive"], optional=true}
+miniz_oxide = {version = "0.7", default-features=false, features = ["with-alloc"], optional = true}
 rayon = {version = "1.3", optional = true}
+sha2 = {version = "0.10", default-features = false, optional = true}
 cfg-if = "1.0"
 # Dusk related deps for WASMI serde
 canonical = {version = "0.7", optional = true}
@@ -52,10 +55,12 @@ std = [
     "dusk-jubjub/default",
     "itertools/default",
     "hashbrown/default",
+    "msgpacker/std",
+    "miniz_oxide/std",
     "alloc",
     "rayon"
 ]
-alloc = ["dusk-bls12_381/alloc"]
+alloc = ["dusk-bls12_381/alloc", "msgpacker", "miniz_oxide", "sha2"]
 debug = ["dusk-cdf", "backtrace"]
 canon = ["dusk-bls12_381/canon", "dusk-jubjub/canon", "canonical", "canonical_derive"]
 rkyv-impl = ["dusk-bls12_381/rkyv-impl", "dusk-jubjub/rkyv-impl", "rkyv", "bytecheck"]

--- a/benches/plonk.rs
+++ b/benches/plonk.rs
@@ -90,9 +90,11 @@ fn run<const DEGREE: usize>(
         Compiler::compile::<BenchCircuit<DEGREE>>(&pp, label)
             .expect("failed to compile circuit");
 
+    let circuit: BenchCircuit<DEGREE> = BenchCircuit::default();
+
     // sanity run
     let (proof, public_inputs) = prover
-        .prove(&mut rand_core::OsRng, &Default::default())
+        .prove(&mut rand_core::OsRng, &circuit)
         .expect("failed to prove");
 
     verifier
@@ -103,9 +105,7 @@ fn run<const DEGREE: usize>(
     let description = format!("Prove 2^{} = {} gates", power, DEGREE);
 
     c.bench_function(description.as_str(), |b| {
-        b.iter(|| {
-            black_box(prover.prove(&mut rand_core::OsRng, &Default::default()))
-        })
+        b.iter(|| black_box(prover.prove(&mut rand_core::OsRng, &circuit)))
     });
 
     let description = format!("Verify 2^{} = {} gates", power, DEGREE);

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -42,13 +42,13 @@ pub trait Composer: Sized + Index<Witness, Output = BlsScalar> {
     ///
     /// A turbo composer expects the first witness to be always present and to
     /// be zero.
-    const ZERO: Witness = Witness::new(0);
+    const ZERO: Witness = Witness::ZERO;
 
     /// `One` representation inside the constraint system.
     ///
     /// A turbo composer expects the 2nd witness to be always present and to
     /// be one.
-    const ONE: Witness = Witness::new(1);
+    const ONE: Witness = Witness::ONE;
 
     /// Identity point representation inside the constraint system
     const IDENTITY: WitnessPoint = WitnessPoint::new(Self::ZERO, Self::ONE);

--- a/src/composer/compiler/compress.rs
+++ b/src/composer/compiler/compress.rs
@@ -1,0 +1,375 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_bytes::Serializable;
+use hashbrown::HashMap;
+use msgpacker::{MsgPacker, Packable, Unpackable};
+
+use alloc::vec::Vec;
+
+use super::{
+    BlsScalar, Builder, Circuit, Compiler, Composer, Constraint, Error,
+    Polynomial, Prover, PublicParameters, Selector, Verifier, Witness,
+};
+
+mod hades;
+
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, MsgPacker,
+)]
+pub struct CompressedConstraint {
+    pub polynomial: usize,
+    pub w_a: usize,
+    pub w_b: usize,
+    pub w_d: usize,
+    pub w_o: usize,
+}
+
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, MsgPacker,
+)]
+pub struct CompressedPolynomial {
+    pub q_m: usize,
+    pub q_l: usize,
+    pub q_r: usize,
+    pub q_o: usize,
+    pub q_c: usize,
+    pub q_d: usize,
+    pub q_arith: usize,
+    pub q_range: usize,
+    pub q_logic: usize,
+    pub q_fixed_group_add: usize,
+    pub q_variable_group_add: usize,
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, MsgPacker,
+)]
+pub enum Version {
+    V1,
+    V2,
+}
+
+impl Version {
+    pub fn into_scalars(self) -> HashMap<BlsScalar, usize> {
+        match self {
+            Version::V1 => {
+                [BlsScalar::zero(), BlsScalar::one(), -BlsScalar::one()]
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, s)| (s, i))
+                    .collect()
+            }
+            Version::V2 => {
+                let mut scalars = Self::V1.into_scalars();
+                // assert we don't override a previously inserted constant
+                for s in hades::constants() {
+                    let len = scalars.len();
+                    scalars.entry(s).or_insert(len);
+                }
+                for r in hades::mds() {
+                    for s in r {
+                        let len = scalars.len();
+                        scalars.entry(s).or_insert(len);
+                    }
+                }
+                scalars
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, MsgPacker)]
+pub struct CompressedCircuit {
+    version: Version,
+    public_inputs: Vec<usize>,
+    witnesses: usize,
+    scalars: Vec<[u8; BlsScalar::SIZE]>,
+    polynomials: Vec<CompressedPolynomial>,
+    circuit: Vec<CompressedConstraint>,
+}
+
+impl CompressedCircuit {
+    pub fn from_circuit<C>(
+        pp: &PublicParameters,
+        version: Version,
+    ) -> Result<Vec<u8>, Error>
+    where
+        C: Circuit,
+    {
+        let max_size = Compiler::max_size(pp);
+        let mut builder = Builder::initialized(max_size);
+        C::default().circuit(&mut builder)?;
+        Ok(Self::from_builder(version, builder))
+    }
+
+    pub fn from_builder(version: Version, builder: Builder) -> Vec<u8> {
+        let mut public_inputs: Vec<_> =
+            builder.public_inputs.keys().copied().collect();
+        public_inputs.sort();
+
+        let witnesses = builder.witnesses.len();
+        let polynomials = builder.constraints;
+
+        let circuit = polynomials.into_iter();
+        let mut scalars = version.into_scalars();
+        let base_scalars_len = scalars.len();
+        let mut polynomials = HashMap::new();
+        let circuit = circuit
+            .map(
+                |Polynomial {
+                     q_m,
+                     q_l,
+                     q_r,
+                     q_o,
+                     q_c,
+                     q_d,
+                     q_arith,
+                     q_range,
+                     q_logic,
+                     q_fixed_group_add,
+                     q_variable_group_add,
+                     w_a,
+                     w_b,
+                     w_d,
+                     w_o,
+                 }| {
+                    let len = scalars.len();
+                    let q_m = *scalars.entry(q_m).or_insert(len);
+                    let len = scalars.len();
+                    let q_l = *scalars.entry(q_l).or_insert(len);
+                    let len = scalars.len();
+                    let q_r = *scalars.entry(q_r).or_insert(len);
+                    let len = scalars.len();
+                    let q_o = *scalars.entry(q_o).or_insert(len);
+                    let len = scalars.len();
+                    let q_c = *scalars.entry(q_c).or_insert(len);
+                    let len = scalars.len();
+                    let q_d = *scalars.entry(q_d).or_insert(len);
+                    let len = scalars.len();
+                    let q_arith = *scalars.entry(q_arith).or_insert(len);
+                    let len = scalars.len();
+                    let q_range = *scalars.entry(q_range).or_insert(len);
+                    let len = scalars.len();
+                    let q_logic = *scalars.entry(q_logic).or_insert(len);
+                    let len = scalars.len();
+                    let q_fixed_group_add =
+                        *scalars.entry(q_fixed_group_add).or_insert(len);
+                    let len = scalars.len();
+                    let q_variable_group_add =
+                        *scalars.entry(q_variable_group_add).or_insert(len);
+                    let polynomial = CompressedPolynomial {
+                        q_m,
+                        q_l,
+                        q_r,
+                        q_o,
+                        q_c,
+                        q_d,
+                        q_arith,
+                        q_range,
+                        q_logic,
+                        q_fixed_group_add,
+                        q_variable_group_add,
+                    };
+
+                    let len = polynomials.len();
+                    let polynomial =
+                        *polynomials.entry(polynomial).or_insert(len);
+
+                    CompressedConstraint {
+                        polynomial,
+                        w_a: w_a.index(),
+                        w_b: w_b.index(),
+                        w_d: w_d.index(),
+                        w_o: w_o.index(),
+                    }
+                },
+            )
+            .collect();
+
+        let scalars_map = scalars;
+        let mut scalars = vec![[0u8; BlsScalar::SIZE]; scalars_map.len()];
+        scalars_map
+            .into_iter()
+            .for_each(|(s, i)| scalars[i] = s.to_bytes());
+
+        // clear the scalars that can be determiniscally reconstructed from the
+        // version
+        let scalars = scalars.split_off(base_scalars_len);
+
+        let polynomials_map = polynomials;
+        let mut polynomials =
+            vec![CompressedPolynomial::default(); polynomials_map.len()];
+        polynomials_map
+            .into_iter()
+            .for_each(|(p, i)| polynomials[i] = p);
+
+        let compressed = Self {
+            version,
+            public_inputs,
+            witnesses,
+            scalars,
+            polynomials,
+            circuit,
+        };
+        let mut buf = Vec::with_capacity(
+            1 + compressed.scalars.len() * BlsScalar::SIZE
+                + compressed.polynomials.len() * 88
+                + compressed.circuit.len() * 40,
+        );
+        compressed.pack(&mut buf);
+        miniz_oxide::deflate::compress_to_vec(&buf, 10)
+    }
+
+    pub fn from_bytes(
+        pp: &PublicParameters,
+        label: &[u8],
+        compressed: &[u8],
+    ) -> Result<(Prover, Verifier), Error> {
+        let compressed = miniz_oxide::inflate::decompress_to_vec(compressed)
+            .map_err(|_| Error::InvalidCompressedCircuit)?;
+        let (
+            _,
+            Self {
+                version,
+                public_inputs,
+                witnesses,
+                scalars,
+                polynomials,
+                circuit,
+            },
+        ) = Self::unpack(&compressed)
+            .map_err(|_| Error::InvalidCompressedCircuit)?;
+
+        let version_scalars_map = version.into_scalars();
+        let mut version_scalars =
+            vec![BlsScalar::zero(); version_scalars_map.len()];
+        version_scalars_map
+            .into_iter()
+            .for_each(|(s, i)| version_scalars[i] = s);
+        for s in scalars {
+            version_scalars.push(BlsScalar::from_bytes(&s)?);
+        }
+        let scalars = version_scalars;
+
+        #[allow(deprecated)]
+        // we use `uninitialized` because the decompressor will also contain the
+        // dummy constraints, if they were part of the prover when encoding.
+        let mut builder = Builder::uninitialized(circuit.len());
+
+        let mut pi = 0;
+        (0..witnesses).for_each(|_| {
+            builder.append_witness(BlsScalar::zero());
+        });
+
+        for (
+            i,
+            CompressedConstraint {
+                polynomial,
+                w_a,
+                w_b,
+                w_d,
+                w_o,
+            },
+        ) in circuit.into_iter().enumerate()
+        {
+            let CompressedPolynomial {
+                q_m,
+                q_l,
+                q_r,
+                q_o,
+                q_c,
+                q_d,
+                q_arith,
+                q_range,
+                q_logic,
+                q_fixed_group_add,
+                q_variable_group_add,
+            } = polynomials
+                .get(polynomial)
+                .copied()
+                .ok_or(Error::InvalidCompressedCircuit)?;
+
+            let q_m = scalars
+                .get(q_m)
+                .copied()
+                .ok_or(Error::InvalidCompressedCircuit)?;
+            let q_l = scalars
+                .get(q_l)
+                .copied()
+                .ok_or(Error::InvalidCompressedCircuit)?;
+            let q_r = scalars
+                .get(q_r)
+                .copied()
+                .ok_or(Error::InvalidCompressedCircuit)?;
+            let q_o = scalars
+                .get(q_o)
+                .copied()
+                .ok_or(Error::InvalidCompressedCircuit)?;
+            let q_c = scalars
+                .get(q_c)
+                .copied()
+                .ok_or(Error::InvalidCompressedCircuit)?;
+            let q_d = scalars
+                .get(q_d)
+                .copied()
+                .ok_or(Error::InvalidCompressedCircuit)?;
+            let q_arith = scalars
+                .get(q_arith)
+                .copied()
+                .ok_or(Error::InvalidCompressedCircuit)?;
+            let q_range = scalars
+                .get(q_range)
+                .copied()
+                .ok_or(Error::InvalidCompressedCircuit)?;
+            let q_logic = scalars
+                .get(q_logic)
+                .copied()
+                .ok_or(Error::InvalidCompressedCircuit)?;
+            let q_fixed_group_add = scalars
+                .get(q_fixed_group_add)
+                .copied()
+                .ok_or(Error::InvalidCompressedCircuit)?;
+            let q_variable_group_add = scalars
+                .get(q_variable_group_add)
+                .copied()
+                .ok_or(Error::InvalidCompressedCircuit)?;
+
+            let w_a = Witness::new(w_a);
+            let w_b = Witness::new(w_b);
+            let w_d = Witness::new(w_d);
+            let w_o = Witness::new(w_o);
+
+            let mut constraint = Constraint::default()
+                .set(Selector::Multiplication, q_m)
+                .set(Selector::Left, q_l)
+                .set(Selector::Right, q_r)
+                .set(Selector::Output, q_o)
+                .set(Selector::Constant, q_c)
+                .set(Selector::Fourth, q_d)
+                .set(Selector::Arithmetic, q_arith)
+                .set(Selector::Range, q_range)
+                .set(Selector::Logic, q_logic)
+                .set(Selector::GroupAddFixedBase, q_fixed_group_add)
+                .set(Selector::GroupAddVariableBase, q_variable_group_add)
+                .a(w_a)
+                .b(w_b)
+                .d(w_d)
+                .o(w_o);
+
+            if let Some(idx) = public_inputs.get(pi) {
+                if idx == &i {
+                    pi += 1;
+                    constraint = constraint.public(BlsScalar::zero());
+                }
+            }
+
+            builder.append_custom_gate(constraint);
+        }
+
+        Compiler::compile_with_builder(pp, label, &builder)
+    }
+}

--- a/src/composer/compiler/compress/hades.rs
+++ b/src/composer/compiler/compress/hades.rs
@@ -1,0 +1,62 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use sha2::{Digest, Sha512};
+
+use super::BlsScalar;
+
+const CONSTANTS: usize = 960;
+
+// Extracted from
+// https://github.com/dusk-network/Hades252/blob/a4d55e06ee9ff7f549043582e8d194eb0a01bf24/assets/HOWTO.md
+
+pub fn constants() -> [BlsScalar; CONSTANTS] {
+    let mut cnst = [BlsScalar::zero(); CONSTANTS];
+    let mut p = BlsScalar::one();
+    let mut bytes = b"poseidon-for-plonk".to_vec();
+
+    cnst.iter_mut().for_each(|c| {
+        bytes = Sha512::digest(bytes.as_slice()).to_vec();
+
+        let mut v = [0x00u8; 64];
+        v.copy_from_slice(&bytes[0..64]);
+
+        *c = BlsScalar::from_bytes_wide(&v) + p;
+        p = *c;
+    });
+
+    cnst
+}
+
+const WIDTH: usize = 5;
+
+pub fn mds() -> [[BlsScalar; WIDTH]; WIDTH] {
+    let mut matrix = [[BlsScalar::zero(); WIDTH]; WIDTH];
+    let mut xs = [BlsScalar::zero(); WIDTH];
+    let mut ys = [BlsScalar::zero(); WIDTH];
+
+    // Generate x and y values deterministically for the cauchy matrix
+    // where x[i] != y[i] to allow the values to be inverted
+    // and there are no duplicates in the x vector or y vector, so that the
+    // determinant is always non-zero [a b]
+    // [c d]
+    // det(M) = (ad - bc) ; if a == b and c == d => det(M) =0
+    // For an MDS matrix, every possible mxm submatrix, must have det(M) != 0
+    (0..WIDTH).for_each(|i| {
+        xs[i] = BlsScalar::from(i as u64);
+        ys[i] = BlsScalar::from((i + WIDTH) as u64);
+    });
+
+    let mut m = 0;
+    (0..WIDTH).for_each(|i| {
+        (0..WIDTH).for_each(|j| {
+            matrix[m][j] = (xs[i] + ys[j]).invert().unwrap();
+        });
+        m += 1;
+    });
+
+    matrix
+}

--- a/src/composer/prover.rs
+++ b/src/composer/prover.rs
@@ -5,7 +5,6 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use alloc::vec::Vec;
-use core::marker::PhantomData;
 use core::ops;
 
 use dusk_bls12_381::BlsScalar;
@@ -27,10 +26,7 @@ use super::{Builder, Circuit, Composer};
 
 /// Turbo Prover with processed keys
 #[derive(Clone)]
-pub struct Prover<C>
-where
-    C: Circuit,
-{
+pub struct Prover {
     label: Vec<u8>,
     pub(crate) prover_key: ProverKey,
     pub(crate) commit_key: CommitKey,
@@ -38,13 +34,9 @@ where
     pub(crate) transcript: Transcript,
     pub(crate) size: usize,
     pub(crate) constraints: usize,
-    circuit: PhantomData<C>,
 }
 
-impl<C> ops::Deref for Prover<C>
-where
-    C: Circuit,
-{
+impl ops::Deref for Prover {
     type Target = ProverKey;
 
     fn deref(&self) -> &Self::Target {
@@ -52,10 +44,7 @@ where
     }
 }
 
-impl<C> Prover<C>
-where
-    C: Circuit,
-{
+impl Prover {
     pub(crate) fn new(
         label: Vec<u8>,
         prover_key: ProverKey,
@@ -75,7 +64,6 @@ where
             transcript,
             size,
             constraints,
-            circuit: PhantomData,
         }
     }
 
@@ -234,7 +222,7 @@ where
     }
 
     /// Prove the circuit
-    pub fn prove<R>(
+    pub fn prove<C, R>(
         &self,
         rng: &mut R,
         circuit: &C,

--- a/src/composer/verifier.rs
+++ b/src/composer/verifier.rs
@@ -5,7 +5,6 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use alloc::vec::Vec;
-use core::marker::PhantomData;
 
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Serializable};
@@ -19,7 +18,7 @@ use crate::transcript::TranscriptProtocol;
 use super::Builder;
 
 /// Verify proofs of a given circuit
-pub struct Verifier<C> {
+pub struct Verifier {
     label: Vec<u8>,
     verifier_key: VerifierKey,
     opening_key: OpeningKey,
@@ -27,10 +26,9 @@ pub struct Verifier<C> {
     transcript: Transcript,
     size: usize,
     constraints: usize,
-    circuit: PhantomData<C>,
 }
 
-impl<C> Verifier<C> {
+impl Verifier {
     pub(crate) fn new(
         label: Vec<u8>,
         verifier_key: VerifierKey,
@@ -50,7 +48,6 @@ impl<C> Verifier<C> {
             transcript,
             size,
             constraints,
-            circuit: PhantomData,
         }
     }
 

--- a/src/constraint_system/constraint.rs
+++ b/src/constraint_system/constraint.rs
@@ -55,8 +55,8 @@ pub(crate) enum WiredWitness {
 /// evaluation
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Constraint {
-    coefficients: [BlsScalar; 12],
-    witnesses: [Witness; 4],
+    coefficients: [BlsScalar; Self::COEFFICIENTS],
+    witnesses: [Witness; Self::WITNESSES],
 
     // TODO Workaround solution to keep the sparse public input indexes in the
     // composer
@@ -93,19 +93,19 @@ impl AsRef<[BlsScalar]> for Constraint {
 }
 
 impl Constraint {
+    /// Internal coefficients count.
+    pub const COEFFICIENTS: usize = 12;
+
+    /// Internal witnesses count.
+    pub const WITNESSES: usize = 4;
+
     /// Initiate the composition of a new selector description of a circuit.
     pub const fn new() -> Self {
         Self {
-            coefficients: [BlsScalar::zero(); 12],
-            witnesses: [Builder::ZERO; 4],
+            coefficients: [BlsScalar::zero(); Self::COEFFICIENTS],
+            witnesses: [Builder::ZERO; Self::WITNESSES],
             has_public_input: false,
         }
-    }
-
-    fn set<T: Into<BlsScalar>>(mut self, r: Selector, s: T) -> Self {
-        self.coefficients[r as usize] = s.into();
-
-        self
     }
 
     fn from_external(constraint: &Self) -> Self {
@@ -122,6 +122,13 @@ impl Constraint {
         s.witnesses.copy_from_slice(&constraint.witnesses);
 
         s
+    }
+
+    /// Replace the value of a polynomial selector
+    pub(crate) fn set<T: Into<BlsScalar>>(mut self, r: Selector, s: T) -> Self {
+        self.coefficients[r as usize] = s.into();
+
+        self
     }
 
     /// Replace the value of an indexed witness

--- a/src/constraint_system/witness.rs
+++ b/src/constraint_system/witness.rs
@@ -30,6 +30,12 @@ pub struct Witness {
 }
 
 impl Witness {
+    /// A `0` witness representation.
+    pub const ZERO: Witness = Witness::new(0);
+
+    /// A `1` witness representation.
+    pub const ONE: Witness = Witness::new(1);
+
     /// Generate a new [`Witness`]
     pub(crate) const fn new(index: usize) -> Self {
         Self { index }

--- a/src/error.rs
+++ b/src/error.rs
@@ -86,6 +86,8 @@ pub enum Error {
         /// Provided value
         provided: usize,
     },
+    /// The provided compressed circuit bytes representation is invalid.
+    InvalidCompressedCircuit,
 }
 
 #[cfg(feature = "std")]
@@ -151,6 +153,7 @@ impl std::fmt::Display for Error {
             Self::InconsistentPublicInputsLen {
                 expected, provided,
             } => write!(f, "The provided public inputs set of length {} doesn't match the processed verifier: {}", provided, expected),
+            Self::InvalidCompressedCircuit => write!(f, "invalid compressed circuit"),
         }
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -14,7 +14,7 @@ pub(crate) fn setup<C, R>(
     rng: &mut R,
     label: &[u8],
     circuit: &C,
-) -> (Prover<C>, Verifier<C>)
+) -> (Prover, Verifier)
 where
     C: Circuit,
     R: RngCore + CryptoRng,
@@ -27,8 +27,8 @@ where
 // Check that proof creation and verification of a satisfied circuit passes
 // and that the public inputs are as expected
 pub(crate) fn check_satisfied_circuit<C, R>(
-    prover: &Prover<C>,
-    verifier: &Verifier<C>,
+    prover: &Prover,
+    verifier: &Verifier,
     pi_expected: &Vec<BlsScalar>,
     circuit: &C,
     rng: &mut R,
@@ -53,8 +53,8 @@ pub(crate) fn check_satisfied_circuit<C, R>(
 // tests.
 #[allow(dead_code)]
 pub(crate) fn check_satisfied_circuit_fails<C, R>(
-    prover: &Prover<C>,
-    verifier: &Verifier<C>,
+    prover: &Prover,
+    verifier: &Verifier,
     pi_expected: &Vec<BlsScalar>,
     circuit: &C,
     rng: &mut R,
@@ -76,7 +76,7 @@ pub(crate) fn check_satisfied_circuit_fails<C, R>(
 // This is also the case when the constants appended to the circuit does not
 // match the ones from the circuit description
 pub(crate) fn check_unsatisfied_circuit<C, R>(
-    prover: &Prover<C>,
+    prover: &Prover,
     circuit: &C,
     rng: &mut R,
     msg: &str,


### PR DESCRIPTION
This commit introduces `Compiler::compress` and `Compiler::decompress`, two functions that will create a compressed representation of a circuit that can be used to generate prover and verifier keys.

The compression strategy takes advantage of the fact that circuit representations are sparse; meaning, most of the scalars are zeroes. We also have a higher incidence of `1` and `-1`, so any value that is equivalent to a `i8` is compressed into a single byte, instead of the regular `32` bytes of a bls12-381.

This will result in expressive gains in terms of storage. For instance, a `2^12` circuit can be compressed into roughly 100Kb.