### PR TITLE
Corrected typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -356,7 +356,7 @@ is necessary since `rkyv/validation` was required as a bound.
 - Removed previous implementations attached to `PublicInputValues`. [#416]
 - Deprecated `anyhow` and `thiserror`. [#343]
 - Remove `serialisation` module and use single serialization fn's. [#347]
-- Remove uncessary `match` branch for `var_c` [#414]
+- Remove unnecessary `match` branch for `var_c` [#414]
 - Remove legacy fns and move to test modules the only-for-testing ones. [#434]
 
 ### Changed


### PR DESCRIPTION
### Changes

1. **File:** `/CHANGELOG.md`
    - Fixed `uncessary` to `unnecessary` (Line 359)

### Purpose

- EImproved the documentation's clarity and professional tone.
- Corrected small grammatical errors to enhance comprehension.