### PR TITLE
Validate point inputs before projecting them to affine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,38 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `Composer::assert_torsion_free_point` boundary check constraining a witness point into the prime-order subgroup, returning it as `TorsionFreeWitnessPoint` [#870]
-- Add `TorsionFreeWitnessPoint` encoding prime-order subgroup membership in the type system [#870]
-- Add `Error::JubJubPointNotTorsionFree` for constant points outside the prime-order subgroup [#870]
-- Add `Error::JubJubPointDegenerate`, returned by the point entry points for an extended point with a zero `Z` coordinate [#889]
-- Add `Composer::component_truncate<N>` to extract the low `N` bits of a witness [#867]
+- Add `Composer::assert_torsion_free_point` [#870]
+- Add `TorsionFreeWitnessPoint` [#870]
+- Add `Error::JubJubPointNotTorsionFree` [#870]
+- Add `Error::JubJubPointDegenerate` [#889]
+- Add `Composer::component_truncate<N>` [#867]
 - Add `Composer::component_range_bits<BITS>` range check counting bits directly [#867]
 - Add the public `Error::JubJubGeneratorNotPrimeOrder` variant [#832]
-- Add the public `Error::CircuitUnsatisfied` variant, returned when proof
-  creation fails because the witness assignment does not satisfy the
-  constraint system [#877]
+- Add `Error::CircuitUnsatisfied` [#877]
 
 ### Changed
 
 - Mark `Error` as `#[non_exhaustive]` [#884]
 - Remove the `Copy` derive from `Error` [#884]
-- Change `component_add_point`, `component_sub_point` and `component_mul_point` to take and return `TorsionFreeWitnessPoint` [#870]
-- Change `component_neg_point` and `component_select_identity` to take and return `TorsionFreeWitnessPoint` [#870]
-- Change `component_select_identity` to constrain its `bit` to be boolean, consuming one additional gate. This changes the verifier key of circuits calling it directly; `component_mul_point` is unaffected [#870]
+- Change `component_add_point`, `component_sub_point` and `component_mul_point` to `TorsionFreeWitnessPoint` [#870]
+- Change `component_neg_point` and `component_select_identity` to `TorsionFreeWitnessPoint` [#870]
+- Change `component_select_identity` to constrain its `bit` to boolean [#870]
+- Change the verifier key of circuits calling `component_select_identity` [#870]
 - Change `Composer::IDENTITY` to a `TorsionFreeWitnessPoint` [#870]
-- Change `append_constant_point` to validate the constant natively and return `Result<TorsionFreeWitnessPoint, Error>` [#870]
-- Change `append_point`, `append_public_point` and `assert_equal_public_point` to take `impl Into<JubJubExtended>` and return `Result<_, Error>`, rejecting an extended point with a zero `Z` coordinate with `Error::JubJubPointDegenerate`. Callers must handle the new `Result`; affine inputs can never reach the new error. The new bound does not accept `&JubJubExtended`, which the old one did through `From<&JubJubExtended> for JubJubAffine`, so call sites passing a reference — as the key and signature accessors across the ecosystem return one — need a `*` [#889]
-- Change `append_constant_point` to take `impl Into<JubJubExtended>` and reject a zero `Z` coordinate with `Error::JubJubPointDegenerate`. Its membership check now runs on the extended point rather than on the affine projection, so an inconsistent extended representation of an on-curve subgroup point is refused with `Error::JubJubPointNotTorsionFree` [#889]
-- Change `component_mul_generator` to return `Result<TorsionFreeWitnessPoint, Error>`, its generator being validated to exact prime order [#870]
-- Detect unsatisfied circuits during quotient computation and return
-  `Error::CircuitUnsatisfied` instead of the misleading
-  `Error::PolynomialDegreeTooLarge` [#877]
-- Report the first unsatisfied constraint — index, gate-identity family and
-  source location — on stderr when a prove attempt's assignment leaves a
-  constraint unsatisfied, under the `debug` feature [#877]
-- Cap logic gadget width at 254 bits; `BIT_PAIRS > 127` is now a compile-time error [#867]
-- Change the verifier key of circuits using the logic gadget [#867]
-- Increase the gate count of `append_logic_and`/`append_logic_xor` to bind their inputs [#867]
+- Change `append_constant_point` to validate natively and return `Result` [#870]
+- Change the point entry points to take `impl Into<JubJubExtended>` [#889]
+- Change the point entry points to return `Result` [#889]
+- Change `append_constant_point` to validate membership on the extended point [#889]
+- Change `component_mul_generator` to return `Result` [#870]
+- Change unsatisfied proving to return `Error::CircuitUnsatisfied` [#877]
+- Report the first unsatisfied constraint under the `debug` feature [#877]
+- Cap logic gadget width at 254 bits [#867]
+- Change the logic gadget's verifier key [#867]
+- Increase `append_logic_and`/`append_logic_xor` gate count to bind inputs [#867]
 - Make `Composer::append_evaluated_output` append exactly one active arithmetic
   row, including when the output selector is zero. This changes circuit layouts
   for direct callers, which must regenerate circuit-specific proving and
@@ -73,10 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   then equalled public zero modulo `q`, while the same digits drove the point
   endpoint to the nonidentity point `[q]G`, allowing a proof of a false public
   scalar/point relation.
-- Wrap the debugger's rotated (`_w`) wire reads to row 0 past the last
-  constraint, matching the prover's cyclic domain rather than reading zero
-  there. No circuit built through the public API changes output, since row 0's
-  wires are always the zero witness.
+- Wrap the debugger's rotated (`_w`) wire reads to row 0
 
 ## [0.22.1] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `Composer::assert_torsion_free_point` boundary check constraining a witness point into the prime-order subgroup, returning it as `TorsionFreeWitnessPoint` [#870]
 - Add `TorsionFreeWitnessPoint` encoding prime-order subgroup membership in the type system [#870]
 - Add `Error::JubJubPointNotTorsionFree` for constant points outside the prime-order subgroup [#870]
+- Add `Error::JubJubPointDegenerate`, returned by the point entry points for an extended point with a zero `Z` coordinate [#889]
 - Add `Composer::component_truncate<N>` to extract the low `N` bits of a witness [#867]
 - Add `Composer::component_range_bits<BITS>` range check counting bits directly [#867]
 - Add the public `Error::JubJubGeneratorNotPrimeOrder` variant [#832]
@@ -28,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `component_select_identity` to constrain its `bit` to be boolean, consuming one additional gate. This changes the verifier key of circuits calling it directly; `component_mul_point` is unaffected [#870]
 - Change `Composer::IDENTITY` to a `TorsionFreeWitnessPoint` [#870]
 - Change `append_constant_point` to validate the constant natively and return `Result<TorsionFreeWitnessPoint, Error>` [#870]
+- Change `append_point`, `append_public_point` and `assert_equal_public_point` to take `impl Into<JubJubExtended>` and return `Result<_, Error>`, rejecting an extended point with a zero `Z` coordinate with `Error::JubJubPointDegenerate`. Callers must handle the new `Result`; affine inputs can never reach the new error. The new bound does not accept `&JubJubExtended`, which the old one did through `From<&JubJubExtended> for JubJubAffine`, so call sites passing a reference — as the key and signature accessors across the ecosystem return one — need a `*` [#889]
+- Change `append_constant_point` to take `impl Into<JubJubExtended>` and reject a zero `Z` coordinate with `Error::JubJubPointDegenerate`. Its membership check now runs on the extended point rather than on the affine projection, so an inconsistent extended representation of an on-curve subgroup point is refused with `Error::JubJubPointNotTorsionFree` [#889]
 - Change `component_mul_generator` to return `Result<TorsionFreeWitnessPoint, Error>`, its generator being validated to exact prime order [#870]
 - Detect unsatisfied circuits during quotient computation and return
   `Error::CircuitUnsatisfied` instead of the misleading
@@ -733,6 +736,7 @@ is necessary since `rkyv/validation` was required as a bound.
 - Proof system module.
 
 <!-- ISSUES -->
+[#889]: https://github.com/dusk-network/plonk/issues/889
 [#884]: https://github.com/dusk-network/plonk/issues/884
 [#877]: https://github.com/dusk-network/plonk/issues/877
 [#870]: https://github.com/dusk-network/plonk/issues/870

--- a/benches/plonk.rs
+++ b/benches/plonk.rs
@@ -36,7 +36,7 @@ impl<const DEGREE: usize> Circuit for BenchCircuit<DEGREE> {
         let w_b = composer.append_witness(self.b);
         let w_x = composer.append_witness(self.x);
         let w_y = composer.append_witness(self.y);
-        let w_z = composer.append_point(self.z);
+        let w_z = composer.append_point(self.z)?;
 
         let mut diff = 0;
         let mut prev = composer.constraints();

--- a/examples/circuit.rs
+++ b/examples/circuit.rs
@@ -56,7 +56,7 @@ impl Circuit for TestCircuit {
         let e = composer.append_witness(self.e);
         let scalar_mul_result = composer
             .component_mul_generator(e, dusk_jubjub::GENERATOR_EXTENDED)?;
-        composer.assert_equal_public_point(scalar_mul_result.into(), self.f);
+        composer.assert_equal_public_point(scalar_mul_result.into(), self.f)?;
 
         Ok(())
     }

--- a/src/composer/point.rs
+++ b/src/composer/point.rs
@@ -26,15 +26,55 @@ pub(super) const EIGHT_INV: JubJubScalar = JubJubScalar::from_raw([
     0x01cfb69d4ca675f5,
 ]);
 
+/// Reject an extended point that has no affine image.
+///
+/// A `JubJubExtended` represents the affine point `(U/Z, V/Z)`, so `Z = 0`
+/// denotes no point at all. dusk-jubjub's projection inverts `Z` without
+/// checking it and aborts the process on zero, and it exposes no fallible
+/// conversion to defer to. The point entry points below therefore call this
+/// *before* projecting, and before `JubJubExtended::is_on_curve`: that
+/// predicate projects internally, so it would abort rather than reject.
+fn reject_degenerate_z(point: &JubJubExtended) -> Result<(), Error> {
+    if point.get_z() == BlsScalar::zero() {
+        return Err(Error::JubJubPointDegenerate);
+    }
+
+    Ok(())
+}
+
 /// Embedded-curve point gadgets
 impl Composer {
-    /// Appends a point in affine form as [`WitnessPoint`]
-    pub fn append_point<P: Into<JubJubAffine>>(
+    /// Appends a point as [`WitnessPoint`], its coordinates allocated as
+    /// private witnesses.
+    ///
+    /// The returned point is untyped, and allocation validates nothing beyond
+    /// the point being representable: neither the curve equation nor subgroup
+    /// membership is established here. For a prover-controlled point that is
+    /// [`Composer::assert_torsion_free_point`]'s job — see
+    /// [`TorsionFreeWitnessPoint`] for the boundary rule.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::JubJubPointDegenerate`] if `point` is an extended
+    /// point with a zero `Z` coordinate, which denotes no affine point.
+    pub fn append_point<P: Into<JubJubExtended>>(
         &mut self,
-        affine: P,
-    ) -> WitnessPoint {
-        let affine = affine.into();
+        point: P,
+    ) -> Result<WitnessPoint, Error> {
+        let point = point.into();
+        reject_degenerate_z(&point)?;
 
+        Ok(self.append_affine_point(JubJubAffine::from(point)))
+    }
+
+    /// Allocate the coordinates of an affine point as private witnesses.
+    ///
+    /// The in-crate seam behind [`Self::append_point`], taking the projected
+    /// point so gadgets that already hold one carry no error path.
+    pub(super) fn append_affine_point(
+        &mut self,
+        affine: JubJubAffine,
+    ) -> WitnessPoint {
         let x = self.append_witness(affine.get_u());
         let y = self.append_witness(affine.get_v());
 
@@ -49,21 +89,33 @@ impl Composer {
     /// [`Error::JubJubPointNotTorsionFree`] instead of baking an invalid
     /// group element into the circuit description. This is the constant-point
     /// arm of the boundary rule documented on [`TorsionFreeWitnessPoint`].
-    pub fn append_constant_point<P: Into<JubJubAffine>>(
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::JubJubPointDegenerate`] if `point` is an extended
+    /// point with a zero `Z` coordinate, which denotes no affine point.
+    ///
+    /// Returns [`Error::JubJubPointNotTorsionFree`] if `point` is not an
+    /// on-curve member of the prime-order subgroup.
+    pub fn append_constant_point<P: Into<JubJubExtended>>(
         &mut self,
-        affine: P,
+        point: P,
     ) -> Result<TorsionFreeWitnessPoint, Error> {
-        let affine = affine.into();
+        let point = point.into();
+        reject_degenerate_z(&point)?;
 
         // `is_torsion_free` alone accepts some off-curve coordinate pairs
         // (e.g. `(0, 0)`, which the order-multiplication ladder collapses
         // onto the identity), so the curve equation is checked separately.
-        let is_member = affine.is_on_curve()
-            & JubJubExtended::from(affine).is_torsion_free();
+        // Checked on the extended point, `is_on_curve` also ties `T1 · T2` to
+        // the affine coordinates, rejecting an inconsistent extended
+        // representation of an otherwise honest point.
+        let is_member = point.is_on_curve() & point.is_torsion_free();
         if !bool::from(is_member) {
             return Err(Error::JubJubPointNotTorsionFree);
         }
 
+        let affine = JubJubAffine::from(point);
         let x = self.append_constant(affine.get_u());
         let y = self.append_constant(affine.get_v());
 
@@ -72,35 +124,44 @@ impl Composer {
         )))
     }
 
-    /// Appends a point in affine form as [`WitnessPoint`]
+    /// Appends a point as [`WitnessPoint`]
     ///
     /// Creates two public inputs as `(x, y)`
     ///
     /// The returned point is untyped: whether a public point is a prime-order
     /// subgroup element is established outside the circuit, as part of the
-    /// verifier's protocol. A caller whose protocol performs that check can
-    /// wrap the result with [`TorsionFreeWitnessPoint::new_unchecked`]; see
+    /// verifier's protocol, so no membership check is performed here. A caller
+    /// whose protocol performs that check can wrap the result with
+    /// [`TorsionFreeWitnessPoint::new_unchecked`]; see
     /// [`TorsionFreeWitnessPoint`] for the boundary rule.
-    pub fn append_public_point<P: Into<JubJubAffine>>(
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::JubJubPointDegenerate`] if `point` is an extended
+    /// point with a zero `Z` coordinate, which denotes no affine point.
+    pub fn append_public_point<P: Into<JubJubExtended>>(
         &mut self,
-        affine: P,
-    ) -> WitnessPoint {
-        let affine = affine.into();
-        let point = self.append_point(affine);
+        point: P,
+    ) -> Result<WitnessPoint, Error> {
+        let point = point.into();
+        reject_degenerate_z(&point)?;
+
+        let affine = JubJubAffine::from(point);
+        let witness = self.append_affine_point(affine);
 
         self.assert_equal_constant(
-            *point.x(),
+            *witness.x(),
             BlsScalar::zero(),
             Some(affine.get_u()),
         );
 
         self.assert_equal_constant(
-            *point.y(),
+            *witness.y(),
             BlsScalar::zero(),
             Some(affine.get_v()),
         );
 
-        point
+        Ok(witness)
     }
 
     /// Asserts that the coordinates of the two points `a` and `b` are the same
@@ -113,12 +174,27 @@ impl Composer {
     /// Asserts `point == public`.
     ///
     /// Will add `public` affine coordinates `(x,y)` as public inputs
-    pub fn assert_equal_public_point<P: Into<JubJubAffine>>(
+    ///
+    /// `public` is compared against rather than allocated, but it is still
+    /// projected to read the two coordinates the public inputs carry, so the
+    /// representability guard applies exactly as it does when allocating. It
+    /// establishes no membership, matching [`Self::append_public_point`]: for
+    /// a public point that is the verifier's protocol to settle, and this
+    /// gadget constrains `point` to a value that protocol already covers.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::JubJubPointDegenerate`] if `public` is an extended
+    /// point with a zero `Z` coordinate, which denotes no affine point.
+    pub fn assert_equal_public_point<P: Into<JubJubExtended>>(
         &mut self,
         point: WitnessPoint,
         public: P,
-    ) {
+    ) -> Result<(), Error> {
         let public = public.into();
+        reject_degenerate_z(&public)?;
+
+        let public = JubJubAffine::from(public);
 
         self.assert_equal_constant(
             *point.x(),
@@ -131,6 +207,8 @@ impl Composer {
             BlsScalar::zero(),
             Some(public.get_v()),
         );
+
+        Ok(())
     }
 
     /// Constrain `point` to lie in the prime-order subgroup of the embedded
@@ -191,7 +269,7 @@ impl Composer {
         point: WitnessPoint,
         q: JubJubAffine,
     ) {
-        let q = self.append_point(q);
+        let q = self.append_affine_point(q);
         let qu = *q.x();
         let qv = *q.y();
 

--- a/src/composer/tests/soundness/fixed_base.rs
+++ b/src/composer/tests/soundness/fixed_base.rs
@@ -179,7 +179,7 @@ impl Circuit for FixedBaseCircuit {
                 digits,
             )?,
         };
-        composer.assert_equal_public_point(point, self.claimed_point);
+        composer.assert_equal_public_point(point, self.claimed_point)?;
         Ok(())
     }
 }

--- a/src/composer/tests/soundness/point.rs
+++ b/src/composer/tests/soundness/point.rs
@@ -231,7 +231,7 @@ fn honest_on_curve_row(composer: &mut Composer, q: WitnessPoint) {
 
 impl Circuit for TorsionFreeCircuit {
     fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
-        let point = composer.append_point(self.point);
+        let point = composer.append_point(self.point)?;
         match &self.mode {
             Mode::Honest => {
                 composer.assert_torsion_free_point(point);
@@ -241,7 +241,7 @@ impl Circuit for TorsionFreeCircuit {
                 // Mirror `assert_torsion_free_gates` gate for gate, with the
                 // three `gate_mul` outputs replaced by attacker witnesses.
                 // `assert_rejected` pins this mirror to the production layout.
-                let q = composer.append_point(*q);
+                let q = composer.append_point(*q)?;
                 let qu = *q.x();
                 let qv = *q.y();
                 let u2 = forged_mul(composer, qu, qu, *u2);
@@ -266,7 +266,7 @@ impl Circuit for TorsionFreeCircuit {
                 // Mirror `assert_torsion_free_gates` with only the first
                 // doubling's output witnesses forged to `s`; the remaining
                 // doublings run honestly from the forged point.
-                let q = composer.append_point(*q);
+                let q = composer.append_point(*q)?;
                 honest_on_curve_row(composer, q);
                 let q2 = forged_double(composer, q, *s);
                 let q4 = composer.add_point_gates(q2, q2);
@@ -328,7 +328,9 @@ fn torsion_free_layout_matches_golden() {
     ];
 
     let mut composer = Composer::initialized();
-    let point = composer.append_point(prime_order_point());
+    let point = composer
+        .append_point(prime_order_point())
+        .expect("honest point");
     composer.assert_torsion_free_point(point);
     assert_eq!(
         gate_digest(&composer.constraints),
@@ -356,7 +358,9 @@ fn mul_point_layout_matches_golden() {
 
     let mut composer = Composer::initialized();
     let scalar = composer.append_witness(JubJubScalar::from(17u64));
-    let point = composer.append_point(prime_order_point());
+    let point = composer
+        .append_point(prime_order_point())
+        .expect("honest point");
     let point = TorsionFreeWitnessPoint::new_unchecked(point);
     composer.component_mul_point(scalar, point);
     assert_eq!(
@@ -691,8 +695,8 @@ impl CurveAdditionCircuit {
 
 impl Circuit for CurveAdditionCircuit {
     fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
-        let a = composer.append_public_point(self.a);
-        let b = composer.append_public_point(self.b);
+        let a = composer.append_public_point(self.a)?;
+        let b = composer.append_public_point(self.b)?;
 
         // The addends are the generator and its double: subgroup constants, so
         // membership is established rather than merely vouched for, which is
@@ -734,7 +738,7 @@ impl Circuit for CurveAdditionCircuit {
             }
         };
 
-        composer.assert_equal_public_point(sum, self.claimed_sum);
+        composer.assert_equal_public_point(sum, self.claimed_sum)?;
 
         Ok(())
     }
@@ -893,8 +897,12 @@ fn component_add_point_layout_matches_golden() {
     ];
 
     let mut composer = Composer::initialized();
-    let a = composer.append_point(GENERATOR_EXTENDED);
-    let b = composer.append_point(GENERATOR_EXTENDED.double());
+    let a = composer
+        .append_point(GENERATOR_EXTENDED)
+        .expect("honest point");
+    let b = composer
+        .append_point(GENERATOR_EXTENDED.double())
+        .expect("honest point");
     composer.component_add_point(
         TorsionFreeWitnessPoint::new_unchecked(a),
         TorsionFreeWitnessPoint::new_unchecked(b),

--- a/src/error.rs
+++ b/src/error.rs
@@ -87,9 +87,14 @@ pub enum Error {
     /// This error occurs when a fixed-base generator is not a prime-order
     /// Jubjub point.
     JubJubGeneratorNotPrimeOrder,
-    /// This error occurs when a JubJub point that is not a member of the
-    /// prime-order subgroup is appended to a circuit as a constant.
+    /// This error occurs when a JubJub point appended to a circuit as a
+    /// constant is not an on-curve member of the prime-order subgroup in a
+    /// consistent extended representation.
     JubJubPointNotTorsionFree,
+    /// This error occurs when a JubJub point in extended coordinates has a
+    /// zero `Z` coordinate, denoting no affine point, and so cannot be
+    /// appended to a circuit or compared against.
+    JubJubPointDegenerate,
     /// WNAF2k should be in `[-1, 0, 1]`
     UnsupportedWNAF2k,
     /// The provided public inputs doesn't match the circuit definition
@@ -185,6 +190,10 @@ impl std::fmt::Display for Error {
             Self::JubJubPointNotTorsionFree => {
                 write!(f, "JubJub point is not in the prime-order subgroup")
             }
+            Self::JubJubPointDegenerate => write!(
+                f,
+                "JubJub point has a zero Z coordinate and denotes no affine point"
+            ),
             Self::BytesError(err) => write!(f, "{:?}", err),
             Self::UnsupportedWNAF2k => write!(
                 f,
@@ -238,7 +247,7 @@ mod tests {
         assert!(matches!(bytes_error, Error::BytesError(_)));
 
         // Format each variant at least once so the `Display` impl gets covered.
-        let all_errors: [Error; 25] = [
+        let all_errors: [Error; 26] = [
             Error::InvalidEvalDomainSize {
                 log_size_of_group: 32,
                 adacity: 28,
@@ -263,6 +272,7 @@ mod tests {
             Error::JubJubScalarMalformed,
             Error::JubJubGeneratorNotPrimeOrder,
             Error::JubJubPointNotTorsionFree,
+            Error::JubJubPointDegenerate,
             Error::UnsupportedWNAF2k,
             Error::InvalidCompressedCircuit,
             Error::LegacyProvingDisabled,

--- a/tests/assert_point.rs
+++ b/tests/assert_point.rs
@@ -35,8 +35,8 @@ fn assert_equal_point() {
 
     impl Circuit for TestCircuit {
         fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
-            let w_p1 = composer.append_point(self.p1);
-            let w_p2 = composer.append_point(self.p2);
+            let w_p1 = composer.append_point(self.p1)?;
+            let w_p2 = composer.append_point(self.p2)?;
             composer.assert_equal_point(w_p1, w_p2);
 
             Ok(())
@@ -124,8 +124,8 @@ fn assert_equal_public_point() {
 
     impl Circuit for TestCircuit {
         fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
-            let w_point = composer.append_point(self.point);
-            composer.assert_equal_public_point(w_point, self.public);
+            let w_point = composer.append_point(self.point)?;
+            composer.assert_equal_public_point(w_point, self.public)?;
 
             Ok(())
         }

--- a/tests/composer.rs
+++ b/tests/composer.rs
@@ -42,7 +42,7 @@ fn circuit_with_all_gates() {
             let w_b = composer.append_witness(self.b);
             let w_x = composer.append_witness(self.x);
             let w_y = composer.append_witness(self.y);
-            let w_z = composer.append_point(self.z);
+            let w_z = composer.append_point(self.z)?;
 
             let s = Constraint::new().mult(1).a(w_a).b(w_b);
 
@@ -50,13 +50,13 @@ fn circuit_with_all_gates() {
 
             composer.append_constant(15);
             composer.append_constant_point(self.z)?;
-            composer.append_public_point(self.z);
+            composer.append_public_point(self.z)?;
             composer.append_public(self.y);
 
             composer.assert_equal(w_x, r_w);
             composer.assert_equal_constant(w_x, 0, Some(self.x));
             composer.assert_equal_point(w_z, w_z);
-            composer.assert_equal_public_point(w_z, self.z);
+            composer.assert_equal_public_point(w_z, self.z)?;
 
             composer.gate_add(Constraint::new().left(1).right(1).a(w_a).b(w_b));
 

--- a/tests/ecc.rs
+++ b/tests/ecc.rs
@@ -41,9 +41,9 @@ fn component_add_point() {
 
     impl Circuit for TestCircuit {
         fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
-            let w_p1 = composer.append_point(self.p1);
-            let w_p2 = composer.append_point(self.p2);
-            let w_sum = composer.append_point(self.sum);
+            let w_p1 = composer.append_point(self.p1)?;
+            let w_p2 = composer.append_point(self.p2)?;
+            let w_sum = composer.append_point(self.sum)?;
 
             // The test inputs are multiples of the prime-order generator or
             // the identity, so subgroup membership holds by construction.
@@ -142,9 +142,9 @@ fn component_sub_point() {
 
     impl Circuit for TestCircuit {
         fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
-            let w_p1 = composer.append_point(self.p1);
-            let w_p2 = composer.append_point(self.p2);
-            let w_sub = composer.append_point(self.sub);
+            let w_p1 = composer.append_point(self.p1)?;
+            let w_p2 = composer.append_point(self.p2)?;
+            let w_sub = composer.append_point(self.sub)?;
 
             // The test inputs are multiples of the prime-order generator or
             // the identity, so subgroup membership holds by construction.
@@ -234,8 +234,8 @@ fn component_neg_point() {
 
     impl Circuit for TestCircuit {
         fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
-            let w_p = composer.append_point(self.p);
-            let w_neg_p = composer.append_point(self.neg_p);
+            let w_p = composer.append_point(self.p)?;
+            let w_neg_p = composer.append_point(self.neg_p)?;
 
             // The test inputs are multiples of the prime-order generator or
             // the identity, so subgroup membership holds by construction.
@@ -326,7 +326,7 @@ fn component_mul_generator() {
     impl Circuit for TestCircuit {
         fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
             let w_scalar = composer.append_witness(self.scalar);
-            let w_result = composer.append_point(self.result);
+            let w_result = composer.append_point(self.result)?;
 
             let circuit_result =
                 composer.component_mul_generator(w_scalar, self.generator)?;
@@ -658,6 +658,120 @@ fn component_mul_generator_accepts_prime_order_generator() {
     assert!(composer.component_mul_generator(scalar, generator).is_ok());
 }
 
+/// An extended point whose affine projection `(U/Z, V/Z)` is undefined:
+/// dusk-jubjub inverts `Z` unchecked and panics on zero. The numerators are
+/// the honest generator's coordinates, so nothing but the `Z` guard separates
+/// this input from a valid one — and `is_on_curve` cannot be what rejects it,
+/// since it projects internally and would panic first.
+fn zero_z_point() -> JubJubExtended {
+    let generator = JubJubAffine::from(dusk_jubjub::GENERATOR_EXTENDED);
+
+    JubJubExtended::from_raw_unchecked(
+        generator.get_u(),
+        generator.get_v(),
+        BlsScalar::zero(),
+        generator.get_u(),
+        generator.get_v(),
+    )
+}
+
+#[test]
+fn append_point_rejects_zero_z_point() {
+    let mut composer = Composer::initialized();
+
+    let result = composer.append_point(zero_z_point());
+
+    assert!(matches!(result, Err(Error::JubJubPointDegenerate)));
+}
+
+#[test]
+fn append_public_point_rejects_zero_z_point() {
+    let mut composer = Composer::initialized();
+
+    let result = composer.append_public_point(zero_z_point());
+
+    assert!(matches!(result, Err(Error::JubJubPointDegenerate)));
+}
+
+#[test]
+fn assert_equal_public_point_rejects_zero_z_point() {
+    let mut composer = Composer::initialized();
+    let point = composer
+        .append_point(dusk_jubjub::GENERATOR)
+        .expect("an honest generator should be appendable");
+
+    let result = composer.assert_equal_public_point(point, zero_z_point());
+
+    assert!(matches!(result, Err(Error::JubJubPointDegenerate)));
+}
+
+#[test]
+fn append_constant_point_separates_its_rejection_branches() {
+    let mut composer = Composer::initialized();
+
+    // Degenerate representation: refused before the membership check, which
+    // is the only order in which its `is_on_curve` half can run at all.
+    assert!(matches!(
+        composer.append_constant_point(zero_z_point()),
+        Err(Error::JubJubPointDegenerate)
+    ));
+
+    // Representable but outside the prime-order subgroup: the native
+    // membership check rejects it, and keeps its own error.
+    for (order, point) in torsion_points() {
+        assert_eq!(
+            composer.append_constant_point(point).unwrap_err(),
+            Error::JubJubPointNotTorsionFree,
+            "order {order}"
+        );
+    }
+}
+
+#[test]
+fn append_constant_point_rejects_inconsistent_extended_coordinates() {
+    let mut composer = Composer::initialized();
+    // The affine projection is the honest generator — on-curve and of prime
+    // order — while `T1 · T2 != U · V · Z`. Validating the extended point
+    // catches that; validating its projection, as the guard did while it sat
+    // after the conversion, would accept it.
+    let affine = JubJubAffine::from(dusk_jubjub::GENERATOR_EXTENDED);
+    let point = JubJubExtended::from_raw_unchecked(
+        affine.get_u(),
+        affine.get_v(),
+        BlsScalar::one(),
+        affine.get_u(),
+        affine.get_v() + BlsScalar::one(),
+    );
+    assert!(bool::from(JubJubAffine::from(point).is_on_curve()));
+    assert!(!bool::from(point.is_on_curve()));
+
+    let result = composer.append_constant_point(point);
+
+    assert!(matches!(result, Err(Error::JubJubPointNotTorsionFree)));
+}
+
+#[test]
+fn point_entry_points_accept_honest_points() {
+    let mut composer = Composer::initialized();
+    // An honest base other than `GENERATOR`, in both accepted input forms, so
+    // the rejection tests above cannot pass against entry points that refuse
+    // every point.
+    let extended =
+        dusk_jubjub::GENERATOR_EXTENDED * &JubJubScalar::from(0xdead_beef_u64);
+    let affine = JubJubAffine::from(extended);
+
+    let point = composer
+        .append_point(extended)
+        .expect("an honest point should be appendable");
+    assert!(composer.append_point(affine).is_ok());
+    assert!(composer.append_constant_point(extended).is_ok());
+    assert!(composer.append_constant_point(affine).is_ok());
+    assert!(composer.append_public_point(extended).is_ok());
+    assert!(composer.append_public_point(affine).is_ok());
+    assert!(composer.assert_equal_public_point(point, extended).is_ok());
+    assert!(composer.assert_equal_public_point(point, affine).is_ok());
+}
+
 #[test]
 fn component_mul_point() {
     pub struct TestCircuit {
@@ -697,8 +811,8 @@ fn component_mul_point() {
     impl Circuit for TestCircuit {
         fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
             let w_scalar = composer.append_witness(self.scalar);
-            let w_point = composer.append_point(self.point);
-            let w_result = composer.append_point(self.result);
+            let w_point = composer.append_point(self.point)?;
+            let w_result = composer.append_point(self.result)?;
 
             // The test base is a multiple of the prime-order generator, so
             // subgroup membership holds by construction.

--- a/tests/select_point.rs
+++ b/tests/select_point.rs
@@ -51,9 +51,9 @@ fn component_select_point() {
     impl Circuit for TestCircuit {
         fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
             let w_bit = composer.append_witness(self.bit);
-            let w_point_a = composer.append_point(self.point_a);
-            let w_point_b = composer.append_point(self.point_b);
-            let w_result = composer.append_point(self.result);
+            let w_point_a = composer.append_point(self.point_a)?;
+            let w_point_b = composer.append_point(self.point_b)?;
+            let w_result = composer.append_point(self.result)?;
 
             let result_circuit =
                 composer.component_select_point(w_bit, w_point_a, w_point_b);
@@ -243,8 +243,8 @@ fn component_select_identity() {
     impl Circuit for TestCircuit {
         fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
             let w_bit = composer.append_witness(self.bit);
-            let w_point = composer.append_point(self.point);
-            let w_result = composer.append_point(self.result);
+            let w_point = composer.append_point(self.point)?;
+            let w_result = composer.append_point(self.result)?;
 
             // The test inputs are multiples of the prime-order generator or
             // the identity, so subgroup membership holds by construction.


### PR DESCRIPTION
## Summary

`append_point`, `append_constant_point`, `append_public_point` and `assert_equal_public_point` accepted anything convertible into an affine point and did the conversion first. A `JubJubExtended` with `Z = 0` denotes no affine point, so the projection inverts zero and aborts the process — and nothing upstream of the four established that `Z` was nonzero.

All four now take `impl Into<JubJubExtended>` and guard `Z` before projecting, the shape `component_mul_generator` already uses. Narrowing to `JubJubAffine` would only have moved the same unwrap into callers, since no checked conversion exists to offer them.

`append_constant_point`'s membership check now runs on the extended point rather than on the projection, which additionally ties `T1 · T2` to the affine coordinates, so an inconsistent extended representation of an on-curve subgroup point is refused. The other three establish no membership, unchanged.

Two breaks for consumers: the new `Result`, and the bound no longer accepting a reference — call sites passing one need a `*`. Both are recorded in the CHANGELOG.

A second commit trims the unreleased changelog entries. They had grown into prose, restating consequences and rationale that the linked issues already carry, and each is reduced to what changed plus its issue link. That reaches beyond this change: entries belonging to #867, #870, #877 and #884 are shortened too, and two entries carrying two facts each are split rather than compressed. Entries contributed by others are left untouched.

Closes #889
