### PR TITLE
Bump to v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2024-08-14
+
 ### Changed 
 
 - Modify the prover to match the paper [#831]
@@ -716,7 +718,8 @@ is necessary since `rkyv/validation` was required as a bound.
 [#282]: https://github.com/dusk-network/plonk/issues/282
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/plonk/compare/v0.19.2...HEAD
+[Unreleased]: https://github.com/dusk-network/plonk/compare/v0.20.0...HEAD
+[0.20.0]: https://github.com/dusk-network/plonk/compare/v0.19.2...v0.20.0
 [0.19.2]: https://github.com/dusk-network/plonk/compare/v0.19.1...v0.19.2
 [0.19.1]: https://github.com/dusk-network/plonk/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/dusk-network/plonk/compare/v0.18.0...v0.19.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-plonk"
-version = "0.19.2"
+version = "0.20.0"
 categories =["algorithms", "cryptography", "science", "mathematics"]
 edition = "2021"
 keywords = ["cryptography", "plonk", "zk-snarks", "zero-knowledge", "crypto"]


### PR DESCRIPTION
## [0.20.0] - 2024-08-14

### Changed 

- Modify the prover to match the paper [#831]
- Modify the verifier to match the paper [#831]
- Rename some variables to match the paper [#831]
- Modify the parallelization to have a faster verifier [#834]

### Removed

- Remove docs [#819]
- Remove unused `Evaluations` struct


[0.20.0]: https://github.com/dusk-network/plonk/compare/v0.19.2...v0.20.0
