### PR TITLE
Implement Display and Error against core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `Composer::component_range_bits<BITS>` range check counting bits directly [#867]
 - Add the public `Error::JubJubGeneratorNotPrimeOrder` variant [#832]
 - Add `Error::CircuitUnsatisfied` [#877]
+- Add `Display` for `Error` to builds without the `std` feature [#895]
+- Add `core::error::Error` for `Error` to builds without the `std` feature [#895]
 
 ### Changed
 
@@ -734,6 +736,7 @@ is necessary since `rkyv/validation` was required as a bound.
 - Proof system module.
 
 <!-- ISSUES -->
+[#895]: https://github.com/dusk-network/plonk/issues/895
 [#890]: https://github.com/dusk-network/plonk/issues/890
 [#889]: https://github.com/dusk-network/plonk/issues/889
 [#887]: https://github.com/dusk-network/plonk/issues/887

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,9 @@
 
 //! A collection of all possible errors encountered in PLONK.
 
+use core::error::Error as CoreError;
+use core::fmt;
+
 use dusk_bytes::Error as DuskBytesError;
 
 /// Defines all possible errors that can be encountered in PLONK.
@@ -117,9 +120,8 @@ pub enum Error {
     UnsupportedProvingVersion,
 }
 
-#[cfg(feature = "std")]
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::InvalidEvalDomainSize {
                 log_size_of_group,
@@ -228,11 +230,14 @@ impl From<DuskBytesError> for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl CoreError for Error {}
 
-#[cfg(all(test, feature = "std"))]
+// The `Display` and `CoreError` impls above are unconditional; this module is
+// gated on `alloc` only because it renders through `to_string`.
+#[cfg(all(test, feature = "alloc"))]
 mod tests {
+    use alloc::string::ToString;
+
     use dusk_bls12_381::BlsScalar;
     use dusk_bytes::{DeserializableSlice, Serializable};
 
@@ -300,6 +305,12 @@ mod tests {
         );
 
         assert!(!bytes_error.to_string().is_empty());
+
+        let _as_core_error: &dyn CoreError = &Error::ProofVerificationError;
+        // Since Rust 1.81 `std::error::Error` is a re-export of
+        // `core::error::Error`, so the `core` impl is what a `std` consumer
+        // sees. This coercion fails to compile if that ever stops holding.
+        #[cfg(feature = "std")]
         let _as_std_error: &dyn std::error::Error =
             &Error::ProofVerificationError;
     }


### PR DESCRIPTION
## Summary

`mod error` and the prelude re-export of `Error` are unconditional, but `Display` and the error-trait impl were both behind `#[cfg(feature = "std")]`. A `--no-default-features` build — what `make no-std` exercises and what `dusk-core` consumes — got an `Error` it could neither print nor use as an error. #884 sharpened this by marking the type `#[non_exhaustive]`, so every downstream `match` needs a wildcard arm that, in a no_std build, had only `Debug` behind it.

Both impls are now unconditional and target `core`. The `Display` body writes only integers and `Debug` arguments, all of which `core::fmt` provides, and `core::error::Error` has been stable since Rust 1.81 against the crate's `rust-version = "1.85"`. Since that release `std::error::Error` is a re-export of the `core` trait, so `std` consumers see the same impl surface and the same rendered strings as before; the test asserts that coercion so a future divergence fails to compile.

The test module's `feature = "std"` gate outlived its reason and is now `feature = "alloc"`, which is what its body actually needs — it renders through `to_string`.

Purely additive: no variants added, renamed, or reworded, no feature definitions touched, and the orphan rule means no consumer can hold a conflicting impl.

Resolves #895
