### PR TITLE
Release dusk-plonk 0.22.1

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -19,47 +19,52 @@ jobs:
 
   build_benches:
     name: Build Benchmarks
-    runs-on: ubuntu-latest
+    runs-on: core
     steps:
       - uses: actions/checkout@v4
+      - uses: dsherret/rust-toolchain-file@v1
       - uses: Swatinem/rust-cache@v2
       - run: cargo bench --no-run
 
   run_examples:
     name: Run Examples
-    runs-on: ubuntu-latest
+    runs-on: core
     steps:
       - uses: actions/checkout@v4
+      - uses: dsherret/rust-toolchain-file@v1
       - uses: Swatinem/rust-cache@v2
       - run: cargo run --release --example circuit
 
   build_docs:
     name: Build Documentation
-    runs-on: ubuntu-latest
+    runs-on: core
     steps:
       - uses: actions/checkout@v4
+      - uses: dsherret/rust-toolchain-file@v1
       - run: make doc
       - run: make doc-internal
 
   build_no_std:
     name: Build no_std
-    runs-on: ubuntu-latest
+    runs-on: core
     steps:
       - uses: actions/checkout@v4
+      - uses: dsherret/rust-toolchain-file@v1
       - uses: Swatinem/rust-cache@v2
       - run: make no-std
 
   test:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: core
     steps:
       - uses: actions/checkout@v4
+      - uses: dsherret/rust-toolchain-file@v1
       - uses: Swatinem/rust-cache@v2
       - run: make test
 
   coverage:
     name: Coverage
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -46,17 +46,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: rustup target add thumbv6m-none-eabi
       - uses: Swatinem/rust-cache@v2
+      - run: make no-std
 
-      - name: Build project with alloc
-        run: cargo build --release --no-default-features --features alloc --target thumbv6m-none-eabi
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - run: make test
 
-      - name: Build project without alloc
-        run: cargo build --release --no-default-features --target thumbv6m-none-eabi
-
-  ci:
-    name: Test with all features
+  coverage:
+    name: Coverage
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -71,7 +73,3 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{secrets.CODECOV_TOKEN}}
-
-  test_stable_std:
-    name: Stable tests std
-    uses: dusk-network/.github/.github/workflows/run-tests.yml@main

--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -64,7 +64,7 @@ jobs:
 
   coverage:
     name: Coverage
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,98 @@
+# Plonk — AI Agent Instructions
+
+## Project Overview
+
+**dusk-plonk** is a pure Rust implementation of the PLONK ZK proving system over BLS12-381 with a KZG10 polynomial commitment scheme and custom gates. Single crate, no workspace.
+
+### Key Directories
+
+| Directory | Purpose |
+|-----------|---------|
+| `src/` | Library source |
+| `src/composer/` | Circuit building, constraint system, gates |
+| `src/proof_system/` | Proving and verification, widgets |
+| `src/commitment_scheme/` | KZG10 polynomial commitments |
+| `src/fft/` | Fast Fourier Transform, polynomial arithmetic |
+| `tests/` | Integration tests |
+| `benches/` | Benchmarks |
+| `examples/` | Usage example (`circuit.rs`) |
+| `docs/` | PLONK specs PDF |
+
+## Commands
+
+### Build
+
+    cargo build
+    make clippy                                  # Preferred — checks and lints in one step
+
+### Test
+
+    make test                                    # Full suite (release mode)
+    cargo test --release                         # Default features
+    cargo test --release --all-features          # All features
+    cargo test --release -t <test_name>          # Single test
+    cargo run --release --example circuit        # Run example
+
+**Tests MUST use `--release`** — debug mode takes up to an hour for proof tests.
+
+### Lint
+
+    make clippy
+    make fmt                                     # Requires nightly toolchain
+
+### no_std Verification
+
+    make no-std
+
+### Docs
+
+    make doc                                     # Build docs with KaTeX
+    make doc-local                               # Build and open in browser
+
+### PR Minimum
+
+    make test
+    make fmt
+    make clippy
+
+## Architecture
+
+Widget-based prover with a Turbo composer. Circuits implement the `Circuit` trait, which defines `circuit(&self, composer: &mut Composer)` to build constraints. The `Compiler` takes a circuit + public parameters and produces prover/verifier pairs.
+
+**Core flow**: Circuit -> Composer (constraint system) -> Compiler -> ProverKey/VerifierKey -> Proof -> Verify.
+
+**Widget types** (in `proof_system/widget/`): arithmetic, logic, range, ECC, permutation — each handles a category of constraints during proving and verification.
+
+**Commitment scheme**: KZG10 with a structured reference string (SRS). The `PublicParameters` type holds the SRS and is needed for compilation.
+
+## Feature Flags
+
+| Feature | Purpose | Default |
+|---------|---------|---------|
+| `std` | Enables rayon parallelism | Yes |
+| `alloc` | Core feature for proof construction/verification | No |
+| `debug` | Runtime debugger with CDF output | No |
+| `rkyv-impl` | rkyv serialization support | No |
+
+## Elevated Care Zone
+
+This is a cryptographic crate — soundness bugs break consensus and privacy. Work with extra diligence.
+
+- **Verify**: `make test` (covers both default and all-features) and `make no-std`
+- **Watch**: polynomial arithmetic, commitment opening proofs, transcript (Fiat-Shamir) binding, gate constraint enforcement
+
+## Conventions
+
+- **`no_std` compatible**: the crate supports `no_std` with `alloc`. Don't add `std` imports outside feature gates.
+- **Release mode testing**: always `--release` for proof tests
+- **Feature gating**: don't pull gated dependencies into default features
+- **Clippy**: don't suppress warnings — fix the underlying issue
+
+## Change Propagation
+
+Changes to plonk ripple to downstream crates — `phoenix/circuits`, `poseidon-merkle`, `rusk` to name a few. Keep this in mind when making code changes, but no need to verify downstream for non-code changes.
+
+## Git
+
+**Branches**: branch from `master`. Don't push to `master` directly.
+**Commits**: follow the style of recent commits in the repo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.1] - 2026-06-12
+
 ### Added
 
 - Add Makefile targets for test, clippy, fmt, bench, no-std, and clean
