### PR TITLE
Fixed typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -330,7 +330,7 @@ is necessary since `rkyv/validation` was required as a bound.
 
 ### Fixed
 
-- Fix circuit debuggger compilation issues. [#488]
+- Fix circuit debugger compilation issues. [#488]
 - Fix import paths for lib components. [#489]
 
 ## [0.6.1] - 2021-03-12


### PR DESCRIPTION
### Changes

1. **File:** `/CHANGELOG.md`
    - Fixed `debuggger` to `debugger` (Line 333)

### Purpose

- Enhanced the clarity and professionalism of the documentation.
- Fixed minor grammatical issues for better understanding.