### PR TITLE
Release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2022-04-06
+
 ### Added
 
 - Add and restructure tests for `assert_equal_point` [#725]
 - Add and restructure tests for `assert_equal_public_point` [#727]
-- Add and restructure tests for `append_gate` [#741]
+- Add and restructure tests for `append_gate` [#737]
 - Add and restructure tests for `assert_equal` and `assert_equal_constant` [#733]
 - Add and restructure tests for logic component [#734]
 - Add and restructure tests for range component [#735]
@@ -26,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix negation of public input values when using `composer.append_public` [#717]
-- Fix `assert_equal_point` method [#721]
+- Fix `assert_equal_point` method [#720]
 - Fix negation of constant in `append_equal_constant` [#728]
 - Fix negation of public point coordinates in `assert_equal_public_point` [#728]
 - Fix `ProverKey::serialization_size` and number of coefficients in a constraint [#743]
@@ -475,13 +477,13 @@ is necessary since `rkyv/validation` was required as a bound.
 [#735]: https://github.com/dusk-network/plonk/issues/735
 [#734]: https://github.com/dusk-network/plonk/issues/734
 [#743]: https://github.com/dusk-network/plonk/issues/743
-[#741]: https://github.com/dusk-network/plonk/issues/741
+[#737]: https://github.com/dusk-network/plonk/issues/737
 [#733]: https://github.com/dusk-network/plonk/issues/733
 [#731]: https://github.com/dusk-network/plonk/issues/731
 [#728]: https://github.com/dusk-network/plonk/issues/728
 [#727]: https://github.com/dusk-network/plonk/issues/727
 [#725]: https://github.com/dusk-network/plonk/issues/725
-[#721]: https://github.com/dusk-network/plonk/issues/721
+[#720]: https://github.com/dusk-network/plonk/issues/720
 [#717]: https://github.com/dusk-network/plonk/issues/717
 [#709]: https://github.com/dusk-network/plonk/issues/709
 [#697]: https://github.com/dusk-network/plonk/issues/697
@@ -572,7 +574,8 @@ is necessary since `rkyv/validation` was required as a bound.
 [#282]: https://github.com/dusk-network/plonk/issues/282
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/plonk/compare/v0.13.1...HEAD
+[Unreleased]: https://github.com/dusk-network/plonk/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/dusk-network/plonk/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/dusk-network/plonk/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/dusk-network/plonk/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/dusk-network/plonk/compare/v0.11.0...v0.12.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-plonk"
-version = "0.13.1"
+version = "0.14.0"
 categories =["algorithms", "cryptography", "science", "mathematics"]
 edition = "2021"
 keywords = ["cryptography", "plonk", "zk-snarks", "zero-knowledge", "crypto"]


### PR DESCRIPTION
## [0.14.0](https://github.com/dusk-network/plonk/compare/v0.13.1...v0.14.0) - 2022-04-06

### Added

- Add and restructure tests for `assert_equal_point` [#725]
- Add and restructure tests for `assert_equal_public_point` [#727]
- Add and restructure tests for `append_gate` [#737]
- Add and restructure tests for `assert_equal` and `assert_equal_constant` [#733]
- Add and restructure tests for logic component [#734]
- Add and restructure tests for range component [#735]
- Add and restructure tests for boolean and select components [#731]
- Add tests for `gate_add` and `gate_mul` [#736]
- Add and restructure tests for `component_decomposition` [#738]

### Removed

- Remove `bit_iterator` macro [#632]

### Fixed

- Fix negation of public input values when using `composer.append_public` [#717]
- Fix `assert_equal_point` method [#720]
- Fix negation of constant in `append_equal_constant` [#728]
- Fix negation of public point coordinates in `assert_equal_public_point` [#728]
- Fix `ProverKey::serialization_size` and number of coefficients in a constraint [#743]
- Fix range gate for `bit_num = 0` [#746]