@@ -791,7 +793,8 @@ is necessary since `rkyv/validation` was required as a bound.
 [#282]: https://github.com/dusk-network/plonk/issues/282
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/plonk/compare/v0.22.0...HEAD
+[Unreleased]: https://github.com/dusk-network/plonk/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/dusk-network/plonk/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/dusk-network/plonk/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/dusk-network/plonk/compare/v0.20.3...v0.21.0
 [0.20.3]: https://github.com/dusk-network/plonk/compare/v0.20.2...v0.20.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Makefile targets for test, clippy, fmt, bench, no-std, and clean
 - Add `AGENTS.md` for AI agent orientation
-- Added more tests for low coverage parts of the code [#861]
-- Added MSRV, set to rust version `1.85` [#860]
 
 ### Changed
 
@@ -20,13 +18,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update CI to use Makefile targets for tests and no_std builds
 - Switch CI runners to `core` self-hosted runners
 
+- Speed up verifier hot paths by evaluating public inputs sparsely and
+  reducing heap allocation and scalar-multiplication overhead in proof
+  verification.
+
+### Fixed
+
+- Hardened prover/verifier deserialization length parsing to reject
+  overflowed malformed length fields without panicking.
+
+## [0.22.0] - 2026-02-27
+
+### Added
+
+- Added more tests for low coverage parts of the code [#861]
+- Added MSRV, set to rust version `1.85` [#860]
+
+### Changed
+
 - Update rust edition to 2024 [#861]
 - Update rust toolchain to stable [#859]
 - Change dependency `msgpacker`to `0.4.8`
 - Update rust toolchain to nightly 2024-10-17 (1.84.0)
-- Speed up verifier hot paths by evaluating public inputs sparsely and
-  reducing heap allocation and scalar-multiplication overhead in proof
-  verification.
 - Added `PlonkVersion::V3` and switched `PlonkVersion::current()` to `V3`.
 - Added explicit versioned proving and verification paths for
   `PlonkVersion::V2` and `PlonkVersion::V3`.
@@ -42,8 +55,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with checked parsing.
 - Removed unsafe transcript label transmute usage.
 - Wired transcript seeding so v3 correctly binds `s_sigma_4`.
-- Hardened prover/verifier deserialization length parsing to reject
-  overflowed malformed length fields without panicking.
 
 ## [0.21.0] - 2025-02-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added more tests for low coverage parts of the code [#861] 
+- Add Makefile targets for test, clippy, fmt, bench, no-std, and clean
+- Add `AGENTS.md` for AI agent orientation
+- Added more tests for low coverage parts of the code [#861]
 - Added MSRV, set to rust version `1.85` [#860]
 
 ### Changed
+
+- Update `rustfmt.toml` with nightly options (group_imports, imports_granularity, reorder_impl_items, use_field_init_shorthand)
+- Update CI to use Makefile targets for tests and no_std builds
 
 - Update rust edition to 2024 [#861]
 - Update rust toolchain to stable [#859]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with checked parsing.
 - Removed unsafe transcript label transmute usage.
 - Wired transcript seeding so v3 correctly binds `s_sigma_4`.
+- Hardened prover/verifier deserialization length parsing to reject
+  overflowed malformed length fields without panicking.
 
 ## [0.21.0] - 2025-02-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update `rustfmt.toml` with nightly options (group_imports, imports_granularity, reorder_impl_items, use_field_init_shorthand)
 - Update CI to use Makefile targets for tests and no_std builds
-- Switch CI runners to `core` self-hosted runners; bump coverage runner to `ubuntu-24.04`
+- Switch CI runners to `core` self-hosted runners
 
 - Update rust edition to 2024 [#861]
 - Update rust toolchain to stable [#859]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update rust toolchain to stable [#859]
 - Change dependency `msgpacker`to `0.4.8`
 - Update rust toolchain to nightly 2024-10-17 (1.84.0)
+- Speed up verifier hot paths by evaluating public inputs sparsely and
+  reducing heap allocation and scalar-multiplication overhead in proof
+  verification.
 - Added `PlonkVersion::V3` and switched `PlonkVersion::current()` to `V3`.
 - Added explicit versioned proving and verification paths for
   `PlonkVersion::V2` and `PlonkVersion::V3`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update `rustfmt.toml` with nightly options (group_imports, imports_granularity, reorder_impl_items, use_field_init_shorthand)
 - Update CI to use Makefile targets for tests and no_std builds
+- Switch CI runners to `core` self-hosted runners; bump coverage runner to `ubuntu-24.04`
 
 - Update rust edition to 2024 [#861]
 - Update rust toolchain to stable [#859]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-plonk"
-version = "0.22.0-rc.0"
+version = "0.22.0"
 categories =["algorithms", "cryptography", "science", "mathematics"]
 edition = "2024"
 rust-version = "1.85"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-plonk"
-version = "0.22.0"
+version = "0.22.1"
 categories =["algorithms", "cryptography", "science", "mathematics"]
 edition = "2024"
 rust-version = "1.85"

--- a/Makefile
+++ b/Makefile
@@ -3,22 +3,22 @@ help: ## Display this help screen
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 test: ## Run tests
-	cargo test --release
-	cargo test --release --all-features
+	@cargo test --release
+	@cargo test --release --all-features
 
 clippy: ## Run clippy
-	cargo clippy --features=rkyv/size_32
+	@cargo clippy --features=rkyv/size_32
 
 fmt: ## Format code (requires nightly)
-	cargo +nightly fmt --all
+	@cargo +nightly fmt --all
 
 bench: ## Run benchmarks
-	cargo bench
+	@cargo bench
 
 no-std: ## Verify no_std compatibility
-	rustup target add thumbv6m-none-eabi
-	cargo build --release --no-default-features --features alloc --target thumbv6m-none-eabi
-	cargo build --release --no-default-features --target thumbv6m-none-eabi
+	@rustup target add thumbv6m-none-eabi
+	@cargo build --release --no-default-features --features alloc --target thumbv6m-none-eabi
+	@cargo build --release --no-default-features --target thumbv6m-none-eabi
 
 doc: ## Generate documentation
 	@cargo rustdoc --lib -- --html-in-header katex-header.html -D warnings
@@ -30,6 +30,6 @@ doc-local: ## Open local documentation
 	@RUSTDOCFLAGS="--html-in-header katex-header.html" cargo doc --no-deps --open
 
 clean: ## Clean build artifacts
-	cargo clean
+	@cargo clean
 
 .PHONY: help test clippy fmt bench no-std doc doc-internal doc-local clean

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,24 @@
 help: ## Display this help screen
-	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run tests
+	cargo test --release
+	cargo test --release --all-features
+
+clippy: ## Run clippy
+	cargo clippy --features=rkyv/size_32
+
+fmt: ## Format code (requires nightly)
+	cargo +nightly fmt --all
+
+bench: ## Run benchmarks
+	cargo bench
+
+no-std: ## Verify no_std compatibility
+	rustup target add thumbv6m-none-eabi
+	cargo build --release --no-default-features --features alloc --target thumbv6m-none-eabi
+	cargo build --release --no-default-features --target thumbv6m-none-eabi
 
 doc: ## Generate documentation
 	@cargo rustdoc --lib -- --html-in-header katex-header.html -D warnings
@@ -10,4 +29,7 @@ doc-internal: ## Generate documentation with private items
 doc-local: ## Open local documentation
 	@RUSTDOCFLAGS="--html-in-header katex-header.html" cargo doc --no-deps --open
 
-.PHONY: help doc doc-internal doc-local
+clean: ## Clean build artifacts
+	cargo clean
+
+.PHONY: help test clippy fmt bench no-std doc doc-internal doc-local clean

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,6 @@
 max_width = 80
 unstable_features = true
 group_imports = "StdExternalCrate"
-imports_granularity = "Crate"
+imports_granularity = "Module"
 reorder_impl_items = true
 use_field_init_shorthand = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,6 @@
 max_width = 80
+unstable_features = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+reorder_impl_items = true
+use_field_init_shorthand = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,3 +4,4 @@ group_imports = "StdExternalCrate"
 imports_granularity = "Module"
 reorder_impl_items = true
 use_field_init_shorthand = true
+wrap_comments = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,6 +2,5 @@ max_width = 80
 unstable_features = true
 group_imports = "StdExternalCrate"
 imports_granularity = "Module"
-reorder_impl_items = true
 use_field_init_shorthand = true
 wrap_comments = true

--- a/src/bit_iterator.rs
+++ b/src/bit_iterator.rs
@@ -54,9 +54,11 @@ impl<E: AsRef<[u8]>> Iterator for BitIterator8<E> {
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod test {
-    use super::*;
     use alloc::vec::Vec;
+
     use dusk_bls12_381::BlsScalar;
+
+    use super::*;
 
     #[test]
     fn test_bit_iterator8() {

--- a/src/commitment_scheme.rs
+++ b/src/commitment_scheme.rs
@@ -16,13 +16,10 @@
 
 mod kzg10;
 
-pub(crate) use kzg10::Commitment;
-
 #[cfg(feature = "alloc")]
 pub(crate) use kzg10::AggregateProof;
-
-#[cfg(feature = "alloc")]
-pub(crate) use kzg10::{CommitKey, OpeningKey};
-
+pub(crate) use kzg10::Commitment;
 #[cfg(feature = "alloc")]
 pub use kzg10::PublicParameters;
+#[cfg(feature = "alloc")]
+pub(crate) use kzg10::{CommitKey, OpeningKey};

--- a/src/commitment_scheme/kzg10/commitment.rs
+++ b/src/commitment_scheme/kzg10/commitment.rs
@@ -5,11 +5,10 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 //! Module containing the representation of a Commitment to a Polynomial.
-use dusk_bls12_381::{G1Affine, G1Projective};
-use dusk_bytes::{DeserializableSlice, Serializable};
-
 #[cfg(feature = "rkyv-impl")]
 use bytecheck::CheckBytes;
+use dusk_bls12_381::{G1Affine, G1Projective};
+use dusk_bytes::{DeserializableSlice, Serializable};
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{
     Archive, Deserialize, Serialize,

--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -7,25 +7,26 @@
 //! Key module contains the utilities and data structures
 //! that support the generation and usage of Commit and
 //! Opening keys.
-use super::{Commitment, proof::Proof};
-use crate::{
-    error::Error, fft::Polynomial, transcript::TranscriptProtocol, util,
-};
 use alloc::vec::Vec;
-use dusk_bls12_381::{
-    BlsScalar, G1Affine, G1Projective, G2Affine, G2Prepared,
-    multiscalar_mul::msm_variable_base,
-};
-use dusk_bytes::{DeserializableSlice, Serializable};
-use merlin::Transcript;
 
 #[cfg(feature = "rkyv-impl")]
 use bytecheck::CheckBytes;
+use dusk_bls12_381::multiscalar_mul::msm_variable_base;
+use dusk_bls12_381::{BlsScalar, G1Affine, G1Projective, G2Affine, G2Prepared};
+use dusk_bytes::{DeserializableSlice, Serializable};
+use merlin::Transcript;
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
 };
+
+use super::Commitment;
+use super::proof::Proof;
+use crate::error::Error;
+use crate::fft::Polynomial;
+use crate::transcript::TranscriptProtocol;
+use crate::util;
 
 /// CommitKey is used to commit to a polynomial which is bounded by the
 /// max_degree.
@@ -279,6 +280,7 @@ pub struct OpeningKey {
 
 impl Serializable<{ G1Affine::SIZE + G2Affine::SIZE * 2 }> for OpeningKey {
     type Error = dusk_bytes::Error;
+
     #[allow(unused_must_use)]
     fn to_bytes(&self) -> [u8; Self::SIZE] {
         use dusk_bytes::Write;
@@ -366,13 +368,14 @@ impl OpeningKey {
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::commitment_scheme::{AggregateProof, PublicParameters};
-    use crate::fft::Polynomial;
     use dusk_bls12_381::BlsScalar;
     use dusk_bytes::Serializable;
     use merlin::Transcript;
     use rand_core::OsRng;
+
+    use super::*;
+    use crate::commitment_scheme::{AggregateProof, PublicParameters};
+    use crate::fft::Polynomial;
 
     // Checks that a polynomial `p` was evaluated at a point `z` and returned
     // the value specified `v`. ie. v = p(z).

--- a/src/commitment_scheme/kzg10/proof.rs
+++ b/src/commitment_scheme/kzg10/proof.rs
@@ -4,8 +4,9 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use super::Commitment;
 use dusk_bls12_381::BlsScalar;
+
+use super::Commitment;
 
 /// Proof that a polynomial `p` was correctly evaluated at a point `z`
 /// producing the evaluated point p(z).
@@ -111,8 +112,9 @@ pub(crate) mod alloc {
 
 #[cfg(all(test, feature = "alloc"))]
 mod tests {
-    use super::*;
     use dusk_bls12_381::{G1Affine, G1Projective};
+
+    use super::*;
 
     #[test]
     fn aggregate_proof_flatten_is_linear_combination() {

--- a/src/commitment_scheme/kzg10/srs.rs
+++ b/src/commitment_scheme/kzg10/srs.rs
@@ -6,21 +6,23 @@
 
 //! The Public Parameters can also be referred to as the Structured Reference
 //! String (SRS).
-use super::key::{CommitKey, OpeningKey};
-use crate::{error::Error, util};
 use alloc::vec::Vec;
+
+#[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
 use dusk_bls12_381::{BlsScalar, G1Affine, G1Projective, G2Affine};
 use dusk_bytes::{DeserializableSlice, Serializable};
 use ff::Field;
 use rand_core::{CryptoRng, RngCore};
-
-#[cfg(feature = "rkyv-impl")]
-use bytecheck::CheckBytes;
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
 };
+
+use super::key::{CommitKey, OpeningKey};
+use crate::error::Error;
+use crate::util;
 
 /// The Public Parameters can also be referred to as the Structured Reference
 /// String (SRS). It is available to both the prover and verifier and allows the
@@ -204,9 +206,10 @@ impl PublicParameters {
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod test {
-    use super::*;
     use dusk_bls12_381::BlsScalar;
     use rand_core::OsRng;
+
+    use super::*;
 
     #[test]
     fn test_powers_of() {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -9,10 +9,9 @@ use dusk_bls12_381::BlsScalar;
 use crate::commitment_scheme::{CommitKey, OpeningKey, PublicParameters};
 use crate::error::Error;
 use crate::fft::{EvaluationDomain, Evaluations, Polynomial};
+use crate::prelude::{Circuit, Composer};
 use crate::proof_system::preprocess::Polynomials;
 use crate::proof_system::{ProverKey, widget};
-
-use crate::prelude::{Circuit, Composer};
 
 mod prover;
 mod verifier;

--- a/src/compiler/prover.rs
+++ b/src/compiler/prover.rs
@@ -186,9 +186,13 @@ impl Prover {
         let constraints = u64::from_be_bytes(constraints) as usize;
         bytes = &bytes[8..];
 
-        if bytes.len()
-            < label_len + prover_key_len + commit_key_len + verifier_key_len
-        {
+        let required_len = label_len
+            .checked_add(prover_key_len)
+            .and_then(|len| len.checked_add(commit_key_len))
+            .and_then(|len| len.checked_add(verifier_key_len))
+            .ok_or(Error::NotEnoughBytes)?;
+
+        if bytes.len() < required_len {
             return Err(Error::NotEnoughBytes);
         }
 
@@ -668,5 +672,24 @@ mod tests {
             result.expect("checked above").is_err(),
             "malformed input must be rejected"
         );
+    }
+
+    #[test]
+    fn prover_try_from_bytes_rejects_overflow_lengths_without_panicking() {
+        let mut bytes = Vec::with_capacity(48);
+        bytes.extend_from_slice(&0u64.to_be_bytes()); // label_len
+        bytes.extend_from_slice(&u64::MAX.to_be_bytes()); // prover_key_len
+        bytes.extend_from_slice(&u64::MAX.to_be_bytes()); // commit_key_len
+        bytes.extend_from_slice(&u64::MAX.to_be_bytes()); // verifier_key_len
+        bytes.extend_from_slice(&0u64.to_be_bytes()); // size
+        bytes.extend_from_slice(&0u64.to_be_bytes()); // constraints
+
+        let result =
+            std::panic::catch_unwind(|| Prover::try_from_bytes(&bytes));
+        assert!(result.is_ok(), "deserializer should never panic");
+        assert!(matches!(
+            result.expect("checked above"),
+            Err(Error::NotEnoughBytes)
+        ));
     }
 }

--- a/src/compiler/prover.rs
+++ b/src/compiler/prover.rs
@@ -13,16 +13,16 @@ use ff::Field;
 use merlin::Transcript;
 use rand_core::{CryptoRng, RngCore};
 
+use super::{Circuit, Composer, PlonkVersion};
 use crate::commitment_scheme::CommitKey;
 use crate::compiler::prover::linearization_poly::ProofEvaluations;
 use crate::error::Error;
 use crate::fft::{EvaluationDomain, Polynomial};
+use crate::proof_system::proof::Proof;
 use crate::proof_system::{
-    ProverKey, VerifierKey, linearization_poly, proof::Proof, quotient_poly,
+    ProverKey, VerifierKey, linearization_poly, quotient_poly,
 };
 use crate::transcript::TranscriptProtocol;
-
-use super::{Circuit, Composer, PlonkVersion};
 
 /// Turbo Prover with processed keys
 #[derive(Clone)]
@@ -636,12 +636,13 @@ impl Prover {
 
 #[cfg(test)]
 mod tests {
-    use super::Prover;
-    use crate::error::Error;
-    use crate::prelude::{Circuit, Compiler, Composer, PublicParameters};
     use dusk_bls12_381::BlsScalar;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
+
+    use super::Prover;
+    use crate::error::Error;
+    use crate::prelude::{Circuit, Compiler, Composer, PublicParameters};
 
     #[derive(Default)]
     struct MinimalCircuit;

--- a/src/compiler/verifier.rs
+++ b/src/compiler/verifier.rs
@@ -10,12 +10,11 @@ use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Serializable};
 use merlin::Transcript;
 
-use super::{Composer, PlonkVersion};
+use super::PlonkVersion;
 use crate::commitment_scheme::OpeningKey;
 use crate::error::Error;
 use crate::proof_system::{Proof, VerifierKey};
 use crate::transcript::TranscriptProtocol;
-
 /// Verify proofs of a given circuit
 pub struct Verifier {
     label: Vec<u8>,
@@ -222,24 +221,20 @@ impl Verifier {
             .iter()
             .for_each(|pi| transcript.append_scalar(b"pi", pi));
 
-        let dense_public_inputs = Composer::dense_public_inputs(
-            &self.public_input_indexes,
-            public_inputs,
-            self.size,
-        );
-
         match version {
             PlonkVersion::V1 => proof.verify_legacy(
                 &self.verifier_key,
                 &mut transcript,
                 &self.opening_key,
-                &dense_public_inputs,
+                &self.public_input_indexes,
+                public_inputs,
             ),
             PlonkVersion::V2 | PlonkVersion::V3 => proof.verify(
                 &self.verifier_key,
                 &mut transcript,
                 &self.opening_key,
-                &dense_public_inputs,
+                &self.public_input_indexes,
+                public_inputs,
             ),
         }
     }

--- a/src/compiler/verifier.rs
+++ b/src/compiler/verifier.rs
@@ -10,12 +10,11 @@ use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Serializable};
 use merlin::Transcript;
 
+use super::{Composer, PlonkVersion};
 use crate::commitment_scheme::OpeningKey;
 use crate::error::Error;
 use crate::proof_system::{Proof, VerifierKey};
 use crate::transcript::TranscriptProtocol;
-
-use super::{Composer, PlonkVersion};
 
 /// Verify proofs of a given circuit
 pub struct Verifier {

--- a/src/compiler/verifier.rs
+++ b/src/compiler/verifier.rs
@@ -139,6 +139,9 @@ impl Verifier {
         let public_input_indexes_len =
             u64::from_be_bytes(public_input_indexes_len) as usize;
         bytes = &bytes[8..];
+        let public_input_indexes_bytes_len = public_input_indexes_len
+            .checked_mul(8)
+            .ok_or(Error::NotEnoughBytes)?;
 
         let size = <[u8; 8]>::try_from(&bytes[..8]).expect("checked len");
         let size = u64::from_be_bytes(size) as usize;
@@ -149,12 +152,13 @@ impl Verifier {
         let constraints = u64::from_be_bytes(constraints) as usize;
         bytes = &bytes[8..];
 
-        if bytes.len()
-            < label_len
-                + verifier_key_len
-                + opening_key_len
-                + public_input_indexes_len * 8
-        {
+        let required_len = label_len
+            .checked_add(verifier_key_len)
+            .and_then(|len| len.checked_add(opening_key_len))
+            .and_then(|len| len.checked_add(public_input_indexes_bytes_len))
+            .ok_or(Error::NotEnoughBytes)?;
+
+        if bytes.len() < required_len {
             return Err(Error::NotEnoughBytes);
         }
 
@@ -167,7 +171,7 @@ impl Verifier {
         let opening_key = &bytes[..opening_key_len];
         bytes = &bytes[opening_key_len..];
 
-        let public_input_indexes = &bytes[..public_input_indexes_len * 8];
+        let public_input_indexes = &bytes[..public_input_indexes_bytes_len];
 
         let label = label.to_vec();
         let verifier_key = VerifierKey::from_slice(verifier_key)?;
@@ -250,5 +254,29 @@ impl Verifier {
                 self.constraints,
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verifier_try_from_bytes_rejects_overflow_lengths_without_panicking() {
+        let mut bytes = Vec::with_capacity(48);
+        bytes.extend_from_slice(&0u64.to_be_bytes()); // label_len
+        bytes.extend_from_slice(&0u64.to_be_bytes()); // verifier_key_len
+        bytes.extend_from_slice(&0u64.to_be_bytes()); // opening_key_len
+        bytes.extend_from_slice(&u64::MAX.to_be_bytes()); // public_input_indexes_len
+        bytes.extend_from_slice(&0u64.to_be_bytes()); // size
+        bytes.extend_from_slice(&0u64.to_be_bytes()); // constraints
+
+        let result =
+            std::panic::catch_unwind(|| Verifier::try_from_bytes(&bytes));
+        assert!(
+            result.is_ok(),
+            "try_from_bytes panicked on overflow lengths"
+        );
+        assert!(matches!(result.unwrap(), Err(Error::NotEnoughBytes)));
     }
 }

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -510,10 +510,12 @@ impl Composer {
         let acc_y = self.append_witness(point_acc[bits].get_v());
 
         // This is the final scalar recurrence state
-        // It is constrained by the previous fixed-base row as d_w and by assert_equal below
+        // It is constrained by the previous fixed-base row as d_w and by
+        // assert_equal below
         let last_accumulated_bit = self.append_witness(scalar_acc[bits]);
 
-        // Keep this anchor row since removing it would break the shifted-wire chain.
+        // Keep this anchor row since removing it would break the shifted-wire
+        // chain.
         let constraint =
             Constraint::new().a(acc_x).b(acc_y).d(last_accumulated_bit);
         self.append_gate(constraint);

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -8,10 +8,10 @@
 
 use alloc::vec::Vec;
 use core::{cmp, ops};
-use hashbrown::HashMap;
 
 use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{JubJubAffine, JubJubExtended, JubJubScalar};
+use hashbrown::HashMap;
 
 use crate::bit_iterator::BitIterator8;
 use crate::error::Error;
@@ -26,9 +26,8 @@ pub(crate) mod permutation;
 
 pub use circuit::Circuit;
 pub use constraint_system::{Constraint, Witness, WitnessPoint};
-pub use gate::Gate;
-
 pub(crate) use constraint_system::{Selector, WireData, WiredWitness};
+pub use gate::Gate;
 pub(crate) use permutation::Permutation;
 
 /// Construct and prove circuits
@@ -61,20 +60,18 @@ impl ops::Index<Witness> for Composer {
 // pub trait Composer: Sized + Index<Witness, Output = BlsScalar> {
 /// Circuit builder tool
 impl Composer {
-    /// Zero representation inside the constraint system.
-    ///
-    /// A turbo composer expects the first witness to be always present and to
-    /// be zero.
-    pub const ZERO: Witness = Witness::ZERO;
-
+    /// Identity point representation inside the constraint system
+    pub const IDENTITY: WitnessPoint = WitnessPoint::new(Self::ZERO, Self::ONE);
     /// `One` representation inside the constraint system.
     ///
     /// A turbo composer expects the 2nd witness to be always present and to
     /// be one.
     pub const ONE: Witness = Witness::ONE;
-
-    /// Identity point representation inside the constraint system
-    pub const IDENTITY: WitnessPoint = WitnessPoint::new(Self::ZERO, Self::ONE);
+    /// Zero representation inside the constraint system.
+    ///
+    /// A turbo composer expects the first witness to be always present and to
+    /// be zero.
+    pub const ZERO: Witness = Witness::ZERO;
 
     /// Constraints count
     pub fn constraints(&self) -> usize {

--- a/src/composer/circuit.rs
+++ b/src/composer/circuit.rs
@@ -7,9 +7,8 @@
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
-use crate::prelude::{Composer, Error};
-
 use super::compress::CompressedCircuit;
+use crate::prelude::{Composer, Error};
 
 /// Circuit implementation that can be proved by a Composer
 ///

--- a/src/composer/compress.rs
+++ b/src/composer/compress.rs
@@ -4,11 +4,11 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use alloc::vec::Vec;
+
 use dusk_bytes::Serializable;
 use hashbrown::HashMap;
 use msgpacker::{MsgPacker, Packable, Unpackable};
-
-use alloc::vec::Vec;
 
 use super::{BlsScalar, Composer, Constraint, Error, Gate, Selector, Witness};
 

--- a/src/composer/compress/hades.rs
+++ b/src/composer/compress/hades.rs
@@ -7,8 +7,9 @@
 // Extracted from
 // https://github.com/dusk-network/Poseidon252/blob/master/assets/HOWTO.md
 
-use super::BlsScalar;
 use sha2::{Digest, Sha512};
+
+use super::BlsScalar;
 
 // the width of the hades permutation container
 const WIDTH: usize = 5;

--- a/src/composer/constraint_system.rs
+++ b/src/composer/constraint_system.rs
@@ -13,9 +13,8 @@ pub(crate) mod constraint;
 pub(crate) mod ecc;
 pub(crate) mod witness;
 
-pub(crate) use constraint::{Selector, WiredWitness};
-pub(crate) use witness::WireData;
-
 pub use constraint::Constraint;
+pub(crate) use constraint::{Selector, WiredWitness};
 pub use ecc::WitnessPoint;
+pub(crate) use witness::WireData;
 pub use witness::Witness;

--- a/src/composer/constraint_system/constraint.rs
+++ b/src/composer/constraint_system/constraint.rs
@@ -4,8 +4,9 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::prelude::{Composer, Witness};
 use dusk_bls12_381::BlsScalar;
+
+use crate::prelude::{Composer, Witness};
 
 /// Selectors used to address a coefficient inside of a [`Constraint`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -94,7 +95,6 @@ impl AsRef<[BlsScalar]> for Constraint {
 impl Constraint {
     /// Internal coefficients count.
     pub const COEFFICIENTS: usize = 12;
-
     /// Internal witnesses count.
     pub const WITNESSES: usize = 4;
 

--- a/src/composer/constraint_system/ecc.rs
+++ b/src/composer/constraint_system/ecc.rs
@@ -4,8 +4,9 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::prelude::Witness;
 use dusk_bls12_381::BlsScalar;
+
+use crate::prelude::Witness;
 
 /// Represents a JubJub point in the circuit
 #[derive(Debug, Clone, Copy)]

--- a/src/composer/constraint_system/witness.rs
+++ b/src/composer/constraint_system/witness.rs
@@ -36,11 +36,10 @@ impl Default for Witness {
 }
 
 impl Witness {
-    /// A `0` witness representation.
-    pub const ZERO: Witness = Witness::new(0);
-
     /// A `1` witness representation.
     pub const ONE: Witness = Witness::new(1);
+    /// A `0` witness representation.
+    pub const ZERO: Witness = Witness::new(0);
 
     /// Generate a new [`Witness`]
     pub(crate) const fn new(index: usize) -> Self {

--- a/src/composer/permutation.rs
+++ b/src/composer/permutation.rs
@@ -4,13 +4,15 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::composer::{WireData, Witness};
-use crate::fft::{EvaluationDomain, Polynomial};
 use alloc::vec::Vec;
+
 use constants::{K1, K2, K3};
 use dusk_bls12_381::BlsScalar;
 use hashbrown::HashMap;
 use itertools::izip;
+
+use crate::composer::{WireData, Witness};
+use crate::fft::{EvaluationDomain, Polynomial};
 
 pub(crate) mod constants;
 
@@ -300,11 +302,12 @@ impl Permutation {
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::fft::Polynomial;
     use dusk_bls12_381::BlsScalar;
     use ff::Field;
     use rand_core::OsRng;
+
+    use super::*;
+    use crate::fft::Polynomial;
 
     #[allow(dead_code)]
     fn compute_fast_permutation_poly(

--- a/src/error.rs
+++ b/src/error.rs
@@ -201,9 +201,10 @@ impl std::error::Error for Error {}
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
-    use super::*;
     use dusk_bls12_381::BlsScalar;
     use dusk_bytes::{DeserializableSlice, Serializable};
+
+    use super::*;
 
     #[test]
     fn display_arms_are_exercised() {

--- a/src/fft/domain.rs
+++ b/src/fft/domain.rs
@@ -12,11 +12,10 @@
 //! This allows us to perform polynomial operations in O(n)
 //! by performing an O(n log n) FFT over such a domain.
 
-use dusk_bls12_381::BlsScalar;
-use dusk_bytes::{DeserializableSlice, Serializable};
-
 #[cfg(feature = "rkyv-impl")]
 use bytecheck::CheckBytes;
+use dusk_bls12_381::BlsScalar;
+use dusk_bytes::{DeserializableSlice, Serializable};
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{
     Archive, Deserialize, Serialize,
@@ -112,6 +111,7 @@ pub(crate) mod alloc {
     #[rustfmt::skip]
     use ::alloc::vec::Vec;
     use core::ops::MulAssign;
+
     use dusk_bls12_381::{GENERATOR, ROOT_OF_UNITY, TWO_ADACITY};
     #[cfg(feature = "std")]
     use rayon::prelude::*;
@@ -385,6 +385,7 @@ pub(crate) mod alloc {
 
     impl Iterator for Elements {
         type Item = BlsScalar;
+
         fn next(&mut self) -> Option<BlsScalar> {
             if self.cur_pow == self.domain.size {
                 None

--- a/src/fft/evaluations.rs
+++ b/src/fft/evaluations.rs
@@ -6,23 +6,24 @@
 
 //! A polynomial represented in evaluations form over a domain of size 2^n.
 
-use super::domain::EvaluationDomain;
-use super::polynomial::Polynomial;
-use crate::error::Error;
 use alloc::vec::Vec;
 use core::ops::{
     Add, AddAssign, DivAssign, Index, Mul, MulAssign, Sub, SubAssign,
 };
-use dusk_bls12_381::BlsScalar;
-use dusk_bytes::{DeserializableSlice, Serializable};
 
 #[cfg(feature = "rkyv-impl")]
 use bytecheck::CheckBytes;
+use dusk_bls12_381::BlsScalar;
+use dusk_bytes::{DeserializableSlice, Serializable};
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
 };
+
+use super::domain::EvaluationDomain;
+use super::polynomial::Polynomial;
+use crate::error::Error;
 
 /// Stores a polynomial in evaluation form.
 #[derive(PartialEq, Eq, Debug, Clone)]

--- a/src/fft/polynomial.rs
+++ b/src/fft/polynomial.rs
@@ -7,21 +7,22 @@
 //! This module contains an implementation of a polynomial in coefficient form
 //! Where each coefficient is represented using a position in the underlying
 //! vector.
-use super::{EvaluationDomain, Evaluations};
-use crate::error::Error;
-use crate::util;
 use alloc::vec::Vec;
 use core::ops::{Add, AddAssign, Deref, DerefMut, Mul, Neg, Sub, SubAssign};
-use dusk_bls12_381::BlsScalar;
-use dusk_bytes::{DeserializableSlice, Serializable};
 
 #[cfg(feature = "rkyv-impl")]
 use bytecheck::CheckBytes;
+use dusk_bls12_381::BlsScalar;
+use dusk_bytes::{DeserializableSlice, Serializable};
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
 };
+
+use super::{EvaluationDomain, Evaluations};
+use crate::error::Error;
+use crate::util;
 
 /// Represents a polynomial in coeffiient form.
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -52,8 +53,8 @@ impl DerefMut for Polynomial {
 }
 
 impl IntoIterator for Polynomial {
-    type Item = BlsScalar;
     type IntoIter = <Vec<BlsScalar> as IntoIterator>::IntoIter;
+    type Item = BlsScalar;
 
     fn into_iter(self) -> Self::IntoIter {
         self.coeffs.into_iter()
@@ -438,10 +439,11 @@ impl<'a> Sub<&'a BlsScalar> for &Polynomial {
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod test {
-    use super::*;
     use ff::Field;
     use rand::rngs::StdRng;
     use rand_core::{CryptoRng, RngCore, SeedableRng};
+
+    use super::*;
 
     impl Polynomial {
         /// Outputs a polynomial of degree `d` where each coefficient is sampled

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,14 +9,14 @@
 //! Use this as the only import that you need to interact
 //! with the principal data structures of the plonk library.
 
+pub use dusk_bls12_381::BlsScalar;
+pub use dusk_jubjub::{JubJubAffine, JubJubExtended, JubJubScalar};
+
+pub use crate::error::Error;
+pub use crate::proof_system::Proof;
 #[cfg(feature = "alloc")]
 pub use crate::{
     commitment_scheme::PublicParameters,
     compiler::{Compiler, PlonkVersion, Prover, Verifier},
     composer::{Circuit, Composer, Constraint, Witness, WitnessPoint},
 };
-
-pub use crate::error::Error;
-pub use crate::proof_system::Proof;
-pub use dusk_bls12_381::BlsScalar;
-pub use dusk_jubjub::{JubJubAffine, JubJubExtended, JubJubScalar};

--- a/src/proof_system/linearization_poly.rs
+++ b/src/proof_system/linearization_poly.rs
@@ -4,21 +4,20 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-#[cfg(feature = "alloc")]
-use crate::{
-    fft::{EvaluationDomain, Polynomial},
-    proof_system::{ProverKey, proof},
-};
-
-use dusk_bls12_381::BlsScalar;
-use dusk_bytes::{DeserializableSlice, Serializable};
-
 #[cfg(feature = "rkyv-impl")]
 use bytecheck::CheckBytes;
+use dusk_bls12_381::BlsScalar;
+use dusk_bytes::{DeserializableSlice, Serializable};
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
+};
+
+#[cfg(feature = "alloc")]
+use crate::{
+    fft::{EvaluationDomain, Polynomial},
+    proof_system::{ProverKey, proof},
 };
 
 /// Subset of all of the evaluations. These evaluations

--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -375,9 +375,9 @@ pub(crate) mod alloc {
 
             // Evaluations to compute [E]_1
             //
-            // IMPORTANT: Ordering must match the prover's batched opening at `z`
-            // (`CommitKey::compute_aggregate_witness([...])`) and the verifier's
-            // commitment list below.
+            // IMPORTANT: Ordering must match the prover's batched opening at
+            // `z` (`CommitKey::compute_aggregate_witness([...])`)
+            // and the verifier's commitment list below.
             let E_evals = vec![
                 // Unshifted openings at z
                 self.evaluations.a_eval,
@@ -1062,11 +1062,11 @@ mod soundness_tests {
     ///
     /// The proof uses:
     /// - Honest wire polynomials (circuit is satisfied at gate level)
-    /// - A RANDOM permutation polynomial z (breaking the permutation
-    ///   argument — gates are not properly wired together)
+    /// - A RANDOM permutation polynomial z (breaking the permutation argument —
+    ///   gates are not properly wired together)
     /// - RANDOM quotient polynomials (not the actual quotient)
-    /// - A FORGED `q_arith_eval` computed to balance the verification
-    ///   equation after observing `z_challenge`
+    /// - A FORGED `q_arith_eval` computed to balance the verification equation
+    ///   after observing `z_challenge`
     ///
     /// This proof is invalid (the permutation argument does not hold)
     /// but exploits the fact that selector evaluations are not bound

--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -7,13 +7,12 @@
 //! A Proof stores the commitments to all of the elements that
 //! are needed to univocally identify a prove of some statement.
 
-use super::linearization_poly::ProofEvaluations;
-use crate::commitment_scheme::Commitment;
-
 use dusk_bytes::{DeserializableSlice, Serializable};
-
 #[cfg(feature = "std")]
 use rayon::prelude::*;
+
+use super::linearization_poly::ProofEvaluations;
+use crate::commitment_scheme::Commitment;
 
 // Number of (unshifted) polynomials opened at `z`, excluding the linearization
 // polynomial `r(X)`.
@@ -30,14 +29,15 @@ const V_MAX_DEGREE: usize = 11;
 const V_MAX_DEGREE_LEGACY: usize = 7;
 
 #[cfg(feature = "rkyv-impl")]
-use crate::util::check_field;
-#[cfg(feature = "rkyv-impl")]
 use bytecheck::{CheckBytes, StructCheckError};
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
 };
+
+#[cfg(feature = "rkyv-impl")]
+use crate::util::check_field;
 
 /// A Proof is a composition of `Commitment`s to the Witness, Permutation,
 /// Quotient, Shifted and Opening polynomials as well as the
@@ -198,19 +198,16 @@ impl Serializable<{ 11 * Commitment::SIZE + ProofEvaluations::SIZE }>
 #[allow(unused_imports)]
 pub(crate) mod alloc {
     use super::*;
-    use crate::{
-        commitment_scheme::{AggregateProof, OpeningKey},
-        error::Error,
-        fft::EvaluationDomain,
-        proof_system::widget::VerifierKey,
-        transcript::TranscriptProtocol,
-        util::batch_inversion,
-    };
+    use crate::commitment_scheme::{AggregateProof, OpeningKey};
+    use crate::error::Error;
+    use crate::fft::EvaluationDomain;
+    use crate::proof_system::widget::VerifierKey;
+    use crate::transcript::TranscriptProtocol;
+    use crate::util::batch_inversion;
     #[rustfmt::skip]
     use ::alloc::vec::Vec;
-    use dusk_bls12_381::{
-        BlsScalar, G1Affine, G1Projective, multiscalar_mul::msm_variable_base,
-    };
+    use dusk_bls12_381::multiscalar_mul::msm_variable_base;
+    use dusk_bls12_381::{BlsScalar, G1Affine, G1Projective};
     use merlin::Transcript;
     #[cfg(feature = "std")]
     use rayon::prelude::*;
@@ -951,10 +948,11 @@ pub(crate) mod alloc {
 
 #[cfg(test)]
 mod proof_tests {
-    use super::*;
     use dusk_bls12_381::BlsScalar;
     use ff::Field;
     use rand_core::OsRng;
+
+    use super::*;
 
     #[test]
     fn test_dusk_bytes_serde_proof() {
@@ -1010,6 +1008,12 @@ mod proof_tests {
 #[cfg(test)]
 #[cfg(feature = "std")]
 mod soundness_tests {
+    use dusk_bls12_381::BlsScalar;
+    use ff::Field;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+    use rand_core::{CryptoRng, RngCore};
+
     use crate::commitment_scheme::{CommitKey, PublicParameters};
     use crate::compiler::{Compiler, Prover, Verifier};
     use crate::composer::{Circuit, Composer, Constraint};
@@ -1018,11 +1022,6 @@ mod soundness_tests {
     use crate::proof_system::linearization_poly::{self, ProofEvaluations};
     use crate::proof_system::proof::{self, Proof};
     use crate::transcript::TranscriptProtocol;
-    use dusk_bls12_381::BlsScalar;
-    use ff::Field;
-    use rand::SeedableRng;
-    use rand::rngs::StdRng;
-    use rand_core::{CryptoRng, RngCore};
 
     // Simple arithmetic circuit: a + b + a*b + d + public + 1 = result
     #[derive(Default)]

--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -220,6 +220,7 @@ pub(crate) mod alloc {
             verifier_key: &VerifierKey,
             transcript: &mut Transcript,
             opening_key: &OpeningKey,
+            public_input_indexes: &[usize],
             pub_inputs: &[BlsScalar],
         ) -> Result<(), Error> {
             let domain = EvaluationDomain::new(verifier_key.n)?;
@@ -341,8 +342,12 @@ pub(crate) mod alloc {
                 .0;
 
             // Evaluate public inputs
-            let pi_eval =
-                compute_barycentric_eval(pub_inputs, &z_challenge, &domain);
+            let pi_eval = compute_barycentric_eval_sparse(
+                public_input_indexes,
+                pub_inputs,
+                &z_challenge,
+                &domain,
+            );
 
             // Compute r_0
             let r_0_eval = pi_eval
@@ -361,24 +366,28 @@ pub(crate) mod alloc {
                     * self.evaluations.z_eval;
 
             // Coefficients to compute [E]_1
-            let mut v_coeffs_E = vec![v_challenge];
+            let mut v_coeffs_E = [BlsScalar::zero(); V_MAX_DEGREE + 3];
+            v_coeffs_E[0] = v_challenge;
 
-            // Compute the powers of the v_challenge
+            // Compute the powers of the v_challenge.
             for i in 1..V_MAX_DEGREE {
-                v_coeffs_E.push(v_coeffs_E[i - 1] * v_challenge);
+                v_coeffs_E[i] = v_coeffs_E[i - 1] * v_challenge;
             }
 
-            // Compute the powers of the v_challenge multiplied by u_challenge
-            v_coeffs_E.push(v_w_challenge * u_challenge);
-            v_coeffs_E.push(v_coeffs_E[V_MAX_DEGREE] * v_w_challenge);
-            v_coeffs_E.push(v_coeffs_E[V_MAX_DEGREE + 1] * v_w_challenge);
+            // Compute the powers of the v_challenge multiplied by
+            // u_challenge.
+            v_coeffs_E[V_MAX_DEGREE] = v_w_challenge * u_challenge;
+            v_coeffs_E[V_MAX_DEGREE + 1] =
+                v_coeffs_E[V_MAX_DEGREE] * v_w_challenge;
+            v_coeffs_E[V_MAX_DEGREE + 2] =
+                v_coeffs_E[V_MAX_DEGREE + 1] * v_w_challenge;
 
             // Evaluations to compute [E]_1
             //
-            // IMPORTANT: Ordering must match the prover's batched opening at
-            // `z` (`CommitKey::compute_aggregate_witness([...])`)
-            // and the verifier's commitment list below.
-            let E_evals = vec![
+            // IMPORTANT: Ordering must match the prover's batched opening at `z`
+            // (`CommitKey::compute_aggregate_witness([...])`) and the verifier's
+            // commitment list below.
+            let E_evals = [
                 // Unshifted openings at z
                 self.evaluations.a_eval,
                 self.evaluations.b_eval,
@@ -408,10 +417,17 @@ pub(crate) mod alloc {
                 .sum();
             E_scalar += -r_0_eval + (u_challenge * self.evaluations.z_eval);
 
-            // We group all the remaining scalar multiplications in the
-            // verification process, with the purpose of
-            // parallelizing them
-            let scalarmuls_points = vec![
+            let mut f_scalars = [BlsScalar::zero(); V_MAX_DEGREE];
+            f_scalars.clone_from_slice(&v_coeffs_E[..V_MAX_DEGREE]);
+
+            // As we include the shifted coefficients when computing [F]_1,
+            // we group them to save scalar multiplications when multiplying
+            // by [a]_1, [b]_1, and [d]_1.
+            f_scalars[0] += v_coeffs_E[V_MAX_DEGREE];
+            f_scalars[1] += v_coeffs_E[V_MAX_DEGREE + 1];
+            f_scalars[3] += v_coeffs_E[V_MAX_DEGREE + 2];
+
+            let f_points = [
                 // Unshifted openings at z
                 self.a_comm.0,
                 self.b_comm.0,
@@ -426,53 +442,16 @@ pub(crate) mod alloc {
                 verifier_key.arithmetic.q_c.0,
                 verifier_key.arithmetic.q_l.0,
                 verifier_key.arithmetic.q_r.0,
-                // Commitment to generator G for [E]_1
-                opening_key.g,
-                // Opening proof commitments
-                self.w_z_chall_w_comm.0,
-                self.w_z_chall_comm.0,
-                self.w_z_chall_w_comm.0,
             ];
-
-            let mut scalarmuls_scalars = v_coeffs_E[..V_MAX_DEGREE].to_vec();
-
-            // As we include the shifted coefficients when computing [F]_1,
-            // we group them to save scalar multiplications when multiplying
-            // by [a]_1, [b]_1, and [d]_1
-            scalarmuls_scalars[0] += v_coeffs_E[V_MAX_DEGREE];
-            scalarmuls_scalars[1] += v_coeffs_E[V_MAX_DEGREE + 1];
-            scalarmuls_scalars[3] += v_coeffs_E[V_MAX_DEGREE + 2];
-
-            scalarmuls_scalars.push(E_scalar);
-            scalarmuls_scalars.push(u_challenge);
-            scalarmuls_scalars.push(z_challenge);
-            scalarmuls_scalars
-                .push(u_challenge * z_challenge * domain.group_gen);
-
-            // Compute the scalar multiplications in single-core
-            #[cfg(not(feature = "std"))]
-            let scalarmuls: Vec<G1Projective> = scalarmuls_points
-                .iter()
-                .zip(scalarmuls_scalars.iter())
-                .map(|(point, scalar)| point * scalar)
-                .collect();
-
-            // Compute the scalar multiplications in multi-core
-            #[cfg(feature = "std")]
-            let scalarmuls: Vec<G1Projective> = scalarmuls_points
-                .par_iter()
-                .zip(scalarmuls_scalars.par_iter())
-                .map(|(point, scalar)| point * scalar)
-                .collect();
 
             // [F]_1 = [D]_1 + (v)[a]_1 + (v^2)[b]_1 + (v^3)[c]_1 + (v^4)[d]_1 +
             // + (v^5)[s_sigma_1]_1 + (v^6)[s_sigma_2]_1 + (v^7)[s_sigma_3]_1 +
             // + (u * v_w)[a]_1 + (u * v_w^2)[b]_1 + (u * v_w^3)[d]_1
-            let mut F: G1Projective = scalarmuls[..V_MAX_DEGREE].iter().sum();
+            let mut F = msm_variable_base(&f_points, &f_scalars);
             F += D;
 
             // [E]_1 = E * G
-            let E = scalarmuls[V_MAX_DEGREE];
+            let E = opening_key.g * E_scalar;
 
             // Compute the G_1 element of the first pairing:
             // [W_z]_1 + u * [W_zw]_1
@@ -480,13 +459,17 @@ pub(crate) mod alloc {
             // Note that we negate this value to be able to subtract
             // the pairings later on, using the multi Miller loop
             let left = G1Affine::from(
-                -(self.w_z_chall_comm.0 + scalarmuls[V_MAX_DEGREE + 1]),
+                -(self.w_z_chall_comm.0
+                    + (self.w_z_chall_w_comm.0 * u_challenge)),
             );
 
             // Compute the G_1 element of the second pairing:
             // z * [W_z]_1 + (u * z * w) * [W_zw]_1 + [F]_1 - [E]_1
             let right = G1Affine::from(
-                scalarmuls[V_MAX_DEGREE + 2] + scalarmuls[V_MAX_DEGREE + 3] + F
+                (self.w_z_chall_comm.0 * z_challenge)
+                    + (self.w_z_chall_w_comm.0
+                        * (u_challenge * z_challenge * domain.group_gen))
+                    + F
                     - E,
             );
 
@@ -514,6 +497,7 @@ pub(crate) mod alloc {
             verifier_key: &VerifierKey,
             transcript: &mut Transcript,
             opening_key: &OpeningKey,
+            public_input_indexes: &[usize],
             pub_inputs: &[BlsScalar],
         ) -> Result<(), Error> {
             let domain = EvaluationDomain::new(verifier_key.n)?;
@@ -635,8 +619,12 @@ pub(crate) mod alloc {
                 .0;
 
             // Evaluate public inputs
-            let pi_eval =
-                compute_barycentric_eval(pub_inputs, &z_challenge, &domain);
+            let pi_eval = compute_barycentric_eval_sparse(
+                public_input_indexes,
+                pub_inputs,
+                &z_challenge,
+                &domain,
+            );
 
             // Compute r_0
             let r_0_eval = pi_eval
@@ -655,24 +643,27 @@ pub(crate) mod alloc {
                     * self.evaluations.z_eval;
 
             // Coefficients to compute [E]_1
-            let mut v_coeffs_E = vec![v_challenge];
+            let mut v_coeffs_E = [BlsScalar::zero(); V_MAX_DEGREE_LEGACY + 3];
+            v_coeffs_E[0] = v_challenge;
 
-            // Compute the powers of the v_challenge
+            // Compute the powers of the v_challenge.
             for i in 1..V_MAX_DEGREE_LEGACY {
-                v_coeffs_E.push(v_coeffs_E[i - 1] * v_challenge);
+                v_coeffs_E[i] = v_coeffs_E[i - 1] * v_challenge;
             }
 
-            // Compute the powers of the v_challenge multiplied by u_challenge
-            v_coeffs_E.push(v_w_challenge * u_challenge);
-            v_coeffs_E.push(v_coeffs_E[V_MAX_DEGREE_LEGACY] * v_w_challenge);
-            v_coeffs_E
-                .push(v_coeffs_E[V_MAX_DEGREE_LEGACY + 1] * v_w_challenge);
+            // Compute the powers of the v_challenge multiplied by
+            // u_challenge.
+            v_coeffs_E[V_MAX_DEGREE_LEGACY] = v_w_challenge * u_challenge;
+            v_coeffs_E[V_MAX_DEGREE_LEGACY + 1] =
+                v_coeffs_E[V_MAX_DEGREE_LEGACY] * v_w_challenge;
+            v_coeffs_E[V_MAX_DEGREE_LEGACY + 2] =
+                v_coeffs_E[V_MAX_DEGREE_LEGACY + 1] * v_w_challenge;
 
             // Evaluations to compute [E]_1
             //
             // IMPORTANT: Ordering must match the legacy prover's batched
             // opening at `z` (pre-soundness-fix).
-            let E_evals = vec![
+            let E_evals = [
                 self.evaluations.a_eval,
                 self.evaluations.b_eval,
                 self.evaluations.c_eval,
@@ -695,10 +686,17 @@ pub(crate) mod alloc {
                 .sum();
             E_scalar += -r_0_eval + (u_challenge * self.evaluations.z_eval);
 
-            // We group all the remaining scalar multiplications in the
-            // verification process, with the purpose of
-            // parallelizing them
-            let scalarmuls_points = vec![
+            let mut f_scalars = [BlsScalar::zero(); V_MAX_DEGREE_LEGACY];
+            f_scalars.clone_from_slice(&v_coeffs_E[..V_MAX_DEGREE_LEGACY]);
+
+            // As we include the shifted coefficients when computing [F]_1,
+            // we group them to save scalar multiplications when multiplying
+            // by [a]_1, [b]_1, and [d]_1.
+            f_scalars[0] += v_coeffs_E[V_MAX_DEGREE_LEGACY];
+            f_scalars[1] += v_coeffs_E[V_MAX_DEGREE_LEGACY + 1];
+            f_scalars[3] += v_coeffs_E[V_MAX_DEGREE_LEGACY + 2];
+
+            let f_points = [
                 self.a_comm.0,
                 self.b_comm.0,
                 self.c_comm.0,
@@ -706,53 +704,16 @@ pub(crate) mod alloc {
                 verifier_key.permutation.s_sigma_1.0,
                 verifier_key.permutation.s_sigma_2.0,
                 verifier_key.permutation.s_sigma_3.0,
-                opening_key.g,
-                self.w_z_chall_w_comm.0,
-                self.w_z_chall_comm.0,
-                self.w_z_chall_w_comm.0,
             ];
-
-            let mut scalarmuls_scalars =
-                v_coeffs_E[..V_MAX_DEGREE_LEGACY].to_vec();
-
-            // As we include the shifted coefficients when computing [F]_1,
-            // we group them to save scalar multiplications when multiplying
-            // by [a]_1, [b]_1, and [d]_1
-            scalarmuls_scalars[0] += v_coeffs_E[V_MAX_DEGREE_LEGACY];
-            scalarmuls_scalars[1] += v_coeffs_E[V_MAX_DEGREE_LEGACY + 1];
-            scalarmuls_scalars[3] += v_coeffs_E[V_MAX_DEGREE_LEGACY + 2];
-
-            scalarmuls_scalars.push(E_scalar);
-            scalarmuls_scalars.push(u_challenge);
-            scalarmuls_scalars.push(z_challenge);
-            scalarmuls_scalars
-                .push(u_challenge * z_challenge * domain.group_gen);
-
-            // Compute the scalar multiplications in single-core
-            #[cfg(not(feature = "std"))]
-            let scalarmuls: Vec<G1Projective> = scalarmuls_points
-                .iter()
-                .zip(scalarmuls_scalars.iter())
-                .map(|(point, scalar)| point * scalar)
-                .collect();
-
-            // Compute the scalar multiplications in multi-core
-            #[cfg(feature = "std")]
-            let scalarmuls: Vec<G1Projective> = scalarmuls_points
-                .par_iter()
-                .zip(scalarmuls_scalars.par_iter())
-                .map(|(point, scalar)| point * scalar)
-                .collect();
 
             // [F]_1 = [D]_1 + (v)[a]_1 + (v^2)[b]_1 + (v^3)[c]_1 + (v^4)[d]_1 +
             // + (v^5)[s_sigma_1]_1 + (v^6)[s_sigma_2]_1 + (v^7)[s_sigma_3]_1 +
             // + (u * v_w)[a]_1 + (u * v_w^2)[b]_1 + (u * v_w^3)[d]_1
-            let mut F: G1Projective =
-                scalarmuls[..V_MAX_DEGREE_LEGACY].iter().sum();
+            let mut F = msm_variable_base(&f_points, &f_scalars);
             F += D;
 
             // [E]_1 = E * G
-            let E = scalarmuls[V_MAX_DEGREE_LEGACY];
+            let E = opening_key.g * E_scalar;
 
             // Compute the G_1 element of the first pairing:
             // [W_z]_1 + u * [W_zw]_1
@@ -760,14 +721,16 @@ pub(crate) mod alloc {
             // Note that we negate this value to be able to subtract
             // the pairings later on, using the multi Miller loop
             let left = G1Affine::from(
-                -(self.w_z_chall_comm.0 + scalarmuls[V_MAX_DEGREE_LEGACY + 1]),
+                -(self.w_z_chall_comm.0
+                    + (self.w_z_chall_w_comm.0 * u_challenge)),
             );
 
             // Compute the G_1 element of the second pairing:
             // z * [W_z]_1 + (u * z * w) * [W_zw]_1 + [F]_1 - [E]_1
             let right = G1Affine::from(
-                scalarmuls[V_MAX_DEGREE_LEGACY + 2]
-                    + scalarmuls[V_MAX_DEGREE_LEGACY + 3]
+                (self.w_z_chall_comm.0 * z_challenge)
+                    + (self.w_z_chall_w_comm.0
+                        * (u_challenge * z_challenge * domain.group_gen))
                     + F
                     - E,
             );
@@ -940,6 +903,49 @@ pub(crate) mod alloc {
 
                 denominators[i] * eval
             })
+            .sum();
+
+        result * numerator
+    }
+
+    pub(crate) fn compute_barycentric_eval_sparse(
+        indexes: &[usize],
+        evaluations: &[BlsScalar],
+        point: &BlsScalar,
+        domain: &EvaluationDomain,
+    ) -> BlsScalar {
+        if indexes.is_empty() {
+            return BlsScalar::zero();
+        }
+
+        let numerator = (point.pow(&[domain.size() as u64, 0, 0, 0])
+            - BlsScalar::one())
+            * domain.size_inv;
+
+        let non_zero_evaluations: Vec<_> = indexes
+            .iter()
+            .copied()
+            .zip(evaluations.iter().copied())
+            .filter(|(_, evaluation)| evaluation != &BlsScalar::zero())
+            .collect();
+
+        if non_zero_evaluations.is_empty() {
+            return BlsScalar::zero();
+        }
+
+        let mut denominators: Vec<BlsScalar> = non_zero_evaluations
+            .iter()
+            .map(|(index, _)| {
+                (domain.group_gen_inv.pow(&[*index as u64, 0, 0, 0]) * point)
+                    - BlsScalar::one()
+            })
+            .collect();
+        batch_inversion(&mut denominators);
+
+        let result: BlsScalar = non_zero_evaluations
+            .iter()
+            .zip(denominators.iter())
+            .map(|((_, evaluation), denominator)| *denominator * *evaluation)
             .sum();
 
         result * numerator

--- a/src/proof_system/quotient_poly.rs
+++ b/src/proof_system/quotient_poly.rs
@@ -4,15 +4,15 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::{
-    error::Error,
-    fft::{EvaluationDomain, Polynomial},
-    proof_system::ProverKey,
-};
 use alloc::vec::Vec;
+
 use dusk_bls12_381::BlsScalar;
 #[cfg(feature = "std")]
 use rayon::prelude::*;
+
+use crate::error::Error;
+use crate::fft::{EvaluationDomain, Polynomial};
+use crate::proof_system::ProverKey;
 
 /// Computes the Quotient [`Polynomial`] given the [`EvaluationDomain`], a
 /// [`ProverKey`] and some other info.

--- a/src/proof_system/widget.rs
+++ b/src/proof_system/widget.rs
@@ -4,8 +4,9 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::commitment_scheme::Commitment;
 use dusk_bytes::{DeserializableSlice, Serializable};
+
+use crate::commitment_scheme::Commitment;
 
 pub mod arithmetic;
 pub mod ecc;
@@ -14,14 +15,15 @@ pub mod permutation;
 pub mod range;
 
 #[cfg(feature = "rkyv-impl")]
-use crate::util::check_field;
-#[cfg(feature = "rkyv-impl")]
 use bytecheck::{CheckBytes, StructCheckError};
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
 };
+
+#[cfg(feature = "rkyv-impl")]
+use crate::util::check_field;
 
 /// PLONK circuit Verification Key.
 ///
@@ -197,11 +199,9 @@ impl VerifierKey {
 #[cfg(feature = "alloc")]
 pub(crate) mod alloc {
     use super::*;
-    use crate::{
-        error::Error,
-        fft::{EvaluationDomain, Evaluations, Polynomial},
-        transcript::TranscriptProtocol,
-    };
+    use crate::error::Error;
+    use crate::fft::{EvaluationDomain, Evaluations, Polynomial};
+    use crate::transcript::TranscriptProtocol;
     #[rustfmt::skip]
     use ::alloc::vec::Vec;
     use dusk_bls12_381::BlsScalar;
@@ -596,10 +596,11 @@ pub(crate) mod alloc {
 #[cfg(feature = "alloc")]
 #[cfg(test)]
 mod test {
+    use ff::Field;
+
     use super::alloc::ProverKey;
     use super::*;
     use crate::fft::{EvaluationDomain, Evaluations, Polynomial};
-    use ff::Field;
     #[rustfmt::skip]
     use ::alloc::vec::Vec;
     use dusk_bls12_381::BlsScalar;
@@ -702,8 +703,9 @@ mod test {
 
     #[test]
     fn test_serialize_deserialize_verifier_key() {
-        use crate::commitment_scheme::Commitment;
         use dusk_bls12_381::G1Affine;
+
+        use crate::commitment_scheme::Commitment;
 
         let n = 2usize.pow(5);
 
@@ -775,10 +777,11 @@ mod test {
 
     #[test]
     fn seed_transcript_binds_s_sigma_4_commitment() {
-        use crate::commitment_scheme::Commitment;
-        use crate::transcript::TranscriptProtocol;
         use dusk_bls12_381::G1Affine;
         use merlin::Transcript;
+
+        use crate::commitment_scheme::Commitment;
+        use crate::transcript::TranscriptProtocol;
 
         let n = 2usize.pow(5);
         let common = Commitment(G1Affine::generator());

--- a/src/proof_system/widget/arithmetic.rs
+++ b/src/proof_system/widget/arithmetic.rs
@@ -11,5 +11,4 @@ mod verifierkey;
 
 #[cfg(feature = "alloc")]
 pub(crate) use proverkey::ProverKey;
-
 pub(crate) use verifierkey::VerifierKey;

--- a/src/proof_system/widget/arithmetic/proverkey.rs
+++ b/src/proof_system/widget/arithmetic/proverkey.rs
@@ -4,17 +4,17 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::fft::{Evaluations, Polynomial};
-use crate::proof_system::linearization_poly::ProofEvaluations;
-use dusk_bls12_381::BlsScalar;
-
 #[cfg(feature = "rkyv-impl")]
 use bytecheck::CheckBytes;
+use dusk_bls12_381::BlsScalar;
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
 };
+
+use crate::fft::{Evaluations, Polynomial};
+use crate::proof_system::linearization_poly::ProofEvaluations;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(

--- a/src/proof_system/widget/arithmetic/verifierkey.rs
+++ b/src/proof_system/widget/arithmetic/verifierkey.rs
@@ -4,16 +4,16 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::commitment_scheme::Commitment;
-use dusk_bytes::{DeserializableSlice, Serializable};
-
 #[cfg(feature = "rkyv-impl")]
 use bytecheck::CheckBytes;
+use dusk_bytes::{DeserializableSlice, Serializable};
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
 };
+
+use crate::commitment_scheme::Commitment;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 #[cfg_attr(

--- a/src/proof_system/widget/ecc/curve_addition.rs
+++ b/src/proof_system/widget/ecc/curve_addition.rs
@@ -11,5 +11,4 @@ mod verifierkey;
 
 #[cfg(feature = "alloc")]
 pub(crate) use proverkey::ProverKey;
-
 pub(crate) use verifierkey::VerifierKey;

--- a/src/proof_system/widget/ecc/curve_addition/proverkey.rs
+++ b/src/proof_system/widget/ecc/curve_addition/proverkey.rs
@@ -4,18 +4,18 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::fft::{Evaluations, Polynomial};
-use crate::proof_system::linearization_poly::ProofEvaluations;
-use dusk_bls12_381::BlsScalar;
-use dusk_jubjub::EDWARDS_D;
-
 #[cfg(feature = "rkyv-impl")]
 use bytecheck::CheckBytes;
+use dusk_bls12_381::BlsScalar;
+use dusk_jubjub::EDWARDS_D;
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
 };
+
+use crate::fft::{Evaluations, Polynomial};
+use crate::proof_system::linearization_poly::ProofEvaluations;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(

--- a/src/proof_system/widget/ecc/curve_addition/verifierkey.rs
+++ b/src/proof_system/widget/ecc/curve_addition/verifierkey.rs
@@ -4,8 +4,6 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::commitment_scheme::Commitment;
-
 #[cfg(feature = "rkyv-impl")]
 use bytecheck::CheckBytes;
 #[cfg(feature = "rkyv-impl")]
@@ -13,6 +11,8 @@ use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
 };
+
+use crate::commitment_scheme::Commitment;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 #[cfg_attr(

--- a/src/proof_system/widget/ecc/scalar_mul/fixed_base.rs
+++ b/src/proof_system/widget/ecc/scalar_mul/fixed_base.rs
@@ -11,7 +11,6 @@ mod verifierkey;
 
 #[cfg(feature = "alloc")]
 pub(crate) use proverkey::ProverKey;
-
 pub(crate) use verifierkey::VerifierKey;
 
 // Note: The ECC gadget does not check that the initial point is on the curve

--- a/src/proof_system/widget/ecc/scalar_mul/fixed_base/proverkey.rs
+++ b/src/proof_system/widget/ecc/scalar_mul/fixed_base/proverkey.rs
@@ -4,18 +4,18 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::fft::{Evaluations, Polynomial};
-use crate::proof_system::linearization_poly::ProofEvaluations;
-use dusk_bls12_381::BlsScalar;
-use dusk_jubjub::EDWARDS_D;
-
 #[cfg(feature = "rkyv-impl")]
 use bytecheck::CheckBytes;
+use dusk_bls12_381::BlsScalar;
+use dusk_jubjub::EDWARDS_D;
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
 };
+
+use crate::fft::{Evaluations, Polynomial};
+use crate::proof_system::linearization_poly::ProofEvaluations;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(

--- a/src/proof_system/widget/ecc/scalar_mul/fixed_base/verifierkey.rs
+++ b/src/proof_system/widget/ecc/scalar_mul/fixed_base/verifierkey.rs
@@ -4,8 +4,6 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::commitment_scheme::Commitment;
-
 #[cfg(feature = "rkyv-impl")]
 use bytecheck::CheckBytes;
 #[cfg(feature = "rkyv-impl")]
@@ -13,6 +11,8 @@ use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
 };
+
+use crate::commitment_scheme::Commitment;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 #[cfg_attr(

--- a/src/proof_system/widget/logic/proverkey.rs
+++ b/src/proof_system/widget/logic/proverkey.rs
@@ -4,18 +4,17 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::fft::{Evaluations, Polynomial};
-use crate::proof_system::linearization_poly::ProofEvaluations;
-
-use dusk_bls12_381::BlsScalar;
-
 #[cfg(feature = "rkyv-impl")]
 use bytecheck::CheckBytes;
+use dusk_bls12_381::BlsScalar;
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
 };
+
+use crate::fft::{Evaluations, Polynomial};
+use crate::proof_system::linearization_poly::ProofEvaluations;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(

--- a/src/proof_system/widget/logic/verifierkey.rs
+++ b/src/proof_system/widget/logic/verifierkey.rs
@@ -4,8 +4,6 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::commitment_scheme::Commitment;
-
 #[cfg(feature = "rkyv-impl")]
 use bytecheck::CheckBytes;
 #[cfg(feature = "rkyv-impl")]
@@ -13,6 +11,8 @@ use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
 };
+
+use crate::commitment_scheme::Commitment;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 #[cfg_attr(

--- a/src/proof_system/widget/permutation.rs
+++ b/src/proof_system/widget/permutation.rs
@@ -11,5 +11,4 @@ mod verifierkey;
 
 #[cfg(feature = "alloc")]
 pub(crate) use proverkey::ProverKey;
-
 pub(crate) use verifierkey::VerifierKey;

--- a/src/proof_system/widget/permutation/proverkey.rs
+++ b/src/proof_system/widget/permutation/proverkey.rs
@@ -4,17 +4,17 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::composer::permutation::constants::{K1, K2, K3};
-use crate::fft::{EvaluationDomain, Evaluations, Polynomial};
-use dusk_bls12_381::BlsScalar;
-
 #[cfg(feature = "rkyv-impl")]
 use bytecheck::CheckBytes;
+use dusk_bls12_381::BlsScalar;
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
 };
+
+use crate::composer::permutation::constants::{K1, K2, K3};
+use crate::fft::{EvaluationDomain, Evaluations, Polynomial};
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(
@@ -66,6 +66,7 @@ impl ProverKey {
         let c = self.compute_quotient_term_check_one_i(z_i, l1_alpha_sq);
         a + b + c
     }
+
     // (a(x) + beta * X + gamma) (b(X) + beta * k1 * X + gamma) (o(X) + beta *
     // k2 * X + gamma)(d(X) + beta * k3 * X + gamma)z(X) * alpha
     fn compute_quotient_identity_range_check_i(
@@ -89,6 +90,7 @@ impl ProverKey {
             * z_i
             * alpha
     }
+
     // (a(x) + beta* Sigma1(X) + gamma) (b(X) + beta * Sigma2(X) + gamma) (o(X)
     // + beta * Sigma3(X) + gamma)(d(X) + beta * Sigma4(X) + gamma) Z(X.omega) *
     // alpha
@@ -118,6 +120,7 @@ impl ProverKey {
 
         -product
     }
+
     // L_1(X)[Z(X) - 1]
     fn compute_quotient_term_check_one_i(
         &self,
@@ -171,6 +174,7 @@ impl ProverKey {
         );
         &(&a + &b) + &c
     }
+
     // (a_eval + beta * z_challenge + gamma)(b_eval + beta * K1 * z_challenge +
     // gamma)(c_eval + beta * K2 * z_challenge + gamma) * alpha z(X)
     fn compute_linearizer_identity_range_check(
@@ -216,6 +220,7 @@ impl ProverKey {
         // * z_challenge + gamma)(c_eval + beta * K2 * z_challenge +
         // gamma) * alpha z(X)
     }
+
     // -(a_eval + beta * sigma_1 + gamma)(b_eval + beta * sigma_2 + gamma)
     // (c_eval + beta * sigma_3 + gamma) * beta *z_eval * alpha^2 * Sigma_4(X)
     fn compute_linearizer_copy_range_check(

--- a/src/proof_system/widget/permutation/verifierkey.rs
+++ b/src/proof_system/widget/permutation/verifierkey.rs
@@ -4,8 +4,6 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::commitment_scheme::Commitment;
-
 #[cfg(feature = "rkyv-impl")]
 use bytecheck::CheckBytes;
 #[cfg(feature = "rkyv-impl")]
@@ -13,6 +11,8 @@ use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
 };
+
+use crate::commitment_scheme::Commitment;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 #[cfg_attr(

--- a/src/proof_system/widget/range.rs
+++ b/src/proof_system/widget/range.rs
@@ -11,5 +11,4 @@ mod verifierkey;
 
 #[cfg(feature = "alloc")]
 pub(crate) use proverkey::ProverKey;
-
 pub(crate) use verifierkey::VerifierKey;

--- a/src/proof_system/widget/range/proverkey.rs
+++ b/src/proof_system/widget/range/proverkey.rs
@@ -4,17 +4,17 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::fft::{Evaluations, Polynomial};
-use crate::proof_system::linearization_poly::ProofEvaluations;
-use dusk_bls12_381::BlsScalar;
-
 #[cfg(feature = "rkyv-impl")]
 use bytecheck::CheckBytes;
+use dusk_bls12_381::BlsScalar;
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
 };
+
+use crate::fft::{Evaluations, Polynomial};
+use crate::proof_system::linearization_poly::ProofEvaluations;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(

--- a/src/proof_system/widget/range/verifierkey.rs
+++ b/src/proof_system/widget/range/verifierkey.rs
@@ -4,8 +4,6 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::commitment_scheme::Commitment;
-
 #[cfg(feature = "rkyv-impl")]
 use bytecheck::CheckBytes;
 #[cfg(feature = "rkyv-impl")]
@@ -13,6 +11,8 @@ use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
 };
+
+use crate::commitment_scheme::Commitment;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 #[cfg_attr(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -10,10 +10,9 @@
 use dusk_bls12_381::BlsScalar;
 
 #[cfg(feature = "debug")]
-use crate::prelude::{Constraint, Witness};
-
-#[cfg(feature = "debug")]
 use crate::debugger::Debugger;
+#[cfg(feature = "debug")]
+use crate::prelude::{Constraint, Witness};
 
 /// Runtime events
 #[derive(Debug, Clone, Copy)]
@@ -72,12 +71,12 @@ impl Runtime {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    #[cfg(feature = "debug")]
-    use crate::prelude::{Constraint, Witness};
     #[cfg(feature = "debug")]
     use dusk_bls12_381::BlsScalar;
+
+    use super::*;
+    #[cfg(feature = "debug")]
+    use crate::prelude::{Constraint, Witness};
 
     #[test]
     fn runtime_new_default_and_events_do_not_panic() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,6 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use alloc::vec::Vec;
+
 use dusk_bls12_381::{
     BlsScalar, G1Affine, G1Projective, G2Affine, G2Projective,
 };

--- a/tests/logic.rs
+++ b/tests/logic.rs
@@ -5,6 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use core::cmp;
+
 use dusk_plonk::prelude::*;
 use ff::Field;
 use rand::SeedableRng;


### PR DESCRIPTION
## Summary

- merge the Plonk 0.22 maintenance history up to private commit `f63cfb0c4a5e5f485361c83ae15584257d3339ab`
- keep the public `v0.22.0` release commit in history
- release the imported maintenance changes as `dusk-plonk 0.22.1`

## Notes

This keeps the Rusk 1.7 dependency line on `0.22.x` instead of moving it to the broader `0.23.0` dependency update.

## Validation

- `cargo package --allow-dirty --no-verify`
- `make test`
- `make clippy`
- `make no-std`
- `cargo publish --dry-run`
