### PR TITLE
Regroup the composer soundness tests into a dedicated subtree

### DIFF
--- a/src/composer.rs
+++ b/src/composer.rs
@@ -28,10 +28,7 @@ mod select;
 mod truncate;
 
 #[cfg(test)]
-mod evaluated_output_soundness_tests;
-
-#[cfg(test)]
-mod soundness_support;
+mod tests;
 
 pub(crate) mod permutation;
 

--- a/src/composer/fixed_base.rs
+++ b/src/composer/fixed_base.rs
@@ -19,9 +19,6 @@ use super::{
 };
 use crate::error::Error;
 
-#[cfg(test)]
-mod soundness_tests;
-
 /// Bit width of a canonical Jubjub scalar.
 pub(super) const JUBJUB_SCALAR_BITS: usize = 252;
 
@@ -37,8 +34,8 @@ pub(super) const FIXED_BASE_LEADING_ZERO_ROUNDS: usize =
 
 /// Widest effective signed-digit width at which the fixed-base accumulator
 /// endpoint cannot encode a modulus wrap: `2^254 - 1 < q - (r - 1)`, verified
-/// against the actual moduli by the width-bound test in this module's
-/// `soundness_tests`. Specific to the `(q, r)` pair — unrelated to
+/// against the actual moduli by the width-bound test in
+/// `tests::soundness::fixed_base`. Specific to the `(q, r)` pair — unrelated to
 /// the 254-bit caps of the logic and truncation gadgets, which derive from
 /// `q < 2^255` alone.
 pub(super) const FIXED_BASE_MAX_SOUND_WIDTH: usize = 254;

--- a/src/composer/fixed_base.rs
+++ b/src/composer/fixed_base.rs
@@ -23,16 +23,16 @@ use crate::error::Error;
 mod soundness_tests;
 
 /// Bit width of a canonical Jubjub scalar.
-const JUBJUB_SCALAR_BITS: usize = 252;
+pub(super) const JUBJUB_SCALAR_BITS: usize = 252;
 
 /// Number of signed-digit rows emitted by the fixed-base scalar-multiplication
 /// widget.
-const FIXED_BASE_SIGNED_DIGIT_ROUNDS: usize = 256;
+pub(super) const FIXED_BASE_SIGNED_DIGIT_ROUNDS: usize = 256;
 
 /// A width-2 NAF of a 252-bit scalar may carry into bit 252, so 253 signed
 /// digits are required. The remaining three most-significant rows must encode
 /// zero.
-const FIXED_BASE_LEADING_ZERO_ROUNDS: usize =
+pub(super) const FIXED_BASE_LEADING_ZERO_ROUNDS: usize =
     FIXED_BASE_SIGNED_DIGIT_ROUNDS - (JUBJUB_SCALAR_BITS + 1);
 
 /// Widest effective signed-digit width at which the fixed-base accumulator
@@ -41,7 +41,7 @@ const FIXED_BASE_LEADING_ZERO_ROUNDS: usize =
 /// `soundness_tests`. Specific to the `(q, r)` pair — unrelated to
 /// the 254-bit caps of the logic and truncation gadgets, which derive from
 /// `q < 2^255` alone.
-const FIXED_BASE_MAX_SOUND_WIDTH: usize = 254;
+pub(super) const FIXED_BASE_MAX_SOUND_WIDTH: usize = 254;
 
 // The leading rounds forced to zero cap the effective signed-digit width of
 // `component_mul_generator`. At the width above or below, the accumulator
