### PR TITLE
Release 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2023-10-11
+
 ### Added
 
 - Add `size` method to the `Circuit` trait [#767]
@@ -615,7 +617,8 @@ is necessary since `rkyv/validation` was required as a bound.
 [#282]: https://github.com/dusk-network/plonk/issues/282
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/plonk/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/dusk-network/plonk/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/dusk-network/plonk/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/dusk-network/plonk/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/dusk-network/plonk/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/dusk-network/plonk/compare/v0.13.1...v0.14.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-plonk"
-version = "0.15.0"
+version = "0.16.0"
 categories =["algorithms", "cryptography", "science", "mathematics"]
 edition = "2021"
 keywords = ["cryptography", "plonk", "zk-snarks", "zero-knowledge", "crypto"]


### PR DESCRIPTION
## [0.16.0] - 2023-10-11

### Added

- Add `size` method to the `Circuit` trait [#767]
- Add `ff` dependency

### Removed

- Remove `PublicParameters` from parameters for circuit compression [#767]
- Remove `canonical` and `canonical_derive` dependency
- Remove `canon` feature

### Changed

- update `dusk-bls12_381` dependency to "0.12"
- update `dusk-jubjub` dependency to "0.13"

[0.16.0]: https://github.com/dusk-network/plonk/compare/v0.15.0...v0.16.0
