### PR TITLE
refactor polynomial operations

### DIFF
--- a/src/fft/evaluations.rs
+++ b/src/fft/evaluations.rs
@@ -7,7 +7,6 @@
 //! A polynomial represented in evaluations form over a domain of size 2^n.
 
 use super::domain::EvaluationDomain;
-use super::polynomial::Polynomial;
 use crate::error::Error;
 use alloc::vec::Vec;
 use core::ops::{
@@ -72,13 +71,6 @@ impl Evaluations {
         domain: EvaluationDomain,
     ) -> Self {
         Self { evals, domain }
-    }
-
-    /// Interpolate a polynomial from a list of evaluations
-    pub(crate) fn interpolate(self) -> Polynomial {
-        let Self { mut evals, domain } = self;
-        domain.ifft_in_place(&mut evals);
-        Polynomial::from_coefficients_vec(evals)
     }
 }
 


### PR DESCRIPTION
I refactored polynomial operations because it was a little bit of complicated.
The reason why I removed `interpolate` was that I would like to work on removal of `Evaluations::domain` as follows and `interpolate` would be the bottleneck of it.
https://github.com/dusk-network/plonk/blob/master/src/fft/evaluations.rs#L39

I would appreciate it if you could confirm.
Thank you.