### PR TITLE
Bump to v0.19.2-rc.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-plonk"
-version = "0.19.1"
+version = "0.19.2-rc.0"
 categories =["algorithms", "cryptography", "science", "mathematics"]
 edition = "2021"
 keywords = ["cryptography", "plonk", "zk-snarks", "zero-knowledge", "crypto"]


### PR DESCRIPTION
### Added

- Add `zeroize` as an optional dependency [#818]
- Add `zeroize` feature [#818]
- Add `Zeroize` trait implementation for `Witness` behind `zeroize` feature [#818]

This rc release outside of the release schedule is needed for being able to open poseidon for audit.