### PR TITLE
Fix grammatical and spelling errors in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Remove 'setup' funcion from common test module [#763]
+- Remove 'setup' function from common test module [#763]
 
 ### Changed
 
@@ -356,7 +356,7 @@ is necessary since `rkyv/validation` was required as a bound.
 - Removed previous implementations attached to `PublicInputValues`. [#416]
 - Deprecated `anyhow` and `thiserror`. [#343]
 - Remove `serialisation` module and use single serialization fn's. [#347]
-- Remove uncessary `match` branch for `var_c` [#414]
+- Remove unnecessary `match` branch for `var_c` [#414]
 - Remove legacy fns and move to test modules the only-for-testing ones. [#434]
 
 ### Changed

--- a/src/proof_system/widget/ecc/scalar_mul/fixed_base.rs
+++ b/src/proof_system/widget/ecc/scalar_mul/fixed_base.rs
@@ -15,7 +15,7 @@ pub(crate) use proverkey::ProverKey;
 pub(crate) use verifierkey::VerifierKey;
 
 // Note: The ECC gadget does not check that the initial point is on the curve
-// for two reasons:
+// following reasons:
 // - We constrain the accumulator to start from the identity point, which the
 //   verifier knows is on the curve
 // - We are adding multiples of the generator to the accumulator which the


### PR DESCRIPTION

## Changes

### CHANGELOG.md
- Old: 'setup' funcion
- New: 'setup' function
Reason: Fixed spelling error of "function"

- Old: uncessary
- New: unnecessary 
Reason: Fixed spelling error of "unnecessary"

### src/proof_system/widget/ecc/scalar_mul/fixed_base.rs
- Old: for two reasons
- New: following reasons
Reason: Fixed logical inconsistency since the comment lists three reasons rather than two

## Description

These changes improve the documentation quality by:
1. Fixing spelling errors that could confuse readers
2. Making the documentation more logically consistent
3. Maintaining professional standards in technical documentation

The changes are minor text corrections that do not affect functionality but improve readability and professionalism of the codebase.