### PR TITLE
Reject trailing data in compressed circuits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reject trailing data when deserializing compressed circuits [#913]
 - Validate cached permutation linear evaluations during checked `Prover`
   deserialization [#908]
 - Validate cached vanishing-coset evaluations during checked `Prover`
@@ -748,6 +749,7 @@ is necessary since `rkyv/validation` was required as a bound.
 - Proof system module.
 
 <!-- ISSUES -->
+[#913]: https://github.com/dusk-network/plonk/issues/913
 [#908]: https://github.com/dusk-network/plonk/issues/908
 [#902]: https://github.com/dusk-network/plonk/issues/902
 [#903]: https://github.com/dusk-network/plonk/issues/903

--- a/src/composer/compress.rs
+++ b/src/composer/compress.rs
@@ -202,7 +202,7 @@ impl CompressedCircuit {
         let compressed = miniz_oxide::inflate::decompress_to_vec(compressed)
             .map_err(|_| Error::InvalidCompressedCircuit)?;
         let (
-            _,
+            consumed,
             Self {
                 hades_optimization,
                 public_inputs,
@@ -213,6 +213,9 @@ impl CompressedCircuit {
             },
         ) = Self::unpack(&compressed)
             .map_err(|_| Error::InvalidCompressedCircuit)?;
+        if consumed != compressed.len() {
+            return Err(Error::InvalidCompressedCircuit);
+        }
 
         let scalar_map = scalar_map(hades_optimization);
         let mut version_scalars = vec![BlsScalar::zero(); scalar_map.len()];

--- a/tests/composer.rs
+++ b/tests/composer.rs
@@ -87,6 +87,20 @@ fn circuit_with_all_gates() {
     let compressed =
         DummyCircuit::compress().expect("failed to compress circuit");
 
+    let mut packed = miniz_oxide::inflate::decompress_to_vec(&compressed)
+        .expect("failed to decompress circuit");
+    packed.push(0xc0); // valid msgpack nil value after the circuit payload
+    let compressed_with_trailing_data =
+        miniz_oxide::deflate::compress_to_vec(&packed, 10);
+    assert!(matches!(
+        Compiler::compile_with_compressed(
+            &pp,
+            label,
+            &compressed_with_trailing_data
+        ),
+        Err(Error::InvalidCompressedCircuit)
+    ));
+
     let (decompressed_prover, decompressed_verifier) =
         Compiler::compile_with_compressed(&pp, label, &compressed).unwrap();
 

--- a/tests/composer.rs
+++ b/tests/composer.rs
@@ -90,6 +90,20 @@ fn circuit_with_all_gates() {
     let compressed =
         DummyCircuit::compress().expect("failed to compress circuit");
 
+    let mut packed = miniz_oxide::inflate::decompress_to_vec(&compressed)
+        .expect("failed to decompress circuit");
+    packed.push(0xc0); // valid msgpack nil value after the circuit payload
+    let compressed_with_trailing_data =
+        miniz_oxide::deflate::compress_to_vec(&packed, 10);
+    assert!(matches!(
+        Compiler::compile_with_compressed(
+            &pp,
+            label,
+            &compressed_with_trailing_data
+        ),
+        Err(Error::InvalidCompressedCircuit)
+    ));
+
     let (decompressed_prover, decompressed_verifier) =
         Compiler::compile_with_compressed(&pp, label, &compressed).unwrap();
 


### PR DESCRIPTION
Ensures compressed circuit deserialization rejects payloads with trailing bytes after the msgpack circuit body. The added regression test appends a valid extra msgpack value to an otherwise valid compressed circuit and verifies that `compile_with_compressed` returns `InvalidCompressedCircuit` instead of accepting the malformed payload.

Closes #913