### PR TITLE
Return a distinct error when proving an unsatisfied circuit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Detect unsatisfied circuits during quotient computation and return
   `Error::CircuitUnsatisfied` instead of the misleading
   `Error::PolynomialDegreeTooLarge` [#877]
+- Report the first unsatisfied constraint — index, gate-identity family and
+  source location — on stderr when a prove attempt's assignment leaves a
+  constraint unsatisfied, under the `debug` feature [#877]
 - Cap logic gadget width at 254 bits; `BIT_PAIRS > 127` is now a compile-time error [#867]
 - Change the verifier key of circuits using the logic gadget [#867]
 - Increase the gate count of `append_logic_and`/`append_logic_xor` to bind their inputs [#867]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `Composer::component_truncate<N>` to extract the low `N` bits of a witness [#867]
 - Add `Composer::component_range_bits<BITS>` range check counting bits directly [#867]
 - Add the public `Error::JubJubGeneratorNotPrimeOrder` variant [#832]
+- Add the public `Error::CircuitUnsatisfied` variant, returned when proof
+  creation fails because the witness assignment does not satisfy the
+  constraint system [#877]
 
 ### Changed
 
@@ -24,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `Composer::IDENTITY` to a `TorsionFreeWitnessPoint` [#870]
 - Change `append_constant_point` to validate the constant natively and return `Result<TorsionFreeWitnessPoint, Error>` [#870]
 - Change `component_mul_generator` to return `Result<TorsionFreeWitnessPoint, Error>`, its generator being validated to exact prime order [#870]
+- Detect unsatisfied circuits during quotient computation and return
+  `Error::CircuitUnsatisfied` instead of the misleading
+  `Error::PolynomialDegreeTooLarge` [#877]
 - Cap logic gadget width at 254 bits; `BIT_PAIRS > 127` is now a compile-time error [#867]
 - Change the verifier key of circuits using the logic gadget [#867]
 - Increase the gate count of `append_logic_and`/`append_logic_xor` to bind their inputs [#867]
@@ -718,6 +724,7 @@ is necessary since `rkyv/validation` was required as a bound.
 - Proof system module.
 
 <!-- ISSUES -->
+[#877]: https://github.com/dusk-network/plonk/issues/877
 [#870]: https://github.com/dusk-network/plonk/issues/870
 [#867]: https://github.com/dusk-network/plonk/issues/867
 [#861]: https://github.com/dusk-network/plonk/issues/861

--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -504,6 +504,15 @@ mod test {
         srs.trim(degree)
     }
     #[test]
+    fn test_commit_rejects_oversized_polynomial() -> Result<(), Error> {
+        let degree = 25;
+        let (ck, _) = setup_test(degree)?;
+
+        let poly = Polynomial::rand(ck.max_degree() + 1, &mut OsRng);
+        assert_eq!(ck.commit(&poly), Err(Error::PolynomialDegreeTooLarge));
+        Ok(())
+    }
+    #[test]
     fn test_basic_commit() -> Result<(), Error> {
         let degree = 25;
         let (ck, opening_key) = setup_test(degree)?;

--- a/src/composer/soundness_support.rs
+++ b/src/composer/soundness_support.rs
@@ -17,9 +17,7 @@
 //! - the rejection must come from an **unsatisfied constraint** specifically,
 //!   not from any error the prover happens to return.
 //!
-//! [`gate_layout`] and [`assert_rejected`] pin those down; see
-//! [`UNSATISFIED`] for what the second one can and cannot tell apart on its
-//! own.
+//! [`gate_layout`] and [`assert_rejected`] pin those down.
 
 use rand::rngs::StdRng;
 
@@ -108,18 +106,6 @@ pub(super) fn gate_digest(gates: &[Gate]) -> [u8; 32] {
     acc.to_bytes()
 }
 
-/// The proving error an unsatisfied assignment surfaces as. The chain: the
-/// assignment does not satisfy the constraint system, so the quotient
-/// polynomial is not divisible by the vanishing polynomial, so a split chunk
-/// of it exceeds the commit key's maximum degree.
-///
-/// The variant is not exclusive to that chain — it is raised by
-/// `CommitKey::check_commit_degree_is_within_bounds`, which an undersized
-/// public parameter setup would also trip. What rules that out here is the
-/// control proof: it succeeds against the same commit key on an identical gate
-/// layout, so the only thing left that can differ is satisfiability.
-const UNSATISFIED: Error = Error::PolynomialDegreeTooLarge;
-
 /// Prove `honest` and verify the resulting proof, returning its public inputs.
 pub(super) fn assert_verifies<C: Circuit>(
     prover: &Prover,
@@ -144,6 +130,11 @@ pub(super) fn assert_verifies<C: Circuit>(
 /// accepted one no longer does, and the resulting `InvalidCircuitSize` would
 /// read as a successful rejection. Without the error check, any unrelated
 /// proving failure would do the same.
+///
+/// The control proof (the accepted circuit proving against the same commit
+/// key on an identical gate layout) is what makes [`Error::CircuitUnsatisfied`]
+/// conclusive here: the only thing that can differ between the accepted and
+/// rejected circuit is satisfiability.
 pub(super) fn assert_rejected<C: Circuit>(
     prover: &Prover,
     rng: &mut StdRng,
@@ -160,7 +151,7 @@ pub(super) fn assert_rejected<C: Circuit>(
 
     match prover.prove(rng, rejected) {
         Ok(_) => panic!("{case}: produced a proof"),
-        Err(error) if error == UNSATISFIED => {}
+        Err(Error::CircuitUnsatisfied) => {}
         Err(other) => panic!(
             "{case}: rejected by `{other:?}`, not by an unsatisfied \
              constraint — it is not exercising the constraint under test",

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -26,6 +26,28 @@ use crate::proof_system::widget::logic::proverkey::{
 use crate::proof_system::widget::range::proverkey::delta as range_delta;
 use crate::runtime::RuntimeEvent;
 
+/// Gate-identity family names, index-aligned with the array returned by
+/// [`Debugger::identity_evaluations`].
+const IDENTITY_FAMILIES: [&str; 17] = [
+    "arithmetic",
+    "range delta c/d",
+    "range delta b/c",
+    "range delta a/b",
+    "range accumulator",
+    "logic left quad",
+    "logic right quad",
+    "logic output quad",
+    "logic product",
+    "logic relation",
+    "fixed-base bit consistency",
+    "fixed-base xy consistency",
+    "fixed-base x accumulator",
+    "fixed-base y accumulator",
+    "variable-base xy consistency",
+    "variable-base x accumulator",
+    "variable-base y accumulator",
+];
+
 /// PLONK debugger
 #[derive(Debug, Clone)]
 pub(crate) struct Debugger {
@@ -64,7 +86,7 @@ impl Debugger {
         &self,
         constraint_index: usize,
         constraint: &Constraint,
-    ) -> [BlsScalar; 17] {
+    ) -> [BlsScalar; IDENTITY_FAMILIES.len()] {
         let qm = *constraint.coeff(Selector::Multiplication);
         let ql = *constraint.coeff(Selector::Left);
         let qr = *constraint.coeff(Selector::Right);
@@ -155,6 +177,58 @@ impl Debugger {
         self.identity_evaluations(constraint_index, constraint)
             .into_iter()
             .all(|identity| identity == BlsScalar::zero())
+    }
+
+    /// Constraints whose assignment fails a gate identity, each paired with
+    /// the name of the first identity family it fails.
+    fn unsatisfied_constraints(&self) -> Vec<(usize, &'static str)> {
+        self.constraints
+            .iter()
+            .enumerate()
+            .filter_map(|(index, (_, constraint))| {
+                self.identity_evaluations(index, constraint)
+                    .into_iter()
+                    .position(|identity| identity != BlsScalar::zero())
+                    .map(|identity| (index, IDENTITY_FAMILIES[identity]))
+            })
+            .collect()
+    }
+
+    /// The diagnostic naming the first unsatisfied constraint, if any.
+    /// Proving destroys the which-constraint information before it fails, so
+    /// this is the only place a failing gate can be named.
+    ///
+    /// The check covers the prove-time assignment against its own
+    /// constraints; the compiled circuit description's selectors are not
+    /// available here. When the two disagree — same gate count, different
+    /// selector values — proving still fails with an unsatisfied-circuit
+    /// error while this report stays silent, so a silent report next to that
+    /// error points at a description/assignment mismatch. The mirror also
+    /// holds: a row vacuous in the description but live at prove time is
+    /// named here while the proof goes through — the report catching a
+    /// constraint missing from the verifier key — which is why the report
+    /// must not be gated on proving having failed.
+    fn unsatisfied_report(&self) -> Option<String> {
+        let unsatisfied = self.unsatisfied_constraints();
+        let (index, family) = unsatisfied.first()?;
+        let source = &self.constraints[*index].0;
+
+        Some(format!(
+            "plonk debugger: {} of {} constraints are unsatisfied; the \
+             first, constraint {index}, fails the {family} identity and was \
+             appended at {}:{}:{}",
+            unsatisfied.len(),
+            self.constraints.len(),
+            source.path(),
+            source.line(),
+            source.col(),
+        ))
+    }
+
+    fn report_unsatisfied(&self) {
+        if let Some(report) = self.unsatisfied_report() {
+            eprintln!("{report}");
+        }
     }
 
     /// Resolver the caller function
@@ -296,6 +370,7 @@ impl Debugger {
             }
 
             RuntimeEvent::ProofFinished => {
+                self.report_unsatisfied();
                 self.write_output();
             }
         }
@@ -349,11 +424,16 @@ mod tests {
             "{name} fixture did not satisfy every identity: {identities:?}"
         );
         assert!(debugger.evaluates_to_zero(0, constraint));
+        assert!(
+            debugger.unsatisfied_constraints().is_empty(),
+            "{name} fixture must report no unsatisfied constraints"
+        );
     }
 
     fn assert_identity_fails(
         name: &str,
         identity_index: usize,
+        family: &'static str,
         constraint: Constraint,
         values: [BlsScalar; 8],
     ) {
@@ -370,6 +450,13 @@ mod tests {
             !debugger.evaluates_to_zero(0, constraint),
             "{name} evaluated as satisfied"
         );
+
+        assert_eq!(
+            debugger.unsatisfied_constraints(),
+            vec![(0, family)],
+            "{name} must be reported as the only unsatisfied constraint, \
+             failing the {family} identity"
+        );
     }
 
     fn add(
@@ -379,6 +466,34 @@ mod tests {
     ) -> [BlsScalar; 8] {
         values[index] += BlsScalar::from(amount);
         values
+    }
+
+    #[test]
+    fn unsatisfied_report_counts_and_names_the_first() {
+        // With no witnesses every wire reads zero, so a gate demanding
+        // constant 1 is unsatisfied on its arithmetic identity.
+        let unsatisfied_gate =
+            || Constraint::arithmetic(&Constraint::new().constant(1u64));
+        let debugger = Debugger {
+            witnesses: Vec::new(),
+            constraints: vec![
+                (EncodableSource::default(), unsatisfied_gate()),
+                (EncodableSource::default(), unsatisfied_gate()),
+            ],
+        };
+
+        let report = debugger
+            .unsatisfied_report()
+            .expect("both constraints are unsatisfied");
+        assert!(report.contains("2 of 2 constraints"));
+        assert!(report.contains("constraint 0"));
+        assert!(report.contains("arithmetic identity"));
+
+        let satisfied = Debugger {
+            witnesses: Vec::new(),
+            constraints: vec![(EncodableSource::default(), Constraint::new())],
+        };
+        assert!(satisfied.unsatisfied_report().is_none());
     }
 
     #[test]
@@ -463,84 +578,147 @@ mod tests {
         let mut invalid_range_3 = range_values;
         invalid_range_3[7] = BlsScalar::from(368u64);
 
+        // (case name, identity index, reported family, constraint, values);
+        // the family is spelled out per case so the assertion pins the
+        // `IDENTITY_FAMILIES` entry independently of the array itself.
         let invalid_cases = [
-            ("arithmetic", 0, arithmetic, add(arithmetic_values, 0, 1)),
-            ("range delta c/d", 1, range, invalid_range_0),
-            ("range delta b/c", 2, range, invalid_range_1),
-            ("range delta a/b", 3, range, invalid_range_2),
-            ("range accumulator", 4, range, invalid_range_3),
-            ("logic left quad", 5, logic_and, add(logic_and_values, 4, 1)),
+            (
+                "arithmetic",
+                0,
+                "arithmetic",
+                arithmetic,
+                add(arithmetic_values, 0, 1),
+            ),
+            (
+                "range delta c/d",
+                1,
+                "range delta c/d",
+                range,
+                invalid_range_0,
+            ),
+            (
+                "range delta b/c",
+                2,
+                "range delta b/c",
+                range,
+                invalid_range_1,
+            ),
+            (
+                "range delta a/b",
+                3,
+                "range delta a/b",
+                range,
+                invalid_range_2,
+            ),
+            (
+                "range accumulator",
+                4,
+                "range accumulator",
+                range,
+                invalid_range_3,
+            ),
+            (
+                "logic left quad",
+                5,
+                "logic left quad",
+                logic_and,
+                add(logic_and_values, 4, 1),
+            ),
             (
                 "logic right quad",
                 6,
+                "logic right quad",
                 logic_and,
                 add(logic_and_values, 5, 3),
             ),
             (
                 "logic output quad",
                 7,
+                "logic output quad",
                 logic_and,
                 add(logic_and_values, 7, 3),
             ),
-            ("logic product", 8, logic_and, add(logic_and_values, 2, 1)),
+            (
+                "logic product",
+                8,
+                "logic product",
+                logic_and,
+                add(logic_and_values, 2, 1),
+            ),
             (
                 "logic AND relation",
                 9,
+                "logic relation",
                 logic_and,
                 add(logic_and_values, 7, 1),
             ),
             (
                 "logic XOR relation",
                 9,
+                "logic relation",
                 logic_xor,
                 add(logic_xor_values, 7, 1),
             ),
             (
                 "fixed-base bit consistency",
                 10,
+                "fixed-base bit consistency",
                 fixed_base,
                 add(fixed_base_values, 7, 1),
             ),
             (
                 "fixed-base xy consistency",
                 11,
+                "fixed-base xy consistency",
                 fixed_base,
                 add(fixed_base_values, 2, 1),
             ),
             (
                 "fixed-base x accumulator",
                 12,
+                "fixed-base x accumulator",
                 fixed_base,
                 add(fixed_base_values, 4, 1),
             ),
             (
                 "fixed-base y accumulator",
                 13,
+                "fixed-base y accumulator",
                 fixed_base,
                 add(fixed_base_values, 5, 1),
             ),
             (
                 "variable-base xy consistency",
                 14,
+                "variable-base xy consistency",
                 variable_base,
                 add(variable_base_values, 7, 1),
             ),
             (
                 "variable-base x accumulator",
                 15,
+                "variable-base x accumulator",
                 variable_base,
                 add(variable_base_values, 4, 1),
             ),
             (
                 "variable-base y accumulator",
                 16,
+                "variable-base y accumulator",
                 variable_base,
                 add(variable_base_values, 5, 1),
             ),
         ];
 
-        for (name, identity_index, constraint, values) in invalid_cases {
-            assert_identity_fails(name, identity_index, constraint, values);
+        for (name, identity_index, family, constraint, values) in invalid_cases
+        {
+            assert_identity_fails(
+                name,
+                identity_index,
+                family,
+                constraint,
+                values,
+            );
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,10 @@ pub enum Error {
     /// of gates than the circuit for the proof creation.
     /// The order: (description_size, circuit_size)
     InvalidCircuitSize(usize, usize),
+    /// This error occurs when proof creation fails because the constraint
+    /// system is not satisfied: the witness assignment or the appended
+    /// constants do not match the compiled circuit description.
+    CircuitUnsatisfied,
 
     // Preprocessing errors
     /// This error occurs when an error triggers during the preprocessing
@@ -144,6 +148,12 @@ impl std::fmt::Display for Error {
                     "circuit description has a different amount of gates than the circuit for the proof creation: description size = {description_size}, circuit size = {circuit_size}"
                 )
             }
+            Self::CircuitUnsatisfied => write!(
+                f,
+                "the circuit is not satisfied: the witness assignment or the \
+                 appended constants do not match the compiled circuit \
+                 description"
+            ),
             Self::DegreeIsZero => {
                 write!(f, "cannot create PublicParameters with max degree 0")
             }
@@ -227,7 +237,7 @@ mod tests {
         assert!(matches!(bytes_error, Error::BytesError(_)));
 
         // Format each variant at least once so the `Display` impl gets covered.
-        let all_errors: [Error; 24] = [
+        let all_errors: [Error; 25] = [
             Error::InvalidEvalDomainSize {
                 log_size_of_group: 32,
                 adacity: 28,
@@ -238,6 +248,7 @@ mod tests {
             Error::InvalidPublicInputBytes,
             Error::CircuitAlreadyPreprocessed,
             Error::InvalidCircuitSize(1, 2),
+            Error::CircuitUnsatisfied,
             Error::MismatchedPolyLen,
             Error::DegreeIsZero,
             Error::TruncatedDegreeTooLarge,

--- a/src/proof_system/quotient_poly.rs
+++ b/src/proof_system/quotient_poly.rs
@@ -99,8 +99,39 @@ pub(crate) fn compute(
         .collect();
 
     let coset = domain_8n.coset_ifft(&quotient);
+    let quotient_poly = Polynomial::from_coefficients_vec(coset);
 
-    Ok(Polynomial::from_coefficients_vec(coset))
+    // A satisfied assignment yields a numerator divisible by the vanishing
+    // polynomial of the domain, and the quotient's degree is bounded by the
+    // numerator's: the permutation product z(x) (degree n + 2, with hiding
+    // degree 2) times the four wire factors (degree n + 1 each, with hiding
+    // degree 1) has degree 5n + 6, and every gate identity stays below that.
+    // Dividing by the vanishing polynomial (degree n) leaves at most 4n + 6.
+    //
+    // An unsatisfied assignment leaves a nonzero remainder r(x) with
+    // deg r < n. On the 8n-sized coset the pointwise division then computes
+    // q(x) + r(x)/z_H(x), and 1/z_H interpolates over that coset to
+    // c_0 + c_1·x^n + ... + c_7·x^7n with c_7 nonzero (z_H only takes 8
+    // distinct values there), pushing the interpolated result to a degree of
+    // at least 7n. The check is anchored on that detection floor rather than
+    // the honest ceiling, so it stays correct should blinding or a new gate
+    // ever push the honest quotient past 4n + 6 — up to 7n of headroom.
+    // Unsatisfied assignments are caught even when the commit key is roomy
+    // enough (small circuits, deserialized oversized keys) that the split
+    // quotient chunks would have committed fine and only failed at
+    // verification.
+    //
+    // `from_coefficients_vec` trims trailing zero coefficients, so the
+    // coefficient vector is either empty or ends on a non-zero coefficient
+    // and `len() == degree + 1`. Comparing lengths therefore reads the
+    // degree in constant time instead of rescanning the coefficients, and
+    // `degree() >= 7n` becomes `len() > 7n` (the empty polynomial passes
+    // either way).
+    if quotient_poly.len() > 7 * domain.size() {
+        return Err(Error::CircuitUnsatisfied);
+    }
+
+    Ok(quotient_poly)
 }
 
 // Ensures that the circuit is satisfied

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -57,7 +57,8 @@ pub(crate) fn check_satisfied_circuit_fails<C, R>(
     verifier.verify(&proof, &pi_expected).expect_err(msg);
 }
 
-// Check that proof creation of an unsatisfied circuit fails
+// Check that proof creation of an unsatisfied circuit fails with the error
+// dedicated to unsatisfied constraints.
 // This is also the case when the constants appended to the circuit does not
 // match the ones from the circuit description
 pub(crate) fn check_unsatisfied_circuit<C, R>(
@@ -69,5 +70,11 @@ pub(crate) fn check_unsatisfied_circuit<C, R>(
     C: Circuit,
     R: RngCore + CryptoRng,
 {
-    prover.prove(rng, circuit).expect_err(msg);
+    match prover.prove(rng, circuit) {
+        Ok(_) => panic!("{msg}"),
+        Err(Error::CircuitUnsatisfied) => (),
+        Err(error) => panic!(
+            "expected `Error::CircuitUnsatisfied`, got `{error:?}`: {msg}"
+        ),
+    }
 }


### PR DESCRIPTION
## Summary

Proving an unsatisfied circuit now returns a dedicated `Error::CircuitUnsatisfied` instead of the opaque `PolynomialDegreeTooLarge`, via an O(1) quotient-degree check; genuine sizing errors keep `PolynomialDegreeTooLarge`. Under the `debug` feature the debugger also names the first unsatisfied constraint on stderr.

Resolves #877