### PR TITLE
Implement Iter and IntoIter for Polynomial

### DIFF
--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -182,7 +182,7 @@ impl CommitKey {
         // Compute commitment
         Ok(Commitment::from(msm_variable_base(
             &self.powers_of_g,
-            &polynomial.coeffs,
+            polynomial,
         )))
     }
 

--- a/src/fft/polynomial.rs
+++ b/src/fft/polynomial.rs
@@ -51,6 +51,15 @@ impl DerefMut for Polynomial {
     }
 }
 
+impl IntoIterator for Polynomial {
+    type Item = BlsScalar;
+    type IntoIter = <Vec<BlsScalar> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.coeffs.into_iter()
+    }
+}
+
 impl Polynomial {
     /// Returns the zero polynomial.
     pub(crate) const fn zero() -> Self {

--- a/src/fft/polynomial.rs
+++ b/src/fft/polynomial.rs
@@ -34,7 +34,7 @@ use rkyv::{
 pub(crate) struct Polynomial {
     /// The coefficient of `x^i` is stored at location `i` in `self.coeffs`.
     #[cfg_attr(feature = "rkyv-impl", omit_bounds)]
-    pub(crate) coeffs: Vec<BlsScalar>,
+    coeffs: Vec<BlsScalar>,
 }
 
 impl Deref for Polynomial {
@@ -140,6 +140,11 @@ impl Polynomial {
             .collect::<Result<Vec<BlsScalar>, dusk_bytes::Error>>()?;
 
         Ok(Polynomial { coeffs })
+    }
+
+    /// Returns an iterator over the polynomial coefficients.
+    fn iter(&self) -> impl Iterator<Item = &BlsScalar> {
+        self.coeffs.iter()
     }
 }
 

--- a/src/proof_system/quotient_poly.rs
+++ b/src/proof_system/quotient_poly.rs
@@ -213,7 +213,7 @@ fn compute_permutation_checks(
     let domain_8n = EvaluationDomain::new(8 * domain.size()).unwrap();
     let l1_poly_alpha =
         compute_first_lagrange_poly_scaled(domain, alpha.square());
-    let l1_alpha_sq_evals = domain_8n.coset_fft(&l1_poly_alpha.coeffs);
+    let l1_alpha_sq_evals = domain_8n.coset_fft(&l1_poly_alpha);
 
     #[cfg(not(feature = "std"))]
     let range = (0..domain_8n.size()).into_iter();

--- a/src/proof_system/widget.rs
+++ b/src/proof_system/widget.rs
@@ -430,7 +430,7 @@ pub(crate) mod alloc {
                     // If the announced len is zero, simply return an empty poly
                     // and leave the buffer intact.
                     if serialized_poly_len == 0 {
-                        return Ok(Polynomial { coeffs: vec![] });
+                        return Ok(Polynomial::zero());
                     }
                     let (a, b) = buf.split_at(serialized_poly_len);
                     let poly = Polynomial::from_slice(a);


### PR DESCRIPTION
# Related issue(s)

Related to https://github.com/dusk-network/plonk/issues/174.

# Description

## Changes

- make the `Vec` inside of the `Polynomial` struct private
- implement `IntoIterator` for `Polynomial`
- implement `iter()` for `Polynomial`
- propagate the effects of previous changes by removing direct access to the wrapped `Vec`