### PR TITLE
Reject zero vanishing-coset evaluations when decoding Provers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reject zero vanishing-coset evaluations during checked `Prover`
+  deserialization [#898]
 - Reject degenerate KZG opening keys and rebuild archived prepared pairing
   values from their validated affine points before use [#887]
 - Bind `append_logic_xor`/`append_logic_and` output to their inputs [#867]
@@ -736,6 +738,7 @@ is necessary since `rkyv/validation` was required as a bound.
 - Proof system module.
 
 <!-- ISSUES -->
+[#898]: https://github.com/dusk-network/plonk/issues/898
 [#895]: https://github.com/dusk-network/plonk/issues/895
 [#890]: https://github.com/dusk-network/plonk/issues/890
 [#889]: https://github.com/dusk-network/plonk/issues/889

--- a/src/compiler/prover.rs
+++ b/src/compiler/prover.rs
@@ -651,6 +651,7 @@ mod tests {
 
     use super::Prover;
     use crate::error::Error;
+    use crate::fft::EvaluationDomain;
     use crate::prelude::{Circuit, Compiler, Composer, PublicParameters};
 
     #[derive(Default)]
@@ -749,6 +750,40 @@ mod tests {
             ..first_evaluations_offset + u64::SIZE + u32::SIZE]
             .copy_from_slice(&0u32.to_bytes());
         assert_deserialization_error_without_panic(&malformed_domain);
+    }
+
+    #[test]
+    fn prover_try_from_bytes_rejects_zero_vanishing_evaluation() {
+        let mut rng = StdRng::seed_from_u64(44);
+        let pp = PublicParameters::setup(1 << 10, &mut rng)
+            .expect("public parameters should build");
+        let (prover, _) = Compiler::compile::<MinimalCircuit>(&pp, b"p1.4-3")
+            .expect("circuit should compile");
+        let mut bytes = prover.to_bytes();
+
+        let label_len = u64::from_be_bytes(
+            bytes[..u64::SIZE].try_into().expect("header is complete"),
+        ) as usize;
+        let prover_key_len = u64::from_be_bytes(
+            bytes[u64::SIZE..2 * u64::SIZE]
+                .try_into()
+                .expect("header is complete"),
+        ) as usize;
+        let prover_key_offset = 6 * u64::SIZE + label_len;
+        let evaluations_size = u64::from_slice(
+            &bytes[prover_key_offset + u64::SIZE
+                ..prover_key_offset + 2 * u64::SIZE],
+        )
+        .expect("serialized evaluation size should decode")
+            as usize;
+        let first_vanishing_evaluation = prover_key_offset + prover_key_len
+            - evaluations_size
+            + EvaluationDomain::SIZE;
+        bytes[first_vanishing_evaluation
+            ..first_vanishing_evaluation + BlsScalar::SIZE]
+            .fill(0);
+
+        assert_deserialization_error_without_panic(&bytes);
     }
 
     #[test]

--- a/src/proof_system/widget.rs
+++ b/src/proof_system/widget.rs
@@ -554,6 +554,9 @@ pub(crate) mod alloc {
             let perm_linear_evaluations = evals_from_reader(&mut buffer)?;
 
             let v_h_coset_8n = evals_from_reader(&mut buffer)?;
+            if v_h_coset_8n.evals.contains(&BlsScalar::zero()) {
+                return Err(dusk_bytes::Error::InvalidData.into());
+            }
 
             let arithmetic = arithmetic::ProverKey {
                 q_m,
@@ -743,6 +746,20 @@ mod test {
         assert!(matches!(
             ProverKey::from_slice(truncated),
             Err(Error::NotEnoughBytes)
+        ));
+    }
+
+    #[test]
+    fn prover_key_rejects_zero_vanishing_evaluation() {
+        let n = 1 << 3;
+        let evaluations_domain =
+            EvaluationDomain::new(8 * n).expect("8n domain should be valid");
+        let mut prover_key = prover_key(n, evaluations_domain);
+        prover_key.v_h_coset_8n.evals[0] = BlsScalar::zero();
+
+        assert!(matches!(
+            ProverKey::from_slice(&prover_key.to_var_bytes()),
+            Err(Error::BytesError(dusk_bytes::Error::InvalidData))
         ));
     }
 


### PR DESCRIPTION
## Summary

Reject zero cached vanishing-coset evaluations during checked `Prover` deserialization so quotient construction cannot try to invert zero and panic.

## Validation

- `make fmt`
- `make clippy`
- `make no-std`
- `make test`

Resolves #898
