### PR TITLE
Include examples in the release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,6 @@ exclude = [
     "**/.gitignore",
     ".gitignore",
     "Cargo.lock",
-    "**/examples",
-    "benchmarks/",
     ".github/"
 ]
 


### PR DESCRIPTION
If the examples are excluded, the crate can not be published.