### PR TITLE
Bind logic gadget output to its inputs

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt install -y kcov
-      - run: RUSTFLAGS='-Cdebuginfo=2 -Cinline-threshold=0 -Clink-dead-code' cargo test --release --no-run --all-features
+      - run: RUSTFLAGS='-Cdebuginfo=2 -Cllvm-args=--inline-threshold=0 -Clink-dead-code' cargo test --release --no-run --all-features
       - name: Collect coverage
         run: >
           find target/release/deps -type f -executable ! -name "*.*" |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `Composer::component_truncate<N>` to extract the low `N` bits of a witness [#867]
+- Add `Composer::component_range_bits<BITS>` range check counting bits directly [#867]
+
+### Changed
+
+- Cap logic gadget width at 254 bits; `BIT_PAIRS > 127` is now a compile-time error [#867]
+- Change the verifier key of circuits using the logic gadget [#867]
+- Increase the gate count of `append_logic_and`/`append_logic_xor` to bind their inputs [#867]
+
+### Deprecated
+
+- Deprecate `Composer::component_range<BIT_PAIRS>` in favour of `Composer::component_range_bits<BITS>` [#867]
+
+### Fixed
+
+- Bind `append_logic_xor`/`append_logic_and` output to their inputs [#867]
+
 ## [0.22.1] - 2026-06-12
 
 ### Added
@@ -665,6 +684,7 @@ is necessary since `rkyv/validation` was required as a bound.
 - Proof system module.
 
 <!-- ISSUES -->
+[#867]: https://github.com/dusk-network/plonk/issues/867
 [#862]: https://github.com/dusk-network/plonk/issues/862
 [#861]: https://github.com/dusk-network/plonk/issues/861
 [#860]: https://github.com/dusk-network/plonk/issues/860

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,5 +140,9 @@ required-features = ["alloc"]
 name = "select_point"
 required-features = ["alloc"]
 
+[[test]]
+name = "truncate"
+required-features = ["alloc"]
+
 [package.metadata.docs.rs]
 rustdoc-args = [ "--html-in-header", "./katex-header.html" ]

--- a/benches/plonk.rs
+++ b/benches/plonk.rs
@@ -54,8 +54,8 @@ impl<const DEGREE: usize> Circuit for BenchCircuit<DEGREE> {
             composer.gate_add(Constraint::new().left(1).right(1).a(w_a).b(w_b));
 
             composer.component_add_point(w_z, w_z);
-            composer.append_logic_and::<128>(w_a, w_b);
-            composer.append_logic_xor::<128>(w_a, w_b);
+            composer.append_logic_and::<127>(w_a, w_b);
+            composer.append_logic_xor::<127>(w_a, w_b);
             composer.component_boolean(Composer::ONE);
             composer.component_decomposition::<254>(w_a);
             composer.component_mul_generator(
@@ -63,7 +63,7 @@ impl<const DEGREE: usize> Circuit for BenchCircuit<DEGREE> {
                 dusk_jubjub::GENERATOR_EXTENDED,
             )?;
             composer.component_mul_point(w_y, w_z);
-            composer.component_range::<128>(w_a);
+            composer.component_range_bits::<256>(w_a);
             composer.component_select(Composer::ONE, w_a, w_b);
             composer.component_select_identity(Composer::ONE, w_z);
             composer.component_select_one(Composer::ONE, w_a);

--- a/examples/circuit.rs
+++ b/examples/circuit.rs
@@ -31,10 +31,10 @@ impl Circuit for TestCircuit {
         let d = composer.append_witness(self.d);
 
         // 1) a < 2^6
-        composer.component_range::<3>(a); // 3 BIT_PAIRS = 6 bits
+        composer.component_range_bits::<6>(a);
 
         // 2) b < 2^4
-        composer.component_range::<2>(b); // 2 BIT_PAIRS = 4 bits
+        composer.component_range_bits::<4>(b);
 
         // 3) a + b + 42 = c where c is public input
         let constraint = Constraint::new()

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -22,6 +22,18 @@ mod compress;
 mod constraint_system;
 mod gate;
 
+#[cfg(test)]
+mod logic_gate_soundness_tests;
+
+#[cfg(test)]
+mod range_soundness_tests;
+
+#[cfg(test)]
+mod soundness_support;
+
+#[cfg(test)]
+mod truncate_soundness_tests;
+
 pub(crate) mod permutation;
 
 pub use circuit::Circuit;
@@ -55,6 +67,21 @@ impl ops::Index<Witness> for Composer {
     fn index(&self, w: Witness) -> &Self::Output {
         &self.witnesses[w.index()]
     }
+}
+
+/// Recompose `bits[start..end]` (little-endian, bit `i` weighing `2^i`) into a
+/// field element with `bits[start]` as the least significant bit, i.e. the
+/// value `sum_{i in [start, end)} bits[i] * 2^(i - start)`.
+fn recompose_bits(bits: &[u8; 256], start: usize, end: usize) -> BlsScalar {
+    let two = BlsScalar::from(2u64);
+    let mut value = BlsScalar::zero();
+    for i in (start..end).rev() {
+        value *= two;
+        if bits[i] == 1 {
+            value += BlsScalar::one();
+        }
+    }
+    value
 }
 
 // pub trait Composer: Sized + Index<Witness, Output = BlsScalar> {
@@ -254,8 +281,19 @@ impl Composer {
     /// Performs a logical AND or XOR op between the inputs provided for
     /// `num_bits = BIT_PAIRS * 2` bits (counting from the least significant).
     ///
-    /// Each logic gate adds `BIT_PAIRS + 1` gates to the circuit to
-    /// perform the whole operation.
+    /// `BIT_PAIRS` is capped at `127` (254 bits): the closing truncation
+    /// binding is only canonical up to 254 bits, since a canonical
+    /// `BlsScalar` is 255 bits. `BIT_PAIRS > 127` would silently drop input
+    /// bits, so it is rejected at **compile time** rather than truncated.
+    ///
+    /// Each logic op adds `BIT_PAIRS + 1` gates for the operation itself, plus
+    /// the gates binding the result to the input witnesses. Per input the
+    /// binding range-checks the high part and the canonical guard's two
+    /// differences — a total width of `510 - num_bits` bits, so roughly
+    /// `(510 - num_bits) / 8` gates plus a small fixed remainder. The binding
+    /// therefore shrinks as `num_bits` grows, but the operation loop grows
+    /// twice as fast, so the total rises with width: 172 gates at 2 bits, 234
+    /// at 250.
     ///
     /// ## Constraint
     /// - is_component_xor = 1 -> Performs XOR between the first `num_bits` for
@@ -268,10 +306,21 @@ impl Composer {
         b: Witness,
         is_component_xor: bool,
     ) -> Witness {
-        // the bits are iterated as chunks of two; hence, we require an even
-        // number
-        let num_bits = cmp::min(BIT_PAIRS * 2, 256);
-        let num_quads = num_bits >> 1;
+        // The bits are processed in quads (two bits each), so the width is
+        // always even. It is capped at 254 — the largest even width for which
+        // the closing truncation binding below is canonical (a canonical
+        // `BlsScalar` is 255 bits). Exceeding `BIT_PAIRS = 127` would silently
+        // drop bits, a soundness footgun, so it is a hard compile-time error
+        // rather than a quiet cap.
+        const {
+            assert!(
+                BIT_PAIRS <= 127,
+                "BIT_PAIRS must be <= 127: the logic gadget operates on at most 254 bits"
+            )
+        };
+
+        let num_bits = BIT_PAIRS * 2;
+        let num_quads = BIT_PAIRS;
 
         let bls_four = BlsScalar::from(4u64);
         let mut left_acc = BlsScalar::zero();
@@ -358,15 +407,110 @@ impl Composer {
 
         // pad last output with `0`
         // | an  | bn  | 0   | dn  |
-        let a = constraint.witness(WiredWitness::A);
-        let b = constraint.witness(WiredWitness::B);
+        let left_acc_wit = constraint.witness(WiredWitness::A);
+        let right_acc_wit = constraint.witness(WiredWitness::B);
         let d = constraint.witness(WiredWitness::D);
 
-        let constraint = Constraint::new().a(a).b(b).d(d);
+        let constraint =
+            Constraint::new().a(left_acc_wit).b(right_acc_wit).d(d);
 
         self.append_custom_gate(constraint);
 
+        // Bind the recomposed accumulators to the input witnesses. The loop
+        // above constrains the accumulators only among themselves;
+        // without this binding the output is decoupled from `a`/`b` and
+        // a malicious prover can pick arbitrary accumulators (and thus
+        // an arbitrary output) for the identical gate layout. Mirrors
+        // `component_range`'s closing `assert_equal`, generalised to a
+        // canonical truncation to `num_bits` bits.
+        self.bind_logic_accumulators::<BIT_PAIRS>(
+            a,
+            b,
+            left_acc_wit,
+            right_acc_wit,
+        );
+
         d
+    }
+
+    /// Bind the recomposed logic accumulators to the gadget's input witnesses.
+    ///
+    /// `left_acc`/`right_acc` are the final accumulators produced by
+    /// [`Self::append_logic_component`]; the logic gate guarantees each lies in
+    /// `[0, 2^num_bits)`. This binds them to the low `num_bits` of `a`/`b` so
+    /// the output cannot be decoupled from the inputs.
+    fn bind_logic_accumulators<const BIT_PAIRS: usize>(
+        &mut self,
+        a: Witness,
+        b: Witness,
+        left_acc: Witness,
+        right_acc: Witness,
+    ) {
+        // A zero-bit logic op reads no input bits and returns `0`, so there is
+        // nothing to bind.
+        if BIT_PAIRS == 0 {
+            return;
+        }
+
+        self.bind_truncated_input::<BIT_PAIRS>(a, left_acc);
+        self.bind_truncated_input::<BIT_PAIRS>(b, right_acc);
+    }
+
+    /// Constrain `acc` to be the low `num_bits = BIT_PAIRS * 2` bits of
+    /// `input` (`BIT_PAIRS <= 127`, enforced by the caller).
+    ///
+    /// `acc` is already constrained to `[0, 2^num_bits)` by the logic gate;
+    /// this ties it to `input` through the shared truncation split.
+    fn bind_truncated_input<const BIT_PAIRS: usize>(
+        &mut self,
+        input: Witness,
+        acc: Witness,
+    ) {
+        // matches the width of `append_logic_component`, which caps
+        // `BIT_PAIRS` at 127 (254 bits) at compile time
+        let num_bits = BIT_PAIRS * 2;
+        self.bind_truncation_split(input, acc, num_bits);
+    }
+
+    /// Bind an already-bounded `low` to the low `num_bits` of `input` via the
+    /// canonical truncation split `input = high * 2^num_bits + low`.
+    ///
+    /// Derives `high` from `input`, range-checks it to
+    /// `[0, 2^(255 - num_bits))`, enforces the linear relation, and adds the
+    /// canonical `< r` guard so the split cannot alias `input + r`. The caller
+    /// MUST already constrain `low` to `[0, 2^num_bits)` — with a range check,
+    /// or through the logic gate for the logic gadget — otherwise the split is
+    /// not unique and the binding is unsound. Shared core of
+    /// [`Self::component_truncate`] and [`Self::bind_truncated_input`].
+    fn bind_truncation_split(
+        &mut self,
+        input: Witness,
+        low: Witness,
+        num_bits: usize,
+    ) {
+        // A canonical field element is < 2^255, so its high part fits in
+        // `255 - num_bits` bits.
+        let high_bits = 255 - num_bits;
+        let pow = BlsScalar::pow_of_2(num_bits as u64);
+
+        // high = floor(input / 2^num_bits), recomposed from the high input
+        // bits, range-checked so it cannot absorb a different low part.
+        let input_bits = self[input].to_bits();
+        let high_value = recompose_bits(&input_bits, num_bits, 256);
+        let high = self.append_witness(high_value);
+        self.range_check(high, high_bits);
+
+        // input == high * 2^num_bits + low
+        let recomposed =
+            self.gate_add(Constraint::new().left(pow).right(1).a(high).b(low));
+        self.assert_equal(recomposed, input);
+
+        // The linear relation above also admits the non-canonical assignment
+        // that recomposes to `input + r` (a small `high` with a different
+        // `low`, both still in range), decoupling `low` from `input`. The
+        // canonical guard rejects exactly that alias, pinning `low` to the
+        // integer reduction.
+        self.assert_canonical_truncation(high, low, num_bits);
     }
 
     /// Evaluate `jubjub · Generator` as a [`WitnessPoint`]
@@ -679,9 +823,10 @@ impl Composer {
         self.append_gate(constraint);
     }
 
-    /// Adds a logical AND gate that performs the bitwise AND between two values
-    /// specified first `num_bits = BIT_PAIRS * 2` bits returning a [`Witness`]
-    /// holding the result.
+    /// Adds a logical AND gate that performs the bitwise AND between two
+    /// values for the specified first `num_bits = BIT_PAIRS * 2` bits
+    /// (`BIT_PAIRS <= 127`, max 254 bits) returning a [`Witness`] holding the
+    /// result.
     pub fn append_logic_and<const BIT_PAIRS: usize>(
         &mut self,
         a: Witness,
@@ -690,9 +835,9 @@ impl Composer {
         self.append_logic_component::<BIT_PAIRS>(a, b, false)
     }
 
-    /// Adds a logical XOR gate that performs the XOR between two values for the
-    /// specified first `num_bits = BIT_PAIRS * 2` bits returning a [`Witness`]
-    /// holding the result.
+    /// Adds a logical XOR gate that performs the XOR between two values for
+    /// the specified first `num_bits = BIT_PAIRS * 2` bits (`BIT_PAIRS <=
+    /// 127`, max 254 bits) returning a [`Witness`] holding the result.
     pub fn append_logic_xor<const BIT_PAIRS: usize>(
         &mut self,
         a: Witness,
@@ -1024,6 +1169,37 @@ impl Composer {
         self.gate_mul(constraint)
     }
 
+    /// Constrains a [`Witness`] to the range `[0, 2^BITS)`, for any (possibly
+    /// odd) compile-time `BITS` up to `256`.
+    ///
+    /// This is the bit-width-native range check. Even widths use the base-4
+    /// quad decomposition; an odd width peels off the most-significant bit as a
+    /// boolean and quad-checks the even remainder, so the cost is essentially
+    /// that of the even check.
+    ///
+    /// Prefer this over the bit-pair-counted [`Self::component_range`]: `BITS`
+    /// is the actual bit width, with no `× 2` to track.
+    ///
+    /// A canonical `BlsScalar` is below `2^255`, so any `BITS >= 255` is
+    /// satisfied by every witness: the check still emits its gates but
+    /// constrains nothing.
+    pub fn component_range_bits<const BITS: usize>(
+        &mut self,
+        witness: Witness,
+    ) {
+        // `range_check` recomposes a witness < 2^256, so wider checks are
+        // meaningless; reject them at compile time rather than silently
+        // capping.
+        const {
+            assert!(
+                BITS <= 256,
+                "BITS must be <= 256: a witness is at most 256 bits wide"
+            )
+        };
+
+        self.range_check(witness, BITS);
+    }
+
     /// Adds a range-constraint gate that checks and constrains a [`Witness`]
     /// to be encoded in at most `num_bits = BIT_PAIRS * 2` bits, which means
     /// that the underlying [`BlsScalar`] of the [`Witness`] will be within the
@@ -1033,14 +1209,194 @@ impl Composer {
     /// (num_bits - 1)/8 + 9 gates, when num_bits > 0,
     /// and 7 gates, when num_bits = 0
     /// to the circuit description.
+    /// Widths above `BIT_PAIRS = 128` are clamped to 256 bits rather than
+    /// rejected, so they all mean the same check.
+    #[deprecated(note = "this counts bit-pairs, an easy 2x footgun. Use \
+        `component_range_bits::<BITS>`, which counts bits directly: for \
+        `N <= 128` replace `component_range::<N>` with \
+        `component_range_bits::<2 * N>`; a wider `N` was clamped to 256 bits, \
+        so it becomes `component_range_bits::<256>`.")]
     pub fn component_range<const BIT_PAIRS: usize>(
         &mut self,
         witness: Witness,
     ) {
-        // the bits are iterated as chunks of two; hence, we require an even
-        // number
-        let num_bits = cmp::min(BIT_PAIRS * 2, 256);
+        // Delegates to the shared base-4 core: `BIT_PAIRS` bit-pairs is `2 *
+        // BIT_PAIRS` bits, capped at 256. The core emits the same base-4
+        // decomposition this entry point checks, so the gate layout — and thus
+        // the verifier key — is identical for every caller.
+        self.range_check_even(witness, cmp::min(BIT_PAIRS * 2, 256));
+    }
 
+    /// Extract the low `N` bits of `witness` as a new [`Witness`], canonically
+    /// bound to its input.
+    ///
+    /// This is the truncation primitive: it proves `low = witness mod 2^N`
+    /// directly via the relation `witness = high * 2^N + low`, with a range
+    /// check on `low` (`N` bits), a range check on `high` (the remaining
+    /// `255 - N` bits), the linear binding gate, and a canonical `< r` guard so
+    /// the `(high, low)` split cannot alias the non-canonical representation
+    /// `witness + r`. `N` may be odd.
+    ///
+    /// `append_logic_xor::<BIT_PAIRS>(witness, ZERO)` also yields the low bits,
+    /// but it is a bitwise operator pressed into a truncation role: it pays for
+    /// the full bitwise widget over the discarded high bits and its width is a
+    /// bit-pair count, not a bit count. Prefer `component_truncate` when the
+    /// intent is "take the low `N` bits"; reach for the logic gate when the
+    /// intent is an actual bitwise `XOR`.
+    ///
+    /// Cost: the gadget range-checks the full `N + (255 - N)` split plus a
+    /// same-width canonical guard, so the decomposed width — and with it the
+    /// gate count — is essentially independent of `N`: 84-88 gates across the
+    /// whole range. That is cheaper than `append_logic_xor::<N / 2>(x, ZERO)`
+    /// at every width, and the gap widens with `N`, since the logic gadget pays
+    /// for its per-quad loop on top of the same binding: 88 against 172 gates
+    /// at 2 bits, 88 against 234 at 250.
+    ///
+    /// `N` is capped at `254` at compile time: a canonical `BlsScalar` is 255
+    /// bits, so a wider truncation would leave the high part with less than one
+    /// bit and the canonical guard ill-defined.
+    pub fn component_truncate<const N: usize>(
+        &mut self,
+        witness: Witness,
+    ) -> Witness {
+        // A canonical `BlsScalar` is 255 bits, so the truncation binding below
+        // is only canonical up to 254 bits. A wider width would silently drop
+        // input bits, so it is a hard compile-time error rather than a quiet
+        // cap.
+        const {
+            assert!(
+                N <= 254,
+                "N must be <= 254: truncation operates on at most 254 bits"
+            )
+        };
+
+        // Split the low `N` bits off `witness` as a bounded witness, then bind
+        // it back to `witness` through the shared truncation split.
+        let low_value = recompose_bits(&self[witness].to_bits(), 0, N);
+        let low = self.append_witness(low_value);
+        self.range_check(low, N);
+        self.bind_truncation_split(witness, low, N);
+
+        low
+    }
+
+    /// Constrain `(high, low)` to be the canonical split of a field element at
+    /// bit `num_bits`, i.e. `high * 2^num_bits + low < r`. This adds only the
+    /// `< r` guard, rejecting the single non-canonical alias `witness + r`; it
+    /// does not bound `low` or `high` itself.
+    ///
+    /// Caller MUST range-check both operands before calling — `low` to
+    /// `[0, 2^num_bits)` and `high` to `[0, 2^(255 - num_bits))` — otherwise
+    /// the split is not unique and the binding is unsound. This is the
+    /// shared core for every truncation caller; the obligation is not
+    /// enforced in-gate.
+    fn assert_canonical_truncation(
+        &mut self,
+        high: Witness,
+        low: Witness,
+        num_bits: usize,
+    ) {
+        let high_bits = 255 - num_bits;
+
+        // Modulus-derived bounds: write `r - 1 = r_high * 2^num_bits + r_low`.
+        // The split is canonical (i.e. `< r`, not `< 2r`) iff `(high, low) <=
+        // (r_high, r_low)` lexicographically.
+        let modulus_bits = (-BlsScalar::one()).to_bits();
+        let r_low = recompose_bits(&modulus_bits, 0, num_bits);
+        let r_high = recompose_bits(&modulus_bits, num_bits, 256);
+
+        // Enforce `high <= r_high` via `diff = r_high - high in [0,
+        // 2^high_bits)`.
+        let diff = self.gate_add(
+            Constraint::new()
+                .left(-BlsScalar::one())
+                .a(high)
+                .constant(r_high),
+        );
+        self.range_check(diff, high_bits);
+
+        // is_top = 1 iff high == r_high (diff == 0). Standard is-zero gadget:
+        // set `product = diff * inverse` and `is_top = 1 - product`, then the
+        // final gate `diff * is_top = 0` pins everything.
+        let diff_inverse = self[diff].invert().unwrap_or(BlsScalar::zero());
+        let inverse = self.append_witness(diff_inverse);
+        let product =
+            self.gate_mul(Constraint::new().mult(1).a(diff).b(inverse));
+        // is_top = 1 - product
+        let is_top = self.gate_add(
+            Constraint::new()
+                .left(-BlsScalar::one())
+                .a(product)
+                .constant(1),
+        );
+        // diff * is_top = 0. This alone pins is_top to exactly `[diff == 0]`,
+        // so no explicit `component_boolean(is_top)` is needed. If diff == 0,
+        // then product = 0 and is_top = 1 - 0 = 1. If diff != 0, this gate
+        // forces is_top = 0, which forces product = 1 and hence the prover to
+        // supply inverse = diff^-1. Either way is_top is 0 or 1; no other value
+        // satisfies the system, so a boolean constraint would be redundant.
+        self.append_gate(Constraint::new().mult(1).a(diff).b(is_top));
+
+        // When high == r_high, require low <= r_low (so the value is < r). The
+        // guard is `is_top * (r_low - low)`, which must lie in `[0,
+        // 2^num_bits)`: for `low > r_low` it underflows to a huge field
+        // element and fails the range check; for `high < r_high` it is zero
+        // (canonicity already holds).
+        let r_low_minus_low = self.gate_add(
+            Constraint::new()
+                .left(-BlsScalar::one())
+                .a(low)
+                .constant(r_low),
+        );
+        let guard = self
+            .gate_mul(Constraint::new().mult(1).a(is_top).b(r_low_minus_low));
+        self.range_check(guard, num_bits);
+    }
+
+    /// Constrain `value` to lie in `[0, 2^num_bits)`, for any (possibly odd)
+    /// runtime `num_bits`. A runtime-sized, odd-capable counterpart to
+    /// [`Self::component_range`], whose `const BIT_PAIRS` entry point can only
+    /// size even widths known at compile time.
+    ///
+    /// Even widths use the quad-based [`Self::range_check_even`] (the same
+    /// width-4 base-4 decomposition as `component_range`); an odd width peels
+    /// off the most-significant bit as a boolean and quad-checks the even
+    /// remainder, so the cost is essentially that of the even check.
+    fn range_check(&mut self, value: Witness, num_bits: usize) {
+        if num_bits % 2 == 0 {
+            self.range_check_even(value, num_bits);
+            return;
+        }
+
+        // value == lower + top_bit * 2^(num_bits - 1), with `lower` in
+        // `[0, 2^(num_bits - 1))` and `top_bit` boolean — so value <
+        // 2^num_bits.
+        let top = num_bits - 1;
+        let value_bits = self[value].to_bits();
+        let lower_value = recompose_bits(&value_bits, 0, top);
+        let top_bit_value = BlsScalar::from(value_bits[top] as u64);
+
+        let lower = self.append_witness(lower_value);
+        self.range_check_even(lower, top);
+
+        let top_bit = self.append_witness(top_bit_value);
+        self.component_boolean(top_bit);
+
+        let recomposed = self.gate_add(
+            Constraint::new()
+                .left(1)
+                .right(BlsScalar::pow_of_2(top as u64))
+                .a(lower)
+                .b(top_bit),
+        );
+        self.assert_equal(recomposed, value);
+    }
+
+    /// Constrain `value` to lie in `[0, 2^num_bits)` for an even runtime
+    /// `num_bits` (`<= 256`). This is the shared base-4 decomposition that
+    /// [`Self::component_range`] and the even path of [`Self::range_check`]
+    /// delegate to — the single source of truth for the width-4 range layout.
+    fn range_check_even(&mut self, witness: Witness, num_bits: usize) {
         // if num_bits = 0 constrain witness to 0
         if num_bits == 0 {
             let constraint = Constraint::new().left(1).a(witness);
@@ -1054,13 +1410,8 @@ impl Composer {
         let mut bits: Vec<_> = bit_iter.collect();
         bits.reverse();
 
-        // considering this is a width-4 program, one gate will contain 4
-        // accumulators. each accumulator proves that a single quad is a
-        // base-4 digit. accumulators are bijective to quads, and these
-        // are 2-bits each. given that, one gate accumulates 8 bits.
+        // each gate holds 4 quads (2 bits each), so one gate accumulates 8 bits
         let mut num_gates = num_bits >> 3;
-
-        // given each gate accumulates 8 bits, its count must be padded
         if num_bits % 8 != 0 {
             num_gates += 1;
         }
@@ -1075,12 +1426,9 @@ impl Composer {
         // last gate is reserved for either the genesis quad or the padding
         let used_gates = num_gates + 1;
 
-        let base = Constraint::new();
-        let base = Constraint::range(&base);
+        let base = Constraint::range(&Constraint::new());
         let mut constraints = vec![base; used_gates];
 
-        // We collect the set of accumulators to return back to the user
-        // and keep a running count of the current accumulator
         let mut accumulators: Vec<Witness> = Vec::new();
         let mut accumulator = BlsScalar::zero();
         let four = BlsScalar::from(4);
@@ -1096,19 +1444,18 @@ impl Composer {
             accumulator += BlsScalar::from(quad);
 
             let accumulator_var = self.append_witness(accumulator);
-
             accumulators.push(accumulator_var);
 
             let idx = i / 4;
-            let witness = match i % 4 {
-                0 => WiredWitness::D,
-                1 => WiredWitness::C,
-                2 => WiredWitness::B,
-                3 => WiredWitness::A,
-                _ => unreachable!(),
-            };
+            // wires fill D, C, B, A within each gate as `i` advances
+            let wire = [
+                WiredWitness::D,
+                WiredWitness::C,
+                WiredWitness::B,
+                WiredWitness::A,
+            ][i % 4];
 
-            constraints[idx].set_witness(witness, accumulator_var);
+            constraints[idx].set_witness(wire, accumulator_var);
         }
 
         // last constraint is zeroed as it is reserved for the genesis quad or
@@ -1117,10 +1464,6 @@ impl Composer {
             *c = Constraint::new();
         }
 
-        // the accumulators count is a function to the number of quads. hence,
-        // this optional gate will not cause different circuits depending on the
-        // witness because this computation is bound to the constant bits count
-        // alone.
         if let Some(accumulator) = accumulators.last() {
             if let Some(c) = constraints.last_mut() {
                 c.set_witness(WiredWitness::D, *accumulator);
@@ -1131,10 +1474,6 @@ impl Composer {
             .into_iter()
             .for_each(|c| self.append_custom_gate(c));
 
-        // the accumulators count is a function to the number of quads. hence,
-        // this optional gate will not cause different circuits depending on the
-        // witness because this computation is bound to the constant bits count
-        // alone.
         if let Some(accumulator) = accumulators.last() {
             self.assert_equal(*accumulator, witness);
         }

--- a/src/composer/logic_gate_soundness_tests.rs
+++ b/src/composer/logic_gate_soundness_tests.rs
@@ -1,0 +1,413 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! Soundness regression for `append_logic_component`'s input binding.
+//!
+//! The logic gadget once rebuilt its output from the bits of `a`/`b` without
+//! wiring the input witnesses into any gate, so a cheating prover could satisfy
+//! the identical gate layout (and so the same verifier key) with accumulators
+//! decoupled from the inputs. `append_logic_component` now binds the inputs;
+//! this test guards against a regression of that historical defect.
+//!
+//! Exhibiting such an assignment requires emitting the logic gate with forged
+//! witnesses, which needs the crate-private logic selector — hence this test
+//! lives in-crate rather than in `tests/`. It is a full
+//! `compile -> prove -> verify` round-trip against the real public gadget.
+//!
+//! Every forgery goes through [`assert_rejected`], which requires it to
+//! emit the honest gate layout and then to be rejected by an unsatisfied
+//! constraint — so a rejection here can only come from the binding, never from
+//! a layout mismatch or an unrelated proving error.
+
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+use super::soundness_support::{
+    assert_rejected, assert_verifies, fits, truncate,
+};
+use super::*;
+use crate::prelude::{Compiler, Prover, PublicParameters, Verifier};
+
+// Inputs pinned to constants so they are identical for every prover. Both fit
+// in 32 bits, so for `BIT_PAIRS = 16` the result is exactly `input_a ^
+// input_b`.
+fn input_a() -> BlsScalar {
+    BlsScalar::from(0x0f0f_0ff0_u64)
+}
+fn input_b() -> BlsScalar {
+    BlsScalar::from(0xffff_0000_u64)
+}
+
+// An attacker's fork of [`Composer::append_logic_component`]: byte-identical
+// gate emission, except the `a`-bits are sourced from `forged` instead of
+// `self[a]`, so the returned witness is decoupled from the input witness `a`.
+// This models a malicious prover that emits the honest gate layout while
+// filling the per-quad accumulators with values unrelated to the inputs.
+//
+// It mirrors `append_logic_component` exactly so that, once that gadget binds
+// its accumulators to its inputs, this fork inherits the binding gates too and
+// the decoupled assignment becomes unsatisfiable.
+fn forge_logic_component<const BIT_PAIRS: usize>(
+    composer: &mut Composer,
+    a: Witness,
+    b: Witness,
+    forged: BlsScalar,
+    is_component_xor: bool,
+) -> Witness {
+    let (d, left_acc_wit, right_acc_wit) =
+        forge_logic_loop::<BIT_PAIRS>(composer, b, forged, is_component_xor);
+
+    // Mirror the honest gadget's binding. The binding wires the REAL `a`/`b` to
+    // the (forged) accumulators, so the forged assignment is now unsatisfiable.
+    composer.bind_logic_accumulators::<BIT_PAIRS>(
+        a,
+        b,
+        left_acc_wit,
+        right_acc_wit,
+    );
+
+    d
+}
+
+// The gate-emission loop shared by every fork: emits the identical logic gates
+// as `append_logic_component` but sources the `a`-bits from `forged`. Returns
+// the output witness and the final left/right accumulator witnesses (so callers
+// can attach the binding gates of their choice). Does NOT bind the inputs.
+fn forge_logic_loop<const BIT_PAIRS: usize>(
+    composer: &mut Composer,
+    b: Witness,
+    forged: BlsScalar,
+    is_component_xor: bool,
+) -> (Witness, Witness, Witness) {
+    let num_bits = cmp::min(BIT_PAIRS * 2, 254);
+    let num_quads = num_bits >> 1;
+
+    let bls_four = BlsScalar::from(4u64);
+    let mut left_acc = BlsScalar::zero();
+    let mut right_acc = BlsScalar::zero();
+    let mut out_acc = BlsScalar::zero();
+
+    // The ONLY deviation from `append_logic_component`: `a`-bits come from
+    // `forged`, not from `composer[a]`.
+    let a_bits: Vec<_> = BitIterator8::new(forged.to_bytes())
+        .skip(256 - num_bits)
+        .collect();
+    let b_bits: Vec<_> = BitIterator8::new(composer[b].to_bytes())
+        .skip(256 - num_bits)
+        .collect();
+
+    let mut constraint = if is_component_xor {
+        Constraint::logic_xor(&Constraint::new())
+    } else {
+        Constraint::logic(&Constraint::new())
+    };
+
+    for i in 0..num_quads {
+        let idx = i * 2;
+
+        let l = (a_bits[idx] as u8) << 1;
+        let r = a_bits[idx + 1] as u8;
+        let left_quad = l + r;
+        let left_quad_bls = BlsScalar::from(left_quad as u64);
+
+        let l = (b_bits[idx] as u8) << 1;
+        let r = b_bits[idx + 1] as u8;
+        let right_quad = l + r;
+        let right_quad_bls = BlsScalar::from(right_quad as u64);
+
+        let out_quad_bls = if is_component_xor {
+            left_quad ^ right_quad
+        } else {
+            left_quad & right_quad
+        } as u64;
+        let out_quad_bls = BlsScalar::from(out_quad_bls);
+
+        let prod_quad_bls = BlsScalar::from((left_quad * right_quad) as u64);
+
+        left_acc = left_acc * bls_four + left_quad_bls;
+        right_acc = right_acc * bls_four + right_quad_bls;
+        out_acc = out_acc * bls_four + out_quad_bls;
+
+        let wit_a = composer.append_witness(left_acc);
+        let wit_b = composer.append_witness(right_acc);
+        let wit_c = composer.append_witness(prod_quad_bls);
+        let wit_d = composer.append_witness(out_acc);
+
+        constraint = constraint.c(wit_c);
+        composer.append_custom_gate(constraint);
+        constraint = constraint.a(wit_a).b(wit_b).d(wit_d);
+    }
+
+    let left_acc_wit = constraint.witness(WiredWitness::A);
+    let right_acc_wit = constraint.witness(WiredWitness::B);
+    let d = constraint.witness(WiredWitness::D);
+    let constraint = Constraint::new().a(left_acc_wit).b(right_acc_wit).d(d);
+    composer.append_custom_gate(constraint);
+
+    (d, left_acc_wit, right_acc_wit)
+}
+
+// One circuit shape; `forged_a` selects the prover.
+//   None       -> honest gadget, result = input_a ^ input_b.
+//   Some(bits) -> cheating fork, result = bits ^ input_b (decoupled from `a`).
+#[derive(Default)]
+struct ForgeCircuit {
+    forged_a: Option<BlsScalar>,
+}
+
+impl Circuit for ForgeCircuit {
+    fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
+        const BIT_PAIRS: usize = 16; // operate on the low 32 bits
+
+        // Pin both inputs so they cannot differ between provers.
+        let a = composer.append_witness(input_a());
+        let b = composer.append_witness(input_b());
+        composer.assert_equal_constant(a, input_a(), None);
+        composer.assert_equal_constant(b, input_b(), None);
+
+        let result = match self.forged_a {
+            None => composer.append_logic_xor::<BIT_PAIRS>(a, b),
+            Some(bits) => {
+                forge_logic_component::<BIT_PAIRS>(composer, a, b, bits, true)
+            }
+        };
+
+        // Expose the result as a public input.
+        let claimed = self.forged_a.unwrap_or_else(input_a) ^ input_b();
+        let public = composer.append_public(claimed);
+        composer.assert_equal(result, public);
+
+        Ok(())
+    }
+}
+
+#[test]
+fn logic_xor_binds_output_to_inputs() {
+    let mut rng = StdRng::seed_from_u64(0x10_91c);
+    let pp =
+        PublicParameters::setup(1 << 12, &mut rng).expect("public parameters");
+
+    // Verifier key compiled from the HONEST gadget.
+    let (prover, verifier): (Prover, Verifier) =
+        Compiler::compile::<ForgeCircuit>(&pp, b"logic-gate-soundness")
+            .expect("compile");
+
+    let honest_result = input_a() ^ input_b();
+
+    // Control: the honest gadget computes the true XOR, and it verifies.
+    let honest = ForgeCircuit { forged_a: None };
+    assert_eq!(
+        assert_verifies(&prover, &verifier, &mut rng, &honest),
+        vec![honest_result],
+    );
+
+    // Forge: same gate layout, accumulators decoupled from the constrained `a`.
+    // Before the fix this proved and verified against the honest verifier key;
+    // the binding now makes the assignment unsatisfiable.
+    let forged_a = BlsScalar::from(0x1234_5678_u64);
+    assert_ne!(forged_a ^ input_b(), honest_result);
+    let forged = ForgeCircuit {
+        forged_a: Some(forged_a),
+    };
+
+    assert_rejected(
+        &prover,
+        &mut rng,
+        &honest,
+        &forged,
+        "decoupled accumulators",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Canonical-truncation regression (250-bit, the Poseidon width).
+//
+// Binding `input = high * 2^num_bits + acc` with `high` range-checked is not,
+// by itself, canonical: the field equation also admits `input + r`, i.e. an
+// attacker can pick `acc' = (input + r) mod 2^num_bits` with a matching small
+// `high'` that still fits the range check. `bind_truncation_split` closes that
+// with the `< r` guard. This forces exactly that alias assignment and requires
+// it to be rejected, pinning the guard at the logic gadget's width — the
+// `component_truncate` module covers the primitive itself.
+// ---------------------------------------------------------------------------
+
+// A small input, so the wrap's `high` stays inside the 5-bit range check.
+fn wrap_input() -> BlsScalar {
+    BlsScalar::from(7u64)
+}
+
+// `r mod 2^250` (the low part of the modulus).
+fn modulus_low_250() -> BlsScalar {
+    // `r - 1` has the same high bits as `r`; its low bit is 0, so
+    // `(r - 1) mod 2^250 = (r mod 2^250) - 1`.
+    truncate(-BlsScalar::one(), 250) + BlsScalar::one()
+}
+
+// The non-canonical truncation `acc' = (input + r) mod 2^250 != input`.
+fn wrap_acc() -> BlsScalar {
+    truncate(wrap_input() + modulus_low_250(), 250)
+}
+
+// The matching `high' = (input - acc') / 2^250`, which makes
+// `high' * 2^250 + acc' == input` in the field.
+fn wrap_high() -> BlsScalar {
+    let pow = BlsScalar::pow_of_2(250);
+    (wrap_input() - wrap_acc()) * pow.invert().expect("2^250 is invertible")
+}
+
+#[derive(Default)]
+struct WrapCircuit {
+    wrap: bool,
+}
+
+impl Circuit for WrapCircuit {
+    fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
+        const BIT_PAIRS: usize = 125; // 250-bit truncation
+        const NUM_BITS: usize = 250;
+        const HIGH_BITS: usize = 255 - NUM_BITS;
+
+        let a = composer.append_witness(wrap_input());
+        composer.assert_equal_constant(a, wrap_input(), None);
+
+        let result = if self.wrap {
+            // Forge the loop with the wrap accumulator, then attach the SAME
+            // binding gates as the honest gadget, but force `high` to the wrap
+            // value `high'` (the honest gadget would derive `high = 0` from
+            // `a`).
+            let (d, left_acc_wit, right_acc_wit) = forge_logic_loop::<BIT_PAIRS>(
+                composer,
+                Composer::ZERO,
+                wrap_acc(),
+                true,
+            );
+
+            let high = composer.append_witness(wrap_high());
+            composer.range_check(high, HIGH_BITS);
+            let pow = BlsScalar::pow_of_2(NUM_BITS as u64);
+            let recomposed = composer.gate_add(
+                Constraint::new().left(pow).right(1).a(high).b(left_acc_wit),
+            );
+            composer.assert_equal(recomposed, a);
+
+            // Emit the canonical `< r` guard on the forged split too, so this
+            // branch reproduces the honest gadget's exact gate layout (and so
+            // its verifier key). The wrap accumulator recomposes to the integer
+            // `input + r`, i.e. a value `>= r`, which is precisely what the
+            // guard rejects: `(high', acc')` exceeds `(r_high, r_low)`
+            // lexicographically, so one of the guard's range checks underflows
+            // and the assignment is unsatisfiable. The rejection is therefore
+            // the guard constraint firing — not a circuit-size mismatch — which
+            // is what pins the guard's soundness at the logic-gadget width.
+            composer.assert_canonical_truncation(high, left_acc_wit, NUM_BITS);
+
+            // `b = 0` is bound honestly.
+            composer.bind_truncated_input::<BIT_PAIRS>(
+                Composer::ZERO,
+                right_acc_wit,
+            );
+
+            d
+        } else {
+            composer.append_logic_xor::<BIT_PAIRS>(a, Composer::ZERO)
+        };
+
+        let claimed = if self.wrap {
+            wrap_acc()
+        } else {
+            truncate(wrap_input(), 250)
+        };
+        let public = composer.append_public(claimed);
+        composer.assert_equal(result, public);
+
+        Ok(())
+    }
+}
+
+#[test]
+fn logic_xor_truncation_is_canonical() {
+    // Sanity on the wrap construction. It has to be a genuine forgery that
+    // clears every constraint except the canonical guard, so that the guard is
+    // the only thing that can reject it.
+    let honest_low = truncate(wrap_input(), 250);
+    assert_ne!(
+        wrap_acc(),
+        honest_low,
+        "wrap accumulator must differ from honest"
+    );
+    assert!(
+        fits(wrap_acc(), 250),
+        "acc' must be < 2^250, the bound the logic gate imposes on it",
+    );
+    assert!(
+        fits(wrap_high(), 5),
+        "high' must clear the 5-bit range check"
+    );
+    assert_eq!(
+        wrap_high() * BlsScalar::pow_of_2(250) + wrap_acc(),
+        wrap_input(),
+        "the wrap split must recompose to the input in-field",
+    );
+
+    let mut rng = StdRng::seed_from_u64(0x10_91d);
+    let pp =
+        PublicParameters::setup(1 << 12, &mut rng).expect("public parameters");
+    let (prover, verifier): (Prover, Verifier) =
+        Compiler::compile::<WrapCircuit>(&pp, b"logic-gate-wrap")
+            .expect("compile");
+
+    // Control: honest prover verifies.
+    let honest = WrapCircuit { wrap: false };
+    assert_eq!(
+        assert_verifies(&prover, &verifier, &mut rng, &honest),
+        vec![honest_low],
+    );
+
+    // The `+ r` alias must not yield a verifying proof. It clears both range
+    // checks and the linear binding, so the canonical guard is the only
+    // constraint left to reject it.
+    assert_rejected(
+        &prover,
+        &mut rng,
+        &honest,
+        &WrapCircuit { wrap: true },
+        "non-canonical (+r) truncation",
+    );
+}
+
+// Pins the *production* binding structurally, without a proving round-trip: it
+// fails the moment the real gadget stops wiring its inputs into a gate. The
+// forge tests above catch the same regression — they attach their own copy of
+// `bind_logic_accumulators`, so dropping the production call makes the honest
+// circuit shrink and `assert_rejected`'s layout comparison fire — but this one
+// says so directly and in a fraction of the time.
+#[test]
+fn append_logic_xor_wires_its_inputs() {
+    const BIT_PAIRS: usize = 125; // 250-bit truncation, the Poseidon width
+
+    let mut composer = Composer::initialized();
+    let a = composer.append_witness(BlsScalar::from(0x0f0f_0ff0_u64));
+    let b = composer.append_witness(BlsScalar::from(0xffff_0000_u64));
+
+    let _ = composer.append_logic_xor::<BIT_PAIRS>(a, b);
+
+    let mut a_wired = false;
+    let mut b_wired = false;
+    for gate in &composer.constraints {
+        for wire in [gate.a, gate.b, gate.c, gate.d] {
+            a_wired |= wire.index() == a.index();
+            b_wired |= wire.index() == b.index();
+        }
+    }
+
+    assert!(
+        a_wired,
+        "append_logic_xor must wire input `a` into a gate (output binding)",
+    );
+    assert!(
+        b_wired,
+        "append_logic_xor must wire input `b` into a gate (output binding)",
+    );
+}

--- a/src/composer/range_soundness_tests.rs
+++ b/src/composer/range_soundness_tests.rs
@@ -1,0 +1,183 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! Regressions for the base-4 range check and its two public entry points.
+//!
+//! `range_check` is the shared core every truncation binding leans on for its
+//! `low`/`high` bounds, so its exact admitted interval is a soundness
+//! parameter, not an implementation detail. `component_range` (deprecated,
+//! bit-pair-counted) and `component_range_bits` (bit-counted) now both delegate
+//! to that core, and the deprecation note promises callers the migration
+//! between them leaves every verifier key untouched.
+//!
+//! These tests pin all three: the interval `range_check` admits, the equality
+//! of the two entry points, and — against a golden captured before the
+//! delegation existed — that the shared core still emits the layout the
+//! deployed keys were generated against.
+
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+use super::soundness_support::{assert_rejected, assert_verifies, gate_digest};
+use super::*;
+use crate::prelude::{Compiler, Prover, PublicParameters, Verifier};
+
+// A bare range check, used to pin `range_check`'s bounds directly.
+struct RangeCircuit<const NUM_BITS: usize> {
+    value: BlsScalar,
+}
+
+impl<const NUM_BITS: usize> Default for RangeCircuit<NUM_BITS> {
+    fn default() -> Self {
+        Self {
+            value: BlsScalar::zero(),
+        }
+    }
+}
+
+impl<const NUM_BITS: usize> Circuit for RangeCircuit<NUM_BITS> {
+    fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
+        let value = composer.append_witness(self.value);
+        composer.range_check(value, NUM_BITS);
+        Ok(())
+    }
+}
+
+// `range_check` admits exactly `[0, 2^NUM_BITS)`: `2^NUM_BITS - 1` proves,
+// `2^NUM_BITS` does not.
+fn assert_range_check_bounds<const NUM_BITS: usize>(
+    pp: &PublicParameters,
+    rng: &mut StdRng,
+) {
+    let (prover, verifier): (Prover, Verifier) =
+        Compiler::compile::<RangeCircuit<NUM_BITS>>(pp, b"range")
+            .expect("compile");
+
+    let in_range = RangeCircuit::<NUM_BITS> {
+        value: BlsScalar::pow_of_2(NUM_BITS as u64) - BlsScalar::one(),
+    };
+    assert_verifies(&prover, &verifier, rng, &in_range);
+
+    let out_of_range = RangeCircuit::<NUM_BITS> {
+        value: BlsScalar::pow_of_2(NUM_BITS as u64),
+    };
+    assert_rejected(
+        &prover,
+        rng,
+        &in_range,
+        &out_of_range,
+        "2^NUM_BITS is out of range",
+    );
+}
+
+#[test]
+fn range_check_enforces_exact_bounds() {
+    let mut rng = StdRng::seed_from_u64(0x4a_06e);
+    let pp = PublicParameters::setup(1 << 8, &mut rng).expect("setup");
+
+    assert_range_check_bounds::<6>(&pp, &mut rng); // even
+    assert_range_check_bounds::<7>(&pp, &mut rng); // odd
+    assert_range_check_bounds::<1>(&pp, &mut rng); // odd, minimal
+}
+
+// The deprecated `component_range::<BIT_PAIRS>` and its replacement
+// `component_range_bits::<2 * BIT_PAIRS>` must emit a byte-identical gate
+// sequence (selectors AND wiring, not just gate count) — both delegate to the
+// shared base-4 core, and this is the contract the deprecation note promises
+// callers: migrating `::<N>` (bit-pairs) to `::<2 * N>` (bits) does not change
+// any verifier key. `Gate` is `PartialEq`, so the whole constraint vector is
+// compared, across widths including the deployed 64-bit phoenix caller
+// (`BIT_PAIRS = 32`) and the 256-bit cap.
+//
+// This is the one test that exercises the deprecated `component_range`; the
+// `#[allow(deprecated)]` is intentional — it is a regression guard for a
+// still-public, still-supported gadget, not a use to be migrated away.
+#[allow(deprecated)]
+#[test]
+fn component_range_migration_is_gate_identical() {
+    let value = -BlsScalar::one(); // every bit set, so all quads are exercised
+
+    macro_rules! assert_layout_eq {
+        ($bit_pairs:literal) => {{
+            let mut bit_pairs = Composer::initialized();
+            let w = bit_pairs.append_witness(value);
+            bit_pairs.component_range::<$bit_pairs>(w);
+
+            let mut bits = Composer::initialized();
+            let w = bits.append_witness(value);
+            bits.component_range_bits::<{ $bit_pairs * 2 }>(w);
+
+            assert_eq!(
+                bit_pairs.constraints,
+                bits.constraints,
+                "component_range::<{}> must match component_range_bits::<{}>",
+                $bit_pairs,
+                $bit_pairs * 2,
+            );
+        }};
+    }
+
+    assert_layout_eq!(0); // 0 bits, the N=254 high part (degenerate branch)
+    assert_layout_eq!(1); // 2 bits
+    assert_layout_eq!(2); // 4 bits, the N=250 high part
+    assert_layout_eq!(4); // 8 bits, one full gate
+    assert_layout_eq!(16); // 32 bits
+    assert_layout_eq!(32); // 64 bits, the deployed phoenix money-range caller
+    assert_layout_eq!(125); // 250 bits, the Schnorr width
+    assert_layout_eq!(127); // 254 bits, the cap
+    assert_layout_eq!(128); // 256 bits, component_range's max (capped width)
+}
+
+// `component_range_migration_is_gate_identical` compares `component_range`
+// against `component_range_bits`, but both now delegate to the shared
+// `range_check_even` core — so it only proves the two entry points agree, not
+// that the shared core still emits the gate layout the deployed verifier keys
+// were generated against. A drift in the core would change both identically and
+// slip through. This pins `component_range` to a `gate_digest` golden captured
+// from `component_range` as released in `v0.22.1` (`f63cfb0`), before it
+// delegated — the only non-circular reference. `BIT_PAIRS = 32` is the deployed
+// phoenix money-range caller (`component_range::<32>` = 2^64); if this digest
+// changes, that circuit's verifier key changed.
+#[allow(deprecated)]
+#[test]
+fn component_range_layout_matches_deployed_golden() {
+    // `gate_digest`s captured from `component_range::<BIT_PAIRS>(-1)` as
+    // released in `v0.22.1` (`f63cfb0`), the pre-delegation implementation.
+    const GOLDEN_16: [u8; 32] = [
+        77, 31, 113, 140, 168, 100, 230, 119, 141, 149, 133, 230, 149, 247,
+        247, 146, 198, 131, 151, 72, 86, 226, 37, 227, 151, 105, 226, 40, 34,
+        107, 152, 55,
+    ];
+    const GOLDEN_32: [u8; 32] = [
+        211, 119, 147, 191, 124, 192, 26, 156, 231, 67, 118, 215, 252, 91, 144,
+        70, 167, 7, 86, 187, 217, 252, 99, 197, 167, 153, 185, 163, 50, 167, 5,
+        33,
+    ];
+    const GOLDEN_128: [u8; 32] = [
+        61, 254, 139, 94, 245, 111, 49, 233, 147, 232, 116, 107, 73, 148, 236,
+        197, 128, 124, 52, 202, 152, 56, 66, 82, 119, 96, 65, 141, 195, 208,
+        155, 98,
+    ];
+
+    macro_rules! assert_golden_eq {
+        ($bit_pairs:literal, $expected:expr) => {{
+            let mut composer = Composer::initialized();
+            let witness = composer.append_witness(-BlsScalar::one());
+            composer.component_range::<$bit_pairs>(witness);
+            assert_eq!(
+                gate_digest(&composer.constraints),
+                $expected,
+                "component_range::<{}> gate layout drifted from the deployed \
+                 verifier key",
+                $bit_pairs,
+            );
+        }};
+    }
+
+    assert_golden_eq!(16, GOLDEN_16);
+    assert_golden_eq!(32, GOLDEN_32); // deployed phoenix 2^64 money range
+    assert_golden_eq!(128, GOLDEN_128); // capped width
+}

--- a/src/composer/soundness_support.rs
+++ b/src/composer/soundness_support.rs
@@ -1,0 +1,169 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! Shared scaffolding for the in-crate soundness regressions.
+//!
+//! Those tests all follow the same shape: compile a verifier key from an honest
+//! gadget, then prove against it with a fork of that gadget filled with forged
+//! witnesses. For such a test to have any teeth, two things have to hold, and
+//! both are easy to get silently wrong:
+//!
+//! - the forgery must emit **exactly** the compiled gate layout, otherwise the
+//!   prover rejects it on a circuit-size mismatch and the test passes without
+//!   ever reaching the constraint it claims to exercise;
+//! - the rejection must come from an **unsatisfied constraint** specifically,
+//!   not from any error the prover happens to return.
+//!
+//! [`gate_layout`] and [`assert_rejected`] pin those down; see
+//! [`UNSATISFIED`] for what the second one can and cannot tell apart on its
+//! own.
+
+use rand::rngs::StdRng;
+
+use super::*;
+use crate::prelude::{Prover, Verifier};
+
+/// `2^num_bits` as a field element.
+pub(super) fn pow(num_bits: usize) -> BlsScalar {
+    BlsScalar::pow_of_2(num_bits as u64)
+}
+
+/// Truncation of `x` to its low `num_bits` bits, as a field element.
+pub(super) fn truncate(x: BlsScalar, num_bits: usize) -> BlsScalar {
+    recompose_bits(&x.to_bits(), 0, num_bits)
+}
+
+/// Whether `x` lies in `[0, 2^num_bits)`, i.e. whether it would clear a
+/// `range_check` of that width. Used to pin down *which* constraint rejects a
+/// forgery: one meant to be caught by the canonical guard must clear every
+/// range check first.
+pub(super) fn fits(x: BlsScalar, num_bits: usize) -> bool {
+    truncate(x, num_bits) == x
+}
+
+/// The gate layout (selectors AND wiring) a circuit emits. [`Gate`] is
+/// `PartialEq`, so comparing these vectors compares the whole constraint
+/// system, which is what the compiled verifier key is derived from.
+pub(super) fn gate_layout<C: Circuit>(circuit: &C) -> Vec<Gate> {
+    let mut composer = Composer::initialized();
+    circuit.circuit(&mut composer).expect("circuit builds");
+    composer.constraints
+}
+
+/// Fold a gate vector (selectors AND wiring) into a single field element: a
+/// deterministic, platform-independent fingerprint of the full gate layout.
+/// Field arithmetic is exact, so the digest is reproducible across machines and
+/// builds; any change to a selector or a wire index changes it. This is a
+/// layout fingerprint, not a cryptographic hash — collisions are irrelevant
+/// because the inputs are not adversarial, only accidentally-drifting layouts.
+///
+/// `Gate` is destructured exhaustively on purpose: the golden test leans on the
+/// converse of the digest's contract — an unchanged digest meaning an unchanged
+/// verifier key — which only holds while every field is folded in. A field
+/// added to `Gate` must fail to compile here, not silently drop out.
+pub(super) fn gate_digest(gates: &[Gate]) -> [u8; 32] {
+    let mult = BlsScalar::from(1_000_003u64);
+    let mut acc = BlsScalar::zero();
+    for gate in gates {
+        let Gate {
+            q_m,
+            q_l,
+            q_r,
+            q_o,
+            q_f,
+            q_c,
+            q_arith,
+            q_range,
+            q_logic,
+            q_fixed_group_add,
+            q_variable_group_add,
+            a,
+            b,
+            c,
+            d,
+        } = gate;
+
+        for selector in [
+            q_m,
+            q_l,
+            q_r,
+            q_o,
+            q_f,
+            q_c,
+            q_arith,
+            q_range,
+            q_logic,
+            q_fixed_group_add,
+            q_variable_group_add,
+        ] {
+            acc = acc * mult + selector;
+        }
+        for wire in [a, b, c, d] {
+            acc = acc * mult + BlsScalar::from(wire.index() as u64);
+        }
+    }
+    acc.to_bytes()
+}
+
+/// The proving error an unsatisfied assignment surfaces as. The chain: the
+/// assignment does not satisfy the constraint system, so the quotient
+/// polynomial is not divisible by the vanishing polynomial, so a split chunk
+/// of it exceeds the commit key's maximum degree.
+///
+/// The variant is not exclusive to that chain — it is raised by
+/// `CommitKey::check_commit_degree_is_within_bounds`, which an undersized
+/// public parameter setup would also trip. What rules that out here is the
+/// control proof: it succeeds against the same commit key on an identical gate
+/// layout, so the only thing left that can differ is satisfiability.
+const UNSATISFIED: Error = Error::PolynomialDegreeTooLarge;
+
+/// Prove `honest` and verify the resulting proof, returning its public inputs.
+pub(super) fn assert_verifies<C: Circuit>(
+    prover: &Prover,
+    verifier: &Verifier,
+    rng: &mut StdRng,
+    honest: &C,
+) -> Vec<BlsScalar> {
+    let (proof, public_inputs) =
+        prover.prove(rng, honest).expect("honest prove");
+    verifier
+        .verify(&proof, &public_inputs)
+        .expect("honest proof must verify");
+
+    public_inputs
+}
+
+/// Require `rejected` to emit the same gate layout as `accepted` and then to be
+/// turned away at proving by an unsatisfied constraint.
+///
+/// Both halves matter. Without the layout check, dropping a constraint from the
+/// production gadget would leave the rejected circuit emitting a gate the
+/// accepted one no longer does, and the resulting `InvalidCircuitSize` would
+/// read as a successful rejection. Without the error check, any unrelated
+/// proving failure would do the same.
+pub(super) fn assert_rejected<C: Circuit>(
+    prover: &Prover,
+    rng: &mut StdRng,
+    accepted: &C,
+    rejected: &C,
+    case: &str,
+) {
+    assert_eq!(
+        gate_layout(rejected),
+        gate_layout(accepted),
+        "{case}: must emit the same gate layout as the accepted circuit, else \
+         its rejection says nothing about the constraint under test",
+    );
+
+    match prover.prove(rng, rejected) {
+        Ok(_) => panic!("{case}: produced a proof"),
+        Err(error) if error == UNSATISFIED => {}
+        Err(other) => panic!(
+            "{case}: rejected by `{other:?}`, not by an unsatisfied \
+             constraint — it is not exercising the constraint under test",
+        ),
+    }
+}

--- a/src/composer/truncate_soundness_tests.rs
+++ b/src/composer/truncate_soundness_tests.rs
@@ -1,0 +1,282 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! Soundness regression for `component_truncate`'s input binding.
+//!
+//! `component_truncate` is the purpose-built primitive for deriving a truncated
+//! value, in place of `append_logic_xor::<N>(x, ZERO)`. The motivating concern:
+//! a truncation gadget must bind its output to its input, and this test pins
+//! that binding down directly. `component_truncate` binds `low` to `witness`
+//! through the relation `witness = high * 2^num_bits + low` plus a canonical
+//! `< r` guard, so a prover cannot satisfy the gate layout (and so the verifier
+//! key) with a `low` decoupled from `witness`.
+//!
+//! Exhibiting a decoupling attempt means emitting `component_truncate`'s exact
+//! gate layout with attacker-chosen `low`/`high` witnesses — which uses
+//! crate-private composer internals, hence this test lives in-crate. Each case
+//! is a full `compile -> prove` round-trip against the verifier key compiled
+//! from the honest gadget: the control proves and verifies, every forgery is
+//! rejected at proving because the binding makes its assignment unsatisfiable.
+//!
+//! For a forgery's rejection to mean anything, it has to come from the
+//! constraint under test and nothing else. Two properties pin that down. First,
+//! the circuit's input and output are **public inputs**, not baked-in
+//! constants, so the emitted gate layout is independent of the values a case
+//! proves with; every case then explicitly asserts its layout is identical to
+//! the honest one, which fails the moment the production gadget stops emitting
+//! a constraint the forgery fork emits. Second, rejection is matched against
+//! the error an unsatisfiable assignment surfaces as — an `InvalidCircuitSize`,
+//! or any other proving error, fails the test rather than passing it.
+//!
+//! The binding is exercised at `N = 250` (the truncated-Poseidon
+//! Schnorr-challenge width), at `N = 254` (the compile-time cap and tightest
+//! canonical-guard margin — the only width where `r_high = 1`), and at an odd
+//! `N = 251` to cover the odd-width range-check path.
+
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+use super::soundness_support::{
+    assert_rejected, assert_verifies, fits, pow, truncate,
+};
+use super::*;
+use crate::prelude::{Compiler, Prover, PublicParameters, Verifier};
+
+// An attacker's fork of [`Composer::component_truncate`]: byte-identical gate
+// emission, except the returned `low` (and the paired `high`) are sourced from
+// attacker-chosen values rather than derived from `witness`. Models a malicious
+// prover emitting the honest gate layout while filling the witnesses with
+// values that decouple the output from the input. Because the gadget binds
+// `low`/`high` to `witness`, any such decoupled assignment is unsatisfiable.
+fn forge_truncate<const N: usize>(
+    composer: &mut Composer,
+    witness: Witness,
+    forged_low: BlsScalar,
+    forged_high: BlsScalar,
+) -> Witness {
+    let high_bits = 255 - N;
+
+    let low = composer.append_witness(forged_low);
+    composer.range_check(low, N);
+
+    let high = composer.append_witness(forged_high);
+    composer.range_check(high, high_bits);
+
+    let recomposed = composer
+        .gate_add(Constraint::new().left(pow(N)).right(1).a(high).b(low));
+    composer.assert_equal(recomposed, witness);
+
+    composer.assert_canonical_truncation(high, low, N);
+
+    low
+}
+
+// Either the honest gadget or, when `forge` is set, the layout-identical fork
+// above.
+//
+// Both the input and the truncation output are exposed as public inputs, so the
+// statement a proof makes is the full pair `(input, low)` — a forgery has to
+// carry a `low` that is not the truncation of the `input` it declares. Pinning
+// the input as a public input rather than as a circuit constant is what keeps
+// the emitted gate layout independent of the values: `assert_equal_constant`
+// would bake the input into a `q_c` selector, so a case proving with a
+// different input than the one compiled would be rejected by that selector
+// alone, masking whether the constraint under test fired at all.
+struct TruncCircuit<const N: usize> {
+    input: BlsScalar,
+    claimed_low: BlsScalar,
+    forge: Option<(BlsScalar, BlsScalar)>,
+}
+
+impl<const N: usize> Default for TruncCircuit<N> {
+    // The default values are arbitrary: gate emission is witness-independent,
+    // so the compiled circuit description keys off `N` alone. A full-width,
+    // near-modulus value is chosen only to make the intent legible.
+    fn default() -> Self {
+        let input = -BlsScalar::one();
+        Self {
+            input,
+            claimed_low: truncate(input, N),
+            forge: None,
+        }
+    }
+}
+
+impl<const N: usize> Circuit for TruncCircuit<N> {
+    fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
+        let witness = composer.append_public(self.input);
+
+        let low = match self.forge {
+            None => composer.component_truncate::<N>(witness),
+            Some((forged_low, forged_high)) => {
+                forge_truncate::<N>(composer, witness, forged_low, forged_high)
+            }
+        };
+
+        let pi = composer.append_public(self.claimed_low);
+        composer.assert_equal(low, pi);
+
+        Ok(())
+    }
+}
+
+// Compile a verifier key from the HONEST gadget at `N`, then confirm
+// the control proves and verifies while two distinct decoupling forgeries —
+// emitting the identical gate layout — are rejected at proving.
+fn assert_binding_holds<const N: usize>(
+    pp: &PublicParameters,
+    rng: &mut StdRng,
+) {
+    let num_bits = N;
+    let high_bits = 255 - N;
+    let label = b"component-truncate-soundness";
+
+    let (prover, verifier): (Prover, Verifier) =
+        Compiler::compile::<TruncCircuit<N>>(pp, label).expect("compile");
+
+    // --- CONTROL: honest prover, honest public input, proves and verifies.
+    // A wide, near-modulus input, so this also pins that honest inputs far
+    // above the truncation width are still accepted. ---
+    let input = -BlsScalar::one();
+    let honest = TruncCircuit::<N> {
+        input,
+        claimed_low: truncate(input, num_bits),
+        forge: None,
+    };
+    let honest_low = honest.claimed_low;
+    assert_eq!(
+        assert_verifies(&prover, &verifier, rng, &honest),
+        vec![input, honest_low],
+        "honest public inputs == (input, truncate(input))"
+    );
+
+    // --- FORGERY A: decoupled `low`, `high` chosen to satisfy the linear
+    // binding in-field. The `low` range check passes, but `high` is then a
+    // full-width field element and fails its range check. ---
+    let forged_low = BlsScalar::from(0x00C0_FFEE_u64);
+    assert_ne!(forged_low, honest_low, "forged low must differ from honest");
+    assert!(
+        fits(forged_low, num_bits),
+        "forged low must clear its range check",
+    );
+    let pow_inverse = pow(num_bits).invert().expect("2^num_bits is invertible");
+    let matching_high = (input - forged_low) * pow_inverse;
+    assert!(
+        !fits(matching_high, high_bits),
+        "FORGERY A is the out-of-range-high case; its high must not fit",
+    );
+    let forgery_a = TruncCircuit::<N> {
+        input,
+        claimed_low: forged_low,
+        forge: Some((forged_low, matching_high)),
+    };
+    assert_rejected(&prover, rng, &honest, &forgery_a, "FORGERY A");
+
+    // --- FORGERY B: the canonical alias. The non-canonical split of
+    // `input + r` clears BOTH range checks and the linear binding (it
+    // recomposes to `input` in the field), yet represents a value >= r. It
+    // splits at exactly `high == r_high`, so it is the guard's *low* half —
+    // `is_top * (r_low - low)` — that rejects it; FORGERY C below covers the
+    // high half.
+    //
+    // The alias only exists for a small input: `input + r` must still split
+    // into a high part that fits `high_bits`, which rules out the control's
+    // near-modulus value. The input is a public input, so using a different one
+    // here does not change the gate layout — asserted below. ---
+    let aliased_input = BlsScalar::one();
+    let aliased_honest_low = truncate(aliased_input, num_bits); // == 1
+    let modulus_bits = (-BlsScalar::one()).to_bits();
+    let r_low = recompose_bits(&modulus_bits, 0, num_bits);
+    let r_high = recompose_bits(&modulus_bits, num_bits, 256);
+    // `modulus_bits` are the bits of `r - 1`, so `1 + r` splits as
+    // `r_high * 2^num_bits + (r_low + 2)`, with no carry into the high part.
+    let alias_low = r_low + BlsScalar::from(2u64);
+    let alias_high = r_high;
+    // The split must recompose to the input in-field (so it clears the linear
+    // binding) yet differ from the honest low (so it is a genuine forgery).
+    assert_eq!(
+        alias_high * pow(num_bits) + alias_low,
+        aliased_input,
+        "alias must recompose to the input in-field"
+    );
+    assert_ne!(
+        alias_low, aliased_honest_low,
+        "aliased low must differ from honest"
+    );
+    // Both range checks must pass, so the canonical guard is the only remaining
+    // reason the assignment can be rejected.
+    assert!(
+        fits(alias_low, num_bits),
+        "aliased low must clear its range check",
+    );
+    assert!(
+        fits(alias_high, high_bits),
+        "aliased high must clear its range check",
+    );
+    let forgery_b = TruncCircuit::<N> {
+        input: aliased_input,
+        claimed_low: alias_low,
+        forge: Some((alias_low, alias_high)),
+    };
+    assert_rejected(&prover, rng, &honest, &forgery_b, "FORGERY B");
+
+    // --- FORGERY C: the same `+ r` alias, taken on the high side. Every case
+    // above splits at `high <= r_high`, so none of them reaches the guard's
+    // `range_check(diff, high_bits)` on `diff = r_high - high` — the one
+    // constraint that keeps `high` from climbing past `r_high` into the rest of
+    // its range check's interval.
+    //
+    // With `input = 2^num_bits` the split `(r_high + 1, r_low + 1)` recomposes
+    // to `r + 2^num_bits == input` in the field, clears both range checks, and
+    // leaves `diff` non-zero — so `is_top` is 0, the guard's low half is
+    // vacuously 0, and only the `diff` range check underflows. ---
+    let high_alias_high = r_high + BlsScalar::one();
+
+    // At `N = 254`, `r_high` is 1 against a 1-bit check, so `r_high + 1` is
+    // already out of range and `range_check(high, high_bits)` rejects the split
+    // before the guard sees it. There is no reachable high-side alias to forge
+    // at that width; the case applies at every other one.
+    if fits(high_alias_high, high_bits) {
+        let high_input = pow(num_bits);
+        let high_alias_low = r_low + BlsScalar::one();
+        assert_eq!(
+            high_alias_high * pow(num_bits) + high_alias_low,
+            high_input,
+            "high-side alias must recompose to the input in-field"
+        );
+        assert_ne!(
+            high_alias_low,
+            truncate(high_input, num_bits), // == 0
+            "high-side aliased low must differ from honest"
+        );
+        assert!(
+            fits(high_alias_low, num_bits),
+            "high-side aliased low must clear its range check",
+        );
+        let forgery_c = TruncCircuit::<N> {
+            input: high_input,
+            claimed_low: high_alias_low,
+            forge: Some((high_alias_low, high_alias_high)),
+        };
+        assert_rejected(&prover, rng, &honest, &forgery_c, "FORGERY C");
+    }
+}
+
+#[test]
+fn truncation_output_is_bound_to_its_input() {
+    let mut rng = StdRng::seed_from_u64(0x7_2c47e);
+    let pp = PublicParameters::setup(1 << 10, &mut rng).expect("setup");
+
+    // 250 bits: the truncated-Poseidon Schnorr-challenge width.
+    assert_binding_holds::<250>(&pp, &mut rng);
+
+    // 254 bits: the compile-time cap and tightest canonical-guard margin, the
+    // only width where `r_high = 1`.
+    assert_binding_holds::<254>(&pp, &mut rng);
+
+    // 251 bits: an odd width, exercising the odd-width range-check path.
+    assert_binding_holds::<251>(&pp, &mut rng);
+}

--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -384,9 +384,9 @@ pub(crate) mod alloc {
 
             // Evaluations to compute [E]_1
             //
-            // IMPORTANT: Ordering must match the prover's batched opening at `z`
-            // (`CommitKey::compute_aggregate_witness([...])`) and the verifier's
-            // commitment list below.
+            // IMPORTANT: Ordering must match the prover's batched opening at
+            // `z` (`CommitKey::compute_aggregate_witness([...])`)
+            // and the verifier's commitment list below.
             let E_evals = [
                 // Unshifted openings at z
                 self.evaluations.a_eval,

--- a/tests/composer.rs
+++ b/tests/composer.rs
@@ -61,7 +61,7 @@ fn circuit_with_all_gates() {
             composer.gate_add(Constraint::new().left(1).right(1).a(w_a).b(w_b));
 
             composer.component_add_point(w_z, w_z);
-            composer.append_logic_and::<128>(w_a, w_b);
+            composer.append_logic_and::<127>(w_a, w_b);
             composer.component_boolean(Composer::ONE);
             composer.component_decomposition::<254>(w_a);
             composer.component_mul_generator(
@@ -69,13 +69,13 @@ fn circuit_with_all_gates() {
                 dusk_jubjub::GENERATOR_EXTENDED,
             )?;
             composer.component_mul_point(w_y, w_z);
-            composer.component_range::<128>(w_a);
+            composer.component_range_bits::<256>(w_a);
             composer.component_select(Composer::ONE, w_a, w_b);
             composer.component_select_identity(Composer::ONE, w_z);
             composer.component_select_one(Composer::ONE, w_a);
             composer.component_select_point(Composer::ONE, w_z, w_z);
             composer.component_select_zero(Composer::ONE, w_a);
-            composer.append_logic_xor::<128>(w_a, w_b);
+            composer.append_logic_xor::<127>(w_a, w_b);
 
             Ok(())
         }

--- a/tests/logic.rs
+++ b/tests/logic.rs
@@ -25,15 +25,12 @@ fn append_logic_and() {
 
     impl<const BIT_PAIRS: usize> TestCircuit<BIT_PAIRS> {
         pub fn new(a: BlsScalar, b: BlsScalar) -> Self {
-            let bits = cmp::min(BIT_PAIRS * 2, 256);
+            // the op width is capped at 254 bits, so the mask never overflows
+            // the 255-bit BlsScalar
+            let bits = cmp::min(BIT_PAIRS * 2, 254);
             let bit_mask = BlsScalar::pow_of_2(bits as u64) - BlsScalar::one();
 
-            // BlsScalar are max 255 bits long which means that a bit_mask with
-            // more than 255 bits will be overflowing and therefore incorrect
-            let result = match bits <= 255 {
-                true => a & b & bit_mask,
-                false => a & b,
-            };
+            let result = a & b & bit_mask;
 
             Self { a, b, result }
         }
@@ -58,7 +55,7 @@ fn append_logic_and() {
     // default circuit
     let label = b"append_logic_and";
     let mut rng = StdRng::seed_from_u64(0x1ead);
-    let capacity = 1 << 8;
+    let capacity = 1 << 12;
     let pp = PublicParameters::setup(capacity, &mut rng)
         .expect("Creation of public parameter shouldn't fail");
     let (prover, verifier) = Compiler::compile::<TestCircuit<0>>(&pp, label)
@@ -137,44 +134,45 @@ fn append_logic_and() {
         &"Sanity check should pass",
     );
 
-    // Test with bits = 256
+    // Test with bits = 254 (the maximum width, BIT_PAIRS = 127)
     //
     // Create new circuit description for the prover and verifier
-    const BIT_PAIRS_128: usize = 128;
+    const BIT_PAIRS_127: usize = 127;
+    let bit_mask = BlsScalar::pow_of_2(254) - BlsScalar::one();
     let (prover, verifier) =
-        Compiler::compile::<TestCircuit<BIT_PAIRS_128>>(&pp, label)
+        Compiler::compile::<TestCircuit<BIT_PAIRS_127>>(&pp, label)
             .expect("Circuit should compile");
 
     // Test sanity:
     let a = -BlsScalar::one();
     let b = -BlsScalar::one();
-    let result = -BlsScalar::one();
-    let circuit: TestCircuit<BIT_PAIRS_128> = TestCircuit { a, b, result };
+    let result = a & b & bit_mask;
+    let circuit: TestCircuit<BIT_PAIRS_127> = TestCircuit { a, b, result };
     check_satisfied_circuit(&prover, &verifier, &pi, &circuit, &mut rng, &msg);
 
     // Test random works:
     let msg = "Circuit verification with random values should pass";
     let a = BlsScalar::random(&mut rng);
     let b = BlsScalar::random(&mut rng);
-    let circuit: TestCircuit<BIT_PAIRS_128> = TestCircuit::new(a, b);
+    let circuit: TestCircuit<BIT_PAIRS_127> = TestCircuit::new(a, b);
     check_satisfied_circuit(&prover, &verifier, &pi, &circuit, &mut rng, &msg);
 
     // Test invalid circuit fails
     let msg = "Proof creation of unsatisfied circuit should fail";
     let a = BlsScalar::random(&mut rng);
     let b = BlsScalar::random(&mut rng);
-    let right_result = a & b;
+    let right_result = a & b & bit_mask;
     let c = BlsScalar::random(&mut rng);
-    let wrong_result = a & c;
+    let wrong_result = a & c & bit_mask;
     assert_ne!(right_result, wrong_result);
-    let circuit: TestCircuit<BIT_PAIRS_128> = TestCircuit {
+    let circuit: TestCircuit<BIT_PAIRS_127> = TestCircuit {
         a,
         b,
         result: wrong_result,
     };
     check_unsatisfied_circuit(&prover, &circuit, &mut rng, &msg);
     // sanity check
-    let circuit_satisfied: TestCircuit<BIT_PAIRS_128> = TestCircuit {
+    let circuit_satisfied: TestCircuit<BIT_PAIRS_127> = TestCircuit {
         a,
         b,
         result: right_result,
@@ -200,15 +198,12 @@ fn append_logic_xor() {
 
     impl<const BIT_PAIRS: usize> TestCircuit<BIT_PAIRS> {
         pub fn new(a: BlsScalar, b: BlsScalar) -> Self {
-            let bits = cmp::min(BIT_PAIRS * 2, 256);
+            // the op width is capped at 254 bits, so the mask never overflows
+            // the 255-bit BlsScalar
+            let bits = cmp::min(BIT_PAIRS * 2, 254);
             let bit_mask = BlsScalar::pow_of_2(bits as u64) - BlsScalar::one();
 
-            // BlsScalar are max 255 bits long so a bit_mask with more than 255
-            // bits will be overflowing and incorrect
-            let result = match bits < 256 {
-                true => (a & bit_mask) ^ (b & bit_mask),
-                false => a ^ b,
-            };
+            let result = (a & bit_mask) ^ (b & bit_mask);
 
             Self { a, b, result }
         }
@@ -234,7 +229,7 @@ fn append_logic_xor() {
     let label = b"append_logic_xor";
 
     let mut rng = StdRng::seed_from_u64(0xdea1);
-    let capacity = 1 << 8;
+    let capacity = 1 << 12;
     let pp = PublicParameters::setup(capacity, &mut rng)
         .expect("Creation of public parameter shouldn't fail");
     let (prover, verifier) = Compiler::compile::<TestCircuit<0>>(&pp, label)
@@ -314,44 +309,45 @@ fn append_logic_xor() {
         &"Sanity check should pass",
     );
 
-    // Test with bits = 256
+    // Test with bits = 254 (the maximum width, BIT_PAIRS = 127)
     //
     // Create new prover and verifier circuit descriptions
-    const BIT_PAIRS_128: usize = 128;
+    const BIT_PAIRS_127: usize = 127;
+    let bit_mask = BlsScalar::pow_of_2(254) - BlsScalar::one();
     let (prover, verifier) =
-        Compiler::compile::<TestCircuit<BIT_PAIRS_128>>(&pp, label)
+        Compiler::compile::<TestCircuit<BIT_PAIRS_127>>(&pp, label)
             .expect("Circuit should compile");
 
     // Test sanity:
     let a = -BlsScalar::one();
     let b = BlsScalar::zero();
-    let result = -BlsScalar::one();
-    let circuit: TestCircuit<BIT_PAIRS_128> = TestCircuit { a, b, result };
+    let result = a & bit_mask;
+    let circuit: TestCircuit<BIT_PAIRS_127> = TestCircuit { a, b, result };
     check_satisfied_circuit(&prover, &verifier, &pi, &circuit, &mut rng, &msg);
 
     // Test random works:
     let msg = "Circuit verification with random values should pass";
     let a = BlsScalar::random(&mut rng);
     let b = BlsScalar::random(&mut rng);
-    let circuit: TestCircuit<BIT_PAIRS_128> = TestCircuit::new(a, b);
+    let circuit: TestCircuit<BIT_PAIRS_127> = TestCircuit::new(a, b);
     check_satisfied_circuit(&prover, &verifier, &pi, &circuit, &mut rng, &msg);
 
     // Test invalid circuit fails
     let msg = "Proof creation of unsatisfied circuit should fail";
     let a = BlsScalar::random(&mut rng);
     let b = BlsScalar::random(&mut rng);
-    let right_result = a ^ b;
+    let right_result = (a & bit_mask) ^ (b & bit_mask);
     let c = BlsScalar::random(&mut rng);
-    let wrong_result = a ^ c;
+    let wrong_result = (a & bit_mask) ^ (c & bit_mask);
     assert_ne!(right_result, wrong_result);
-    let circuit: TestCircuit<BIT_PAIRS_128> = TestCircuit {
+    let circuit: TestCircuit<BIT_PAIRS_127> = TestCircuit {
         a,
         b,
         result: wrong_result,
     };
     check_unsatisfied_circuit(&prover, &circuit, &mut rng, &msg);
     // sanity check
-    let circuit_satisfied: TestCircuit<BIT_PAIRS_128> = TestCircuit {
+    let circuit_satisfied: TestCircuit<BIT_PAIRS_127> = TestCircuit {
         a,
         b,
         result: right_result,

--- a/tests/range.rs
+++ b/tests/range.rs
@@ -15,21 +15,21 @@ use common::{check_satisfied_circuit, check_unsatisfied_circuit};
 #[test]
 fn range() {
     #[derive(Default)]
-    pub struct TestCircuit<const BIT_PAIRS: usize> {
+    pub struct TestCircuit<const BITS: usize> {
         a: BlsScalar,
     }
 
-    impl<const BIT_PAIRS: usize> TestCircuit<BIT_PAIRS> {
+    impl<const BITS: usize> TestCircuit<BITS> {
         pub fn new(a: BlsScalar) -> Self {
             Self { a }
         }
     }
 
-    impl<const BIT_PAIRS: usize> Circuit for TestCircuit<BIT_PAIRS> {
+    impl<const BITS: usize> Circuit for TestCircuit<BITS> {
         fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
             let w_a = composer.append_witness(self.a);
 
-            composer.component_range::<BIT_PAIRS>(w_a);
+            composer.component_range_bits::<BITS>(w_a);
 
             Ok(())
         }
@@ -37,7 +37,7 @@ fn range() {
 
     // Compile common circuit descriptions for the prover and verifier to be
     // used by all tests
-    let label = b"component_range";
+    let label = b"component_range_bits";
     let mut rng = StdRng::seed_from_u64(0xb1eeb);
     let capacity = 1 << 6;
     let pp = PublicParameters::setup(capacity, &mut rng)
@@ -74,73 +74,95 @@ fn range() {
     // Test bits = 2
     //
     // Compile new circuit descriptions for the prover and verifier
-    const BIT_PAIRS_1: usize = 1;
+    const BITS_2: usize = 2;
     let (prover, verifier) =
-        Compiler::compile::<TestCircuit<BIT_PAIRS_1>>(&pp, label)
+        Compiler::compile::<TestCircuit<BITS_2>>(&pp, label)
             .expect("Circuit should compile");
 
     // Test:
     // 1 < 2^2
     let msg = "Verification of a satisfied circuit should pass";
     let a = BlsScalar::one();
-    let circuit: TestCircuit<BIT_PAIRS_1> = TestCircuit::new(a);
+    let circuit: TestCircuit<BITS_2> = TestCircuit::new(a);
     check_satisfied_circuit(&prover, &verifier, &pi, &circuit, &mut rng, &msg);
 
     // Test fails:
     // 4 !< 2^2
     let msg = "Proof creation of an unsatisfied circuit should fail";
     let a = BlsScalar::from(4);
-    let circuit: TestCircuit<BIT_PAIRS_1> = TestCircuit::new(a);
+    let circuit: TestCircuit<BITS_2> = TestCircuit::new(a);
+    check_unsatisfied_circuit(&prover, &circuit, &mut rng, &msg);
+
+    // Test bits = 7 (odd width)
+    //
+    // Compile new circuit descriptions for the prover and verifier
+    const BITS_7: usize = 7;
+    let (prover, verifier) =
+        Compiler::compile::<TestCircuit<BITS_7>>(&pp, label)
+            .expect("Circuit should compile");
+
+    // Test:
+    // 2^7 - 1 < 2^7
+    let msg = "Verification of a satisfied odd-width circuit should pass";
+    let a = BlsScalar::from(127);
+    let circuit: TestCircuit<BITS_7> = TestCircuit::new(a);
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, &mut rng, &msg);
+
+    // Test fails:
+    // 2^7 !< 2^7
+    let msg = "Proof creation of an unsatisfied odd-width circuit should fail";
+    let a = BlsScalar::from(128);
+    let circuit: TestCircuit<BITS_7> = TestCircuit::new(a);
     check_unsatisfied_circuit(&prover, &circuit, &mut rng, &msg);
 
     // Test bits = 74
     //
     // Compile new circuit descriptions for the prover and verifier
-    const BIT_PAIRS_37: usize = 37;
+    const BITS_74: usize = 74;
     let (prover, verifier) =
-        Compiler::compile::<TestCircuit<BIT_PAIRS_37>>(&pp, label)
+        Compiler::compile::<TestCircuit<BITS_74>>(&pp, label)
             .expect("Circuit should compile");
 
     // Test:
     // 2^73 < 2^74
     let msg = "Verification of a satisfied circuit should pass";
     let a = BlsScalar::pow_of_2(73);
-    let circuit: TestCircuit<BIT_PAIRS_37> = TestCircuit::new(a);
+    let circuit: TestCircuit<BITS_74> = TestCircuit::new(a);
     check_satisfied_circuit(&prover, &verifier, &pi, &circuit, &mut rng, &msg);
 
     // Test:
     // 2^74 - 1 < 2^74
     let msg = "Verification of a satisfied circuit should pass";
     let a = BlsScalar::pow_of_2(74) - BlsScalar::one();
-    let circuit: TestCircuit<BIT_PAIRS_37> = TestCircuit::new(a);
+    let circuit: TestCircuit<BITS_74> = TestCircuit::new(a);
     check_satisfied_circuit(&prover, &verifier, &pi, &circuit, &mut rng, &msg);
 
     // Test fails:
     // 2^74 !< 2^74
     let msg = "Proof creation of an unsatisfied circuit should fail";
     let a = BlsScalar::pow_of_2(74);
-    let circuit: TestCircuit<BIT_PAIRS_37> = TestCircuit::new(a);
+    let circuit: TestCircuit<BITS_74> = TestCircuit::new(a);
     check_unsatisfied_circuit(&prover, &circuit, &mut rng, &msg);
 
     // Test bits = 256
     //
     // Compile new circuit descriptions for the prover and verifier
-    const BIT_PAIRS_128: usize = 128;
+    const BITS_256: usize = 256;
     let (prover, verifier) =
-        Compiler::compile::<TestCircuit<BIT_PAIRS_128>>(&pp, label)
+        Compiler::compile::<TestCircuit<BITS_256>>(&pp, label)
             .expect("Circuit should compile");
 
     // Test:
     // 2^255 < 2^256
     let msg = "Verification of a satisfied circuit should pass";
     let a = BlsScalar::pow_of_2(255);
-    let circuit: TestCircuit<BIT_PAIRS_128> = TestCircuit::new(a);
+    let circuit: TestCircuit<BITS_256> = TestCircuit::new(a);
     check_satisfied_circuit(&prover, &verifier, &pi, &circuit, &mut rng, &msg);
 
     // Test:
     // -bls(1) < 2^256
     let msg = "Verification of a satisfied circuit should pass";
     let a = -BlsScalar::one();
-    let circuit: TestCircuit<BIT_PAIRS_128> = TestCircuit::new(a);
+    let circuit: TestCircuit<BITS_256> = TestCircuit::new(a);
     check_satisfied_circuit(&prover, &verifier, &pi, &circuit, &mut rng, &msg);
 }

--- a/tests/truncate.rs
+++ b/tests/truncate.rs
@@ -1,0 +1,161 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_plonk::prelude::*;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+mod common;
+use common::{check_satisfied_circuit, check_unsatisfied_circuit};
+
+// Truncates `input` to its low `N` bits and exposes the result as a public
+// input. A satisfying assignment requires `claimed_low` to equal the honest
+// truncation of `input`.
+struct TruncCircuit<const N: usize> {
+    input: BlsScalar,
+    claimed_low: BlsScalar,
+}
+
+impl<const N: usize> Default for TruncCircuit<N> {
+    // The default input value is arbitrary: the gate layout keys off the
+    // compile-time `N` (the split widths are fixed by `N`, not by the value),
+    // so any input compiles the same circuit description.
+    fn default() -> Self {
+        Self {
+            input: -BlsScalar::one(),
+            claimed_low: BlsScalar::zero(),
+        }
+    }
+}
+
+impl<const N: usize> Circuit for TruncCircuit<N> {
+    fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
+        let witness = composer.append_witness(self.input);
+        let low = composer.component_truncate::<N>(witness);
+        let pi = composer.append_public(self.claimed_low);
+        composer.assert_equal(low, pi);
+
+        Ok(())
+    }
+}
+
+#[test]
+fn truncate() {
+    let mut rng = StdRng::seed_from_u64(0x7_b1eeb);
+    let pp = PublicParameters::setup(1 << 12, &mut rng)
+        .expect("Creation of public parameter shouldn't fail");
+    let label = b"component_truncate";
+
+    // --- 8-bit truncation: exercises a non-zero high part with hand-computable
+    // values. `0x1234` truncates to `0x34`. ---
+    let (prover, verifier) = Compiler::compile::<TruncCircuit<8>>(&pp, label)
+        .expect("Circuit should compile");
+
+    let input = BlsScalar::from(0x1234u64);
+    let low = BlsScalar::from(0x34u64);
+    let pi = vec![low];
+    let msg = "8-bit truncation of a wider input should verify";
+    let circuit = TruncCircuit::<8> {
+        input,
+        claimed_low: low,
+    };
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, &mut rng, msg);
+
+    // A claimed low that is not the truncation is unsatisfiable.
+    let msg = "Wrong truncation claim should fail to prove";
+    let circuit = TruncCircuit::<8> {
+        input,
+        claimed_low: BlsScalar::from(0x35u64),
+    };
+    check_unsatisfied_circuit(&prover, &circuit, &mut rng, msg);
+
+    // --- 7-bit (odd) truncation: `0x1234` truncates to `0x34 & 0x7f = 0x34`;
+    // `0x12B4` (low byte `0xB4`) truncates to `0xB4 & 0x7f = 0x34` too, so the
+    // dropped 8th bit is genuinely exercised. ---
+    let (prover, verifier) = Compiler::compile::<TruncCircuit<7>>(&pp, label)
+        .expect("Circuit should compile");
+
+    let input = BlsScalar::from(0x12B4u64);
+    let low = BlsScalar::from(0x34u64); // 0xB4 mod 2^7
+    let pi = vec![low];
+    let msg = "Odd-width (7-bit) truncation should verify";
+    let circuit = TruncCircuit::<7> {
+        input,
+        claimed_low: low,
+    };
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, &mut rng, msg);
+
+    let msg = "Wrong odd-width truncation claim should fail to prove";
+    let circuit = TruncCircuit::<7> {
+        input,
+        claimed_low: BlsScalar::from(0xB4u64), // the untruncated low byte
+    };
+    check_unsatisfied_circuit(&prover, &circuit, &mut rng, msg);
+
+    // --- 250-bit truncation: the Schnorr-challenge width. An input below
+    // `2^250` is its own truncation (zero high part). ---
+    let (prover, verifier) = Compiler::compile::<TruncCircuit<250>>(&pp, label)
+        .expect("Circuit should compile");
+
+    let input = BlsScalar::from(0x1_2345_6789_abcdu64);
+    let pi = vec![input];
+    let msg = "Sub-2^250 input truncates to itself and should verify";
+    let circuit = TruncCircuit::<250> {
+        input,
+        claimed_low: input,
+    };
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, &mut rng, msg);
+
+    let msg = "Wrong truncation claim should fail to prove";
+    let circuit = TruncCircuit::<250> {
+        input,
+        claimed_low: input + BlsScalar::one(),
+    };
+    check_unsatisfied_circuit(&prover, &circuit, &mut rng, msg);
+
+    // --- N = 0: the lower boundary. The low part is the empty bit range, so
+    // the truncation of any input is `0`. ---
+    let (prover, verifier) = Compiler::compile::<TruncCircuit<0>>(&pp, label)
+        .expect("Circuit should compile");
+
+    let input = BlsScalar::from(0x1_2345_6789_abcdu64);
+    let pi = vec![BlsScalar::zero()];
+    let msg = "Truncation to 0 bits is always 0 and should verify";
+    let circuit = TruncCircuit::<0> {
+        input,
+        claimed_low: BlsScalar::zero(),
+    };
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, &mut rng, msg);
+
+    let msg = "Non-zero claim for a 0-bit truncation should fail to prove";
+    let circuit = TruncCircuit::<0> {
+        input,
+        claimed_low: BlsScalar::one(),
+    };
+    check_unsatisfied_circuit(&prover, &circuit, &mut rng, msg);
+
+    // --- N = 254: the upper boundary (the compile-time cap and the only width
+    // where the canonical guard's `r_high` is 1). An input below `2^254` is its
+    // own truncation. ---
+    let (prover, verifier) = Compiler::compile::<TruncCircuit<254>>(&pp, label)
+        .expect("Circuit should compile");
+
+    let input = BlsScalar::from(0x1_2345_6789_abcdu64);
+    let pi = vec![input];
+    let msg = "Sub-2^254 input truncates to itself and should verify";
+    let circuit = TruncCircuit::<254> {
+        input,
+        claimed_low: input,
+    };
+    check_satisfied_circuit(&prover, &verifier, &pi, &circuit, &mut rng, msg);
+
+    let msg = "Wrong 254-bit truncation claim should fail to prove";
+    let circuit = TruncCircuit::<254> {
+        input,
+        claimed_low: input + BlsScalar::one(),
+    };
+    check_unsatisfied_circuit(&prover, &circuit, &mut rng, msg);
+}


### PR DESCRIPTION
The logic gadget reconstructed its operands from the bits of `a` and `b` without wiring the input witnesses into any gate, leaving the output decoupled from the inputs. A prover could satisfy the identical gate layout — and so the same verifier key — with arbitrary accumulators, for instance proving `0 & 0 = 0` while declaring `a = 3, b = 3`.

Close the gadget with a binding that ties each reconstructed accumulator back to the low bits of its input. The binding is a range-bounded canonical truncation rather than a plain equality, so inputs wider than the op width are still accepted; a plain `assert_equal` would reject honest inputs.

The op width is capped at 254 bits, the widest even width for which the truncation binding stays canonical against a 255-bit `BlsScalar`. `BIT_PAIRS > 127` is now a compile-time error rather than a silent cap.

Extract the shared pieces this needs: `range_check`/`range_check_even` as the single base-4 range layout, `component_truncate` as the canonical truncation primitive, and `component_range_bits` as a bit-counted range check, deprecating the bit-pair-counted `component_range`.

This changes the verifier key of any circuit using the logic gadget.