### PR TITLE
Add `size` method to `Circuit` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `size` method to the `Circuit` trait [#767]
+
+### Removed
+
+- Remove public parametes as parameters for circuit compression [#767]
+
 ## [0.15.0] - 2023-08-30
 
 ### Fixed

--- a/src/composer/builder.rs
+++ b/src/composer/builder.rs
@@ -77,13 +77,13 @@ impl ops::Index<Witness> for Builder {
 }
 
 impl Composer for Builder {
-    fn uninitialized(capacity: usize) -> Self {
+    fn uninitialized() -> Self {
         Self {
-            constraints: Vec::with_capacity(capacity),
+            constraints: Vec::new(),
             public_inputs: HashMap::new(),
-            witnesses: Vec::with_capacity(capacity),
+            witnesses: Vec::new(),
             perm: Permutation::new(),
-            runtime: Runtime::with_capacity(capacity),
+            runtime: Runtime::new(),
         }
     }
 

--- a/src/composer/circuit.rs
+++ b/src/composer/circuit.rs
@@ -16,4 +16,16 @@ pub trait Circuit: Default {
     fn circuit<C>(&self, composer: &mut C) -> Result<(), Error>
     where
         C: Composer;
+
+    /// Returns the size of the circuit.
+    fn size<C>(&self) -> usize
+    where
+        C: Composer,
+    {
+        let mut composer = C::initialized();
+        match self.circuit(&mut composer) {
+            Ok(_) => composer.constraints(),
+            Err(_) => 0,
+        }
+    }
 }

--- a/src/composer/compiler.rs
+++ b/src/composer/compiler.rs
@@ -35,9 +35,7 @@ impl Compiler {
     where
         C: Circuit,
     {
-        let max_size = Self::max_size(pp);
-        let mut builder = Builder::initialized(max_size);
-
+        let mut builder = Builder::initialized();
         C::default().circuit(&mut builder)?;
 
         Self::compile_with_builder(pp, label, &builder)
@@ -54,9 +52,7 @@ impl Compiler {
     where
         C: Circuit,
     {
-        let max_size = Self::max_size(pp);
-        let mut builder = Builder::initialized(max_size);
-
+        let mut builder = Builder::initialized();
         circuit.circuit(&mut builder)?;
 
         Self::compile_with_builder(pp, label, &builder)
@@ -65,14 +61,11 @@ impl Compiler {
     /// Return a bytes representation of a compressed circuit, capable of
     /// generating its prover and verifier instances.
     #[cfg(feature = "alloc")]
-    pub fn compress<C>(pp: &PublicParameters) -> Result<Vec<u8>, Error>
+    pub fn compress<C>() -> Result<Vec<u8>, Error>
     where
         C: Circuit,
     {
-        compress::CompressedCircuit::from_circuit::<C>(
-            pp,
-            compress::Version::V2,
-        )
+        compress::CompressedCircuit::from_circuit::<C>(compress::Version::V2)
     }
 
     /// Generates a [Prover] and [Verifier] from a buffer created by
@@ -83,11 +76,6 @@ impl Compiler {
         compressed: &[u8],
     ) -> Result<(Prover, Verifier), Error> {
         compress::CompressedCircuit::from_bytes(pp, label, compressed)
-    }
-
-    /// Returns the maximum constraints length for the parameters.
-    fn max_size(pp: &PublicParameters) -> usize {
-        (pp.commit_key.powers_of_g.len() - 1) >> 1
     }
 
     /// Create a new arguments set from a given circuit instance

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -181,6 +181,13 @@ impl Debugger {
         }
     }
 
+    pub(crate) fn new() -> Self {
+        Self {
+            witnesses: Vec::new(),
+            constraints: Vec::new(),
+        }
+    }
+
     pub(crate) fn with_capacity(capacity: usize) -> Self {
         Self {
             witnesses: Vec::with_capacity(capacity),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -42,6 +42,15 @@ pub struct Runtime {
 }
 
 impl Runtime {
+    /// Create a new PLONK runtime
+    #[allow(unused_variables)]
+    pub fn new() -> Self {
+        Self {
+            #[cfg(feature = "debug")]
+            debugger: Debugger::new(),
+        }
+    }
+
     /// Create a new PLONK runtime with the provided capacity
     #[allow(unused_variables)]
     pub fn with_capacity(capacity: usize) -> Self {

--- a/tests/composer.rs
+++ b/tests/composer.rs
@@ -87,7 +87,7 @@ fn circuit_with_all_gates() {
     let (prover, verifier) = Compiler::compile::<DummyCircuit>(&pp, label)
         .expect("failed to compile circuit");
 
-    let compressed = Compiler::compress::<DummyCircuit>(&pp)
+    let compressed = Compiler::compress::<DummyCircuit>()
         .expect("failed to compress circuit");
 
     let (decompressed_prover, decompressed_verifier) =


### PR DESCRIPTION
This change also removes the need to preallocate the circuit builder which in turn removes the need to pass the public parameters when compressing a circuit.

Resolves #767 