### PR TITLE
Release 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2024-01-03
+
 ### Fixed
 
 - Fix inconsistency in gate ordering of arithmetic verifier key [#797]
@@ -678,7 +680,8 @@ is necessary since `rkyv/validation` was required as a bound.
 [#282]: https://github.com/dusk-network/plonk/issues/282
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/plonk/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/dusk-network/plonk/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/dusk-network/plonk/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/dusk-network/plonk/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/dusk-network/plonk/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/dusk-network/plonk/compare/v0.15.0...v0.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix inconsistency in gate ordering of arithmetic verifier key [#797]
 - Fix leading coefficients might be zero [#796]
+- Fix tests when default features are turned off by placing them behind the `alloc` feature
 
 ### Changed
 
@@ -29,6 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Remove `Builder` struct with introduction of `Composer` struct [#802]
+- Remove example from README in favor of an actual example in the example directory that is behind the `alloc` feature [#346]
+
+### Added
+
+- Add example for circuit creation [#346]
 
 ## [0.18.0] - 2023-12-13
 
@@ -660,6 +666,7 @@ is necessary since `rkyv/validation` was required as a bound.
 [#351]: https://github.com/dusk-network/plonk/issues/351
 [#396]: https://github.com/dusk-network/plonk/issues/396
 [#354]: https://github.com/dusk-network/plonk/issues/354
+[#346]: https://github.com/dusk-network/plonk/issues/346
 [#343]: https://github.com/dusk-network/plonk/issues/343
 [#383]: https://github.com/dusk-network/plonk/issues/383
 [#371]: https://github.com/dusk-network/plonk/issues/371

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-plonk"
-version = "0.18.0"
+version = "0.19.0"
 categories =["algorithms", "cryptography", "science", "mathematics"]
 edition = "2021"
 keywords = ["cryptography", "plonk", "zk-snarks", "zero-knowledge", "crypto"]


### PR DESCRIPTION
## [0.19.0] - 2024-01-03

### Fixed

- Fix inconsistency in gate ordering of arithmetic verifier key [#797]
- Fix leading coefficients might be zero [#796]
- Fix tests when default features are turned off by placing them behind the `alloc` feature

### Changed

- Improve InvalidCircuitSize error [#792]
- Hide all modules except 'prelude' [#782]
- Turn `Composer` trait into a struct [#802]
- Rename `Arithmetization` to `Gate` [#802]
- Change internal module structure [#805]:
  - Move compiler module to root
  - Move prover and verifier modules under compiler
  - Move compress module under composer
  - Move constraint_system module under composer
  - Move permutation module under composer
- Change API for circuit (de-)compression [#804]

### Removed

- Remove `Builder` struct with introduction of `Composer` struct [#802]
- Remove example from README in favor of an actual example in the example directory that is behind the `alloc` feature [#346]

### Added

- Add example for circuit creation [#346]

[0.19.0]: https://github.com/dusk-network/plonk/compare/v0.18.0...v0.19.0
