### PR TITLE
Reject zero-Z fixed-base generators without panicking

### DIFF
--- a/src/composer.rs
+++ b/src/composer.rs
@@ -612,7 +612,11 @@ impl Composer {
     ) -> Result<WitnessPoint, Error> {
         let generator = generator.into();
 
-        if !bool::from(generator.is_on_curve() & generator.is_prime_order()) {
+        // Check Z first: is_on_curve converts to affine and panics on Z = 0.
+        if generator.get_z() == BlsScalar::zero()
+            || !bool::from(generator.is_on_curve())
+            || !bool::from(generator.is_prime_order())
+        {
             return Err(Error::JubJubGeneratorNotPrimeOrder);
         }
 

--- a/tests/ecc.rs
+++ b/tests/ecc.rs
@@ -444,6 +444,23 @@ fn component_mul_generator_rejects_non_prime_order_generator() {
 }
 
 #[test]
+fn component_mul_generator_rejects_zero_z_generator() {
+    let mut composer = Composer::initialized();
+    let scalar = composer.append_witness(JubJubScalar::one());
+    let generator = JubJubExtended::from_raw_unchecked(
+        BlsScalar::zero(),
+        BlsScalar::one(),
+        BlsScalar::zero(),
+        BlsScalar::zero(),
+        BlsScalar::zero(),
+    );
+
+    let result = composer.component_mul_generator(scalar, generator);
+
+    assert!(matches!(result, Err(Error::JubJubGeneratorNotPrimeOrder)));
+}
+
+#[test]
 fn component_mul_point() {
     pub struct TestCircuit {
         scalar: JubJubScalar,


### PR DESCRIPTION
`component_mul_generator` validates caller-supplied extended points with `is_on_curve`, but that method converts to affine and panics when `z = 0`.

This rejects zero-z representations before invoking the remaining point checks and adds a regression test confirming malformed generators return `JubJubGeneratorNotPrimeOrder`.

This is a host-side validation change only and does not alter the circuit layout.