### PR TITLE
Bump to version 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2023-11-1
+
 ### Added
 
 - Add `JubJubScalarMalformed` error [#784]
@@ -632,7 +634,8 @@ is necessary since `rkyv/validation` was required as a bound.
 [#282]: https://github.com/dusk-network/plonk/issues/282
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/plonk/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/dusk-network/plonk/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/dusk-network/plonk/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/dusk-network/plonk/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/dusk-network/plonk/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/dusk-network/plonk/compare/v0.14.0...v0.14.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-plonk"
-version = "0.16.0"
+version = "0.17.0"
 categories =["algorithms", "cryptography", "science", "mathematics"]
 edition = "2021"
 keywords = ["cryptography", "plonk", "zk-snarks", "zero-knowledge", "crypto"]


### PR DESCRIPTION
## [0.17.0] - 2023-11-1

### Added

- Add `JubJubScalarMalformed` error [#784]
- Add blinding factors to the quotient polynomial [#773]

### Changed

- Update `criterion` dev-dependency to 0.5
- Fix clippy warnings [#774]
- Rename `composer::Polynomial` to `composer::Arithmetization`
- Rename `fft::{Polynomial as FftPolynomial}` to `fft::Polynomial`

[0.17.0]: https://github.com/dusk-network/plonk/compare/v0.16.0...v0.17.0