### PR TITLE
Bump to v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2023-12-13
+
+### Changed
+
+- dusk-bls12_381 -> 0.13
+- dusk-jubjub -> 0.14
+
 ## [0.17.0] - 2023-11-1
 
 ### Added
@@ -634,7 +641,8 @@ is necessary since `rkyv/validation` was required as a bound.
 [#282]: https://github.com/dusk-network/plonk/issues/282
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/plonk/compare/v0.17.0...HEAD
+[Unreleased]: https://github.com/dusk-network/plonk/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/dusk-network/plonk/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/dusk-network/plonk/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/dusk-network/plonk/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/dusk-network/plonk/compare/v0.14.1...v0.15.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-plonk"
-version = "0.17.0"
+version = "0.18.0"
 categories =["algorithms", "cryptography", "science", "mathematics"]
 edition = "2021"
 keywords = ["cryptography", "plonk", "zk-snarks", "zero-knowledge", "crypto"]


### PR DESCRIPTION
## [0.18.0] - 2023-12-13

### Changed

- dusk-bls12_381 -> 0.13
- dusk-jubjub -> 0.14

[0.18.0]: https://github.com/dusk-network/plonk/compare/v0.17.0...v0.18.0
