### PR TITLE
Update rust toolchain to nightly 2024-10-17 (1.84.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update rust toolchain to nightly 2024-10-17 (1.84.0)
+
 ## [0.21.0] - 2025-02-06
 
 ### Changed

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-11-10"
-components = ["rustfmt", "clippy"]
+channel = "nightly-2024-10-17"
+components = ["rustfmt", "cargo", "clippy"]


### PR DESCRIPTION
Update the toolchain to match version 1.82 used in other repositories and resolve recent CI failures.

Edit: Update to 1.84 due to #![feature(unsafe_extern_blocks)] problems that made the CI still fail.

CI failure reference: https://github.com/dusk-network/plonk/pull/854