### PR TITLE
Make Error non_exhaustive and drop its Copy derive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Mark `Error` as `#[non_exhaustive]` [#884]
 - Change `component_add_point`, `component_sub_point` and `component_mul_point` to take and return `TorsionFreeWitnessPoint` [#870]
 - Change `component_neg_point` and `component_select_identity` to take and return `TorsionFreeWitnessPoint` [#870]
 - Change `component_select_identity` to constrain its `bit` to be boolean, consuming one additional gate. This changes the verifier key of circuits calling it directly; `component_mul_point` is unaffected [#870]
@@ -731,6 +732,7 @@ is necessary since `rkyv/validation` was required as a bound.
 - Proof system module.
 
 <!-- ISSUES -->
+[#884]: https://github.com/dusk-network/plonk/issues/884
 [#877]: https://github.com/dusk-network/plonk/issues/877
 [#870]: https://github.com/dusk-network/plonk/issues/870
 [#867]: https://github.com/dusk-network/plonk/issues/867

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Mark `Error` as `#[non_exhaustive]` [#884]
+- Remove the `Copy` derive from `Error` [#884]
 - Change `component_add_point`, `component_sub_point` and `component_mul_point` to take and return `TorsionFreeWitnessPoint` [#870]
 - Change `component_neg_point` and `component_select_identity` to take and return `TorsionFreeWitnessPoint` [#870]
 - Change `component_select_identity` to constrain its `bit` to be boolean, consuming one additional gate. This changes the verifier key of circuits calling it directly; `component_mul_point` is unaffected [#870]

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ use dusk_bytes::Error as DuskBytesError;
 
 /// Defines all possible errors that can be encountered in PLONK.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub enum Error {
     // FFT errors
     /// This error occurs when an error triggers on any of the fft module

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,7 @@
 use dusk_bytes::Error as DuskBytesError;
 
 /// Defines all possible errors that can be encountered in PLONK.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
     // FFT errors


### PR DESCRIPTION
## Summary

`Error` gains `#[non_exhaustive]`, so adding a variant stops being a breaking change for downstream crates. Three variants were added this cycle alone and more are queued.

The `Copy` derive comes off in the same change. It constrains every future variant to a payload that is itself `Copy`, and removing it later would need its own major release window.

Both are breaking: downstream matches on `Error` now need a wildcard arm, and code copying an `Error` out of a shared reference has to clone it. They land now because the release already carries breaking changes.

Closes #884