@@ -160,7 +160,7 @@ impl Composer {
     /// can inject adversarial assignments into the exact production layout.
     /// The constraints, not the provenance of `signed_digits`, must reject
     /// noncanonical and field-wrapping representations.
-    fn append_fixed_base_signed_digits(
+    pub(super) fn append_fixed_base_signed_digits(
         &mut self,
         jubjub: Witness,
         generator: JubJubExtended,

--- a/src/composer/logic.rs
+++ b/src/composer/logic.rs
@@ -15,9 +15,6 @@ use dusk_bls12_381::BlsScalar;
 use super::{Composer, Constraint, WiredWitness, Witness};
 use crate::bit_iterator::BitIterator8;
 
-#[cfg(test)]
-mod soundness_tests;
-
 /// Bitwise logic gadgets
 impl Composer {
     /// Performs a logical AND or XOR op between the inputs provided for

--- a/src/composer/logic.rs
+++ b/src/composer/logic.rs
@@ -181,7 +181,7 @@ impl Composer {
     /// [`Self::append_logic_component`]; the logic gate guarantees each lies in
     /// `[0, 2^num_bits)`. This binds them to the low `num_bits` of `a`/`b` so
     /// the output cannot be decoupled from the inputs.
-    fn bind_logic_accumulators<const BIT_PAIRS: usize>(
+    pub(super) fn bind_logic_accumulators<const BIT_PAIRS: usize>(
         &mut self,
         a: Witness,
         b: Witness,
@@ -203,7 +203,7 @@ impl Composer {
     ///
     /// `acc` is already constrained to `[0, 2^num_bits)` by the logic gate;
     /// this ties it to `input` through the shared truncation split.
-    fn bind_truncated_input<const BIT_PAIRS: usize>(
+    pub(super) fn bind_truncated_input<const BIT_PAIRS: usize>(
         &mut self,
         input: Witness,
         acc: Witness,

--- a/src/composer/point.rs
+++ b/src/composer/point.rs
@@ -22,7 +22,7 @@ mod soundness_tests;
 /// The inverse of the curve cofactor in the scalar field: `8⁻¹ mod r`, with
 /// `r` the order of the prime-order subgroup. Used to derive the honest
 /// witness `Q = [8⁻¹]·P` for [`Composer::assert_torsion_free_point`].
-const EIGHT_INV: JubJubScalar = JubJubScalar::from_raw([
+pub(super) const EIGHT_INV: JubJubScalar = JubJubScalar::from_raw([
     0x5a12e1cbdadee597,
     0x14cd041279990210,
     0x20cce76020268760,
@@ -189,7 +189,7 @@ impl Composer {
     /// The constraints behind [`Self::assert_torsion_free_point`], taking the
     /// witness `Q` as a parameter. Kept separate so the soundness tests can
     /// stand in for a malicious prover and inject an arbitrary `Q`.
-    fn assert_torsion_free_gates(
+    pub(super) fn assert_torsion_free_gates(
         &mut self,
         point: WitnessPoint,
         q: JubJubAffine,
@@ -279,7 +279,7 @@ impl Composer {
     /// points. Kept separate so in-crate gadgets (the torsion-free check and
     /// its soundness tests) can emit the addition gates for points whose
     /// membership is not yet established.
-    fn add_point_gates(
+    pub(super) fn add_point_gates(
         &mut self,
         a: WitnessPoint,
         b: WitnessPoint,

--- a/src/composer/point.rs
+++ b/src/composer/point.rs
@@ -16,9 +16,6 @@ use super::{
 };
 use crate::error::Error;
 
-#[cfg(test)]
-mod soundness_tests;
-
 /// The inverse of the curve cofactor in the scalar field: `8⁻¹ mod r`, with
 /// `r` the order of the prime-order subgroup. Used to derive the honest
 /// witness `Q = [8⁻¹]·P` for [`Composer::assert_torsion_free_point`].

--- a/src/composer/range.rs
+++ b/src/composer/range.rs
@@ -16,9 +16,6 @@ use super::bits::recompose_bits;
 use super::{Composer, Constraint, WiredWitness, Witness};
 use crate::bit_iterator::BitIterator8;
 
-#[cfg(test)]
-mod soundness_tests;
-
 /// Range-check gadgets
 impl Composer {
     /// Constrains a [`Witness`] to the range `[0, 2^BITS)`, for any (possibly

--- a/src/composer/tests.rs
+++ b/src/composer/tests.rs
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! In-crate tests for the composer.
+//!
+//! These reach composer internals that are not part of the public API, so they
+//! live here rather than in the crate-root `tests/` directory.
+
+mod soundness;

--- a/src/composer/tests/soundness.rs
+++ b/src/composer/tests/soundness.rs
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! Soundness regressions for the composer's gadgets, one module per gadget
+//! family, over the scaffolding in [`support`].
+//!
+//! Each of them compiles a verifier key from an honest gadget and then proves
+//! against it with a fork of that gadget filled with forged witnesses, so they
+//! need the crate-private constraint emitters the honest gadgets are built
+//! from.
+
+mod evaluated_output;
+mod fixed_base;
+mod logic;
+mod point;
+mod range;
+mod support;
+mod truncate;

--- a/src/composer/tests/soundness/evaluated_output.rs
+++ b/src/composer/tests/soundness/evaluated_output.rs
@@ -18,11 +18,13 @@
 //! mismatch. Separate structural checks pin the helper and both wrappers to
 //! exactly one intended arithmetic row.
 
+use dusk_bls12_381::BlsScalar;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 
-use super::soundness_support::{assert_rejected, assert_verifies};
-use super::*;
+use super::support::{assert_rejected, assert_verifies};
+use crate::composer::{Circuit, Composer, Constraint, Witness};
+use crate::error::Error;
 use crate::prelude::{
     Compiler, PlonkVersion, Prover, PublicParameters, Verifier,
 };

--- a/src/composer/tests/soundness/fixed_base.rs
+++ b/src/composer/tests/soundness/fixed_base.rs
@@ -22,11 +22,18 @@
 //! them. The final test builds no circuit: it pins the width bound those
 //! constraints rely on to the field moduli by exact integer arithmetic.
 
+use dusk_bls12_381::BlsScalar;
+use dusk_jubjub::{JubJubExtended, JubJubScalar};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 
-use super::*;
-use crate::composer::soundness_support::{assert_rejected, assert_verifies};
+use super::support::{assert_rejected, assert_verifies};
+use crate::composer::Composer;
+use crate::composer::fixed_base::{
+    FIXED_BASE_LEADING_ZERO_ROUNDS, FIXED_BASE_MAX_SOUND_WIDTH,
+    FIXED_BASE_SIGNED_DIGIT_ROUNDS, JUBJUB_SCALAR_BITS,
+};
+use crate::error::Error;
 use crate::prelude::{
     Circuit, Compiler, PlonkVersion, Prover, PublicParameters, Verifier,
 };

--- a/src/composer/tests/soundness/logic.rs
+++ b/src/composer/tests/soundness/logic.rs
@@ -24,13 +24,13 @@
 
 use core::cmp;
 
+use dusk_bls12_381::BlsScalar;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 
-use super::*;
-use crate::composer::soundness_support::{
-    assert_rejected, assert_verifies, fits, truncate,
-};
+use super::support::{assert_rejected, assert_verifies, fits, truncate};
+use crate::bit_iterator::BitIterator8;
+use crate::composer::{Composer, Constraint, WiredWitness, Witness};
 use crate::prelude::{
     Circuit, Compiler, Error, Prover, PublicParameters, Verifier,
 };

--- a/src/composer/tests/soundness/point.rs
+++ b/src/composer/tests/soundness/point.rs
@@ -43,14 +43,18 @@
 //! by struct literal makes a new field on it break the build here rather than
 //! silently weaken the pin.
 
-use dusk_jubjub::GENERATOR_EXTENDED;
+use dusk_bls12_381::BlsScalar;
+use dusk_jubjub::{
+    EDWARDS_D, GENERATOR_EXTENDED, JubJubAffine, JubJubExtended, JubJubScalar,
+};
 use ff::Field;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 
-use super::*;
-use crate::composer::soundness_support::{
-    assert_rejected, assert_verifies, gate_digest,
+use super::support::{assert_rejected, assert_verifies, gate_digest};
+use crate::composer::point::EIGHT_INV;
+use crate::composer::{
+    Composer, Constraint, TorsionFreeWitnessPoint, Witness, WitnessPoint,
 };
 use crate::fft::{EvaluationDomain, Evaluations, Polynomial};
 use crate::prelude::{

--- a/src/composer/tests/soundness/range.rs
+++ b/src/composer/tests/soundness/range.rs
@@ -18,13 +18,12 @@
 //! delegation existed — that the shared core still emits the layout the
 //! deployed keys were generated against.
 
+use dusk_bls12_381::BlsScalar;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 
-use super::*;
-use crate::composer::soundness_support::{
-    assert_rejected, assert_verifies, gate_digest,
-};
+use super::support::{assert_rejected, assert_verifies, gate_digest};
+use crate::composer::Composer;
 use crate::prelude::{
     Circuit, Compiler, Error, Prover, PublicParameters, Verifier,
 };

--- a/src/composer/tests/soundness/support.rs
+++ b/src/composer/tests/soundness/support.rs
@@ -19,10 +19,14 @@
 //!
 //! [`gate_layout`] and [`assert_rejected`] pin those down.
 
+use alloc::vec::Vec;
+
+use dusk_bls12_381::BlsScalar;
 use rand::rngs::StdRng;
 
-use super::bits::recompose_bits;
-use super::*;
+use crate::composer::bits::recompose_bits;
+use crate::composer::{Circuit, Composer, Gate};
+use crate::error::Error;
 use crate::prelude::{Prover, Verifier};
 
 /// `2^num_bits` as a field element.

--- a/src/composer/tests/soundness/truncate.rs
+++ b/src/composer/tests/soundness/truncate.rs
@@ -36,13 +36,13 @@
 //! canonical-guard margin — the only width where `r_high = 1`), and at an odd
 //! `N = 251` to cover the odd-width range-check path.
 
+use dusk_bls12_381::BlsScalar;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 
-use super::*;
-use crate::composer::soundness_support::{
-    assert_rejected, assert_verifies, fits, pow, truncate,
-};
+use super::support::{assert_rejected, assert_verifies, fits, pow, truncate};
+use crate::composer::bits::recompose_bits;
+use crate::composer::{Composer, Constraint, Witness};
 use crate::prelude::{
     Circuit, Compiler, Error, Prover, PublicParameters, Verifier,
 };

--- a/src/composer/truncate.rs
+++ b/src/composer/truncate.rs
@@ -12,9 +12,6 @@ use dusk_bls12_381::BlsScalar;
 use super::bits::recompose_bits;
 use super::{Composer, Constraint, Witness};
 
-#[cfg(test)]
-mod soundness_tests;
-
 /// Truncation gadgets
 impl Composer {
     /// Bind an already-bounded `low` to the low `num_bits` of `input` via the


### PR DESCRIPTION
## Summary

The composer's soundness tests followed two layouts: five nested under their gadget as `composer/{family}/soundness_tests.rs`, and the sixth plus the shared support module flat at `composer/` level. Finding a gadget's coverage, or reading what the suite covers as a whole, meant knowing which layout applied.

This gathers all seven under `composer/tests/soundness/`, one module per family. It stays an in-crate module tree, not the crate-root `tests/` directory: these are unit tests exercising private internals, which the integration directory cannot reach at all.

Pure motion — every test body is unchanged, including the gate-digest goldens. Only the import blocks differ, since `use super::*` on a gadget module has to become the named imports it was standing in for.

The tests reach the gadgets' constraint emitters and width constants directly: a forgery only proves something when it emits the same gate layout as the honest gadget, which means calling the same emitter and sharing the same bounds. Nesting each family's tests under its gadget is what gave them that access, so relocating them widens exactly the items they use to `pub(super)` — reaching the `composer` subtree and nothing beyond it. `select_identity_gates` stays private; no test calls it.
