### PR TITLE
rename polynomial to arithmetization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update `criterion` dev-dependency to 0.5
 - Fix clippy warnings [#774]
+- Rename `composer::Polynomial` to `composer::Arithmetization`
+- Rename `fft::{Polynomial as FftPolynomial}` to `fft::Polynomial`
 
 ## [0.16.0] - 2023-10-11
 

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -21,17 +21,17 @@ use crate::constraint_system::{
 use crate::error::Error;
 use crate::runtime::{Runtime, RuntimeEvent};
 
+mod arithmetization;
 mod builder;
 mod circuit;
 mod compiler;
-mod polynomial;
 mod prover;
 mod verifier;
 
+pub use arithmetization::Arithmetization;
 pub use builder::Builder;
 pub use circuit::Circuit;
 pub use compiler::Compiler;
-pub use polynomial::Polynomial;
 pub use prover::Prover;
 pub use verifier::Verifier;
 

--- a/src/composer/arithmetization.rs
+++ b/src/composer/arithmetization.rs
@@ -10,7 +10,7 @@ use crate::constraint_system::Witness;
 
 /// Represents a polynomial in coefficient form with its associated wire data
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Polynomial {
+pub struct Arithmetization {
     // Selectors
     /// Multiplier selector
     pub(crate) q_m: BlsScalar,

--- a/src/composer/builder.rs
+++ b/src/composer/builder.rs
@@ -14,13 +14,13 @@ use crate::constraint_system::{Constraint, Selector, WiredWitness, Witness};
 use crate::permutation::Permutation;
 use crate::runtime::Runtime;
 
-use super::{Composer, Polynomial};
+use super::{Arithmetization, Composer};
 
 /// Construct and prove circuits
 #[derive(Debug, Clone)]
 pub struct Builder {
     /// Constraint system gates
-    pub(crate) constraints: Vec<Polynomial>,
+    pub(crate) constraints: Vec<Arithmetization>,
 
     /// Sparse representation of the public inputs
     pub(crate) public_inputs: HashMap<usize, BlsScalar>,
@@ -125,7 +125,7 @@ impl Composer for Builder {
         let q_variable_group_add =
             *constraint.coeff(Selector::GroupAddVariableBase);
 
-        let poly = Polynomial {
+        let poly = Arithmetization {
             q_m,
             q_l,
             q_r,

--- a/src/composer/compiler.rs
+++ b/src/composer/compiler.rs
@@ -12,11 +12,11 @@ use dusk_bls12_381::BlsScalar;
 use crate::commitment_scheme::{CommitKey, OpeningKey, PublicParameters};
 use crate::constraint_system::{Constraint, Selector, Witness};
 use crate::error::Error;
-use crate::fft::{EvaluationDomain, Evaluations, Polynomial as FftPolynomial};
+use crate::fft::{EvaluationDomain, Evaluations, Polynomial};
 use crate::proof_system::preprocess::Polynomials;
 use crate::proof_system::{widget, ProverKey};
 
-use super::{Builder, Circuit, Composer, Polynomial, Prover, Verifier};
+use super::{Arithmetization, Builder, Circuit, Composer, Prover, Verifier};
 
 #[cfg(feature = "alloc")]
 mod compress;
@@ -151,19 +151,19 @@ impl Compiler {
         let q_fixed_group_add_poly = domain.ifft(&q_fixed_group_add);
         let q_variable_group_add_poly = domain.ifft(&q_variable_group_add);
 
-        let q_m_poly = FftPolynomial::from_coefficients_vec(q_m_poly);
-        let q_l_poly = FftPolynomial::from_coefficients_vec(q_l_poly);
-        let q_r_poly = FftPolynomial::from_coefficients_vec(q_r_poly);
-        let q_o_poly = FftPolynomial::from_coefficients_vec(q_o_poly);
-        let q_c_poly = FftPolynomial::from_coefficients_vec(q_c_poly);
-        let q_d_poly = FftPolynomial::from_coefficients_vec(q_d_poly);
-        let q_arith_poly = FftPolynomial::from_coefficients_vec(q_arith_poly);
-        let q_range_poly = FftPolynomial::from_coefficients_vec(q_range_poly);
-        let q_logic_poly = FftPolynomial::from_coefficients_vec(q_logic_poly);
+        let q_m_poly = Polynomial::from_coefficients_vec(q_m_poly);
+        let q_l_poly = Polynomial::from_coefficients_vec(q_l_poly);
+        let q_r_poly = Polynomial::from_coefficients_vec(q_r_poly);
+        let q_o_poly = Polynomial::from_coefficients_vec(q_o_poly);
+        let q_c_poly = Polynomial::from_coefficients_vec(q_c_poly);
+        let q_d_poly = Polynomial::from_coefficients_vec(q_d_poly);
+        let q_arith_poly = Polynomial::from_coefficients_vec(q_arith_poly);
+        let q_range_poly = Polynomial::from_coefficients_vec(q_range_poly);
+        let q_logic_poly = Polynomial::from_coefficients_vec(q_logic_poly);
         let q_fixed_group_add_poly =
-            FftPolynomial::from_coefficients_vec(q_fixed_group_add_poly);
+            Polynomial::from_coefficients_vec(q_fixed_group_add_poly);
         let q_variable_group_add_poly =
-            FftPolynomial::from_coefficients_vec(q_variable_group_add_poly);
+            Polynomial::from_coefficients_vec(q_variable_group_add_poly);
 
         // 2. compute the sigma polynomials
         let [s_sigma_1_poly, s_sigma_2_poly, s_sigma_3_poly, s_sigma_4_poly] =

--- a/src/composer/compiler/compress.rs
+++ b/src/composer/compiler/compress.rs
@@ -11,8 +11,8 @@ use msgpacker::{MsgPacker, Packable, Unpackable};
 use alloc::vec::Vec;
 
 use super::{
-    BlsScalar, Builder, Circuit, Compiler, Composer, Constraint, Error,
-    Polynomial, Prover, PublicParameters, Selector, Verifier, Witness,
+    Arithmetization, BlsScalar, Builder, Circuit, Compiler, Composer,
+    Constraint, Error, Prover, PublicParameters, Selector, Verifier, Witness,
 };
 
 mod hades;
@@ -103,7 +103,7 @@ impl CompressedCircuit {
         let mut polynomials = HashMap::new();
         let constraints = constraints
             .map(
-                |Polynomial {
+                |Arithmetization {
                      q_m,
                      q_l,
                      q_r,

--- a/src/composer/prover.rs
+++ b/src/composer/prover.rs
@@ -15,7 +15,7 @@ use rand_core::{CryptoRng, RngCore};
 
 use crate::commitment_scheme::CommitKey;
 use crate::error::Error;
-use crate::fft::{EvaluationDomain, Polynomial as FftPolynomial};
+use crate::fft::{EvaluationDomain, Polynomial};
 use crate::proof_system::proof::Proof;
 use crate::proof_system::{
     linearization_poly, quotient_poly, ProverKey, VerifierKey,
@@ -79,7 +79,7 @@ impl Prover {
         witnesses: &[BlsScalar],
         hiding_degree: usize,
         domain: &EvaluationDomain,
-    ) -> FftPolynomial
+    ) -> Polynomial
     where
         R: RngCore + CryptoRng,
     {
@@ -92,7 +92,7 @@ impl Prover {
             w_vec_inverse.push(blinding_scalar);
         }
 
-        FftPolynomial::from_coefficients_vec(w_vec_inverse)
+        Polynomial::from_coefficients_vec(w_vec_inverse)
     }
 
     fn prepare_serialize(
@@ -324,7 +324,7 @@ impl Prover {
 
         // compute public inputs polynomial
         let pi_poly = domain.ifft(&dense_public_inputs);
-        let pi_poly = FftPolynomial::from_coefficients_vec(pi_poly);
+        let pi_poly = Polynomial::from_coefficients_vec(pi_poly);
 
         // compute quotient polynomial
         let wires = (&a_w_poly, &b_w_poly, &o_w_poly, &d_w_poly);
@@ -373,10 +373,10 @@ impl Prover {
         // t_4'(X) - b_12
         t_4_vec[0] -= b_12;
 
-        let t_low_poly = FftPolynomial::from_coefficients_vec(t_low_vec);
-        let t_mid_poly = FftPolynomial::from_coefficients_vec(t_mid_vec);
-        let t_high_poly = FftPolynomial::from_coefficients_vec(t_high_vec);
-        let t_4_poly = FftPolynomial::from_coefficients_vec(t_4_vec);
+        let t_low_poly = Polynomial::from_coefficients_vec(t_low_vec);
+        let t_mid_poly = Polynomial::from_coefficients_vec(t_mid_vec);
+        let t_high_poly = Polynomial::from_coefficients_vec(t_high_vec);
+        let t_4_poly = Polynomial::from_coefficients_vec(t_4_vec);
 
         // commit to split quotient polynomial
         let t_low_commit = self.commit_key.commit(&t_low_poly)?;


### PR DESCRIPTION
close https://github.com/dusk-network/plonk/issues/706

`composer::Polynomial` and `fft::Polynomial` are confusing so renamed `composer::Polynomial` to `Arithmetization`.
I renamed `fft::Polynomial as FftPolynomial ` to `Polynomial` accordingly.

I would appreciate it if you could confirm.
Thank you.