### PR TITLE
Reject empty commitment keys when decoding Provers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reject zero vanishing-coset evaluations during checked `Prover`
   deserialization [#898]
+- Reject empty commitment keys during checked `Prover` deserialization [#897]
 - Reject degenerate KZG opening keys and rebuild archived prepared pairing
   values from their validated affine points before use [#887]
 - Bind `append_logic_xor`/`append_logic_and` output to their inputs [#867]
@@ -739,6 +740,7 @@ is necessary since `rkyv/validation` was required as a bound.
 
 <!-- ISSUES -->
 [#898]: https://github.com/dusk-network/plonk/issues/898
+[#897]: https://github.com/dusk-network/plonk/issues/897
 [#895]: https://github.com/dusk-network/plonk/issues/895
 [#890]: https://github.com/dusk-network/plonk/issues/890
 [#889]: https://github.com/dusk-network/plonk/issues/889

--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -112,6 +112,10 @@ impl CommitKey {
         len.copy_from_slice(&bytes[..u64::SIZE]);
         let len = u64::from_le_bytes(len) as usize;
 
+        if len == 0 {
+            return Err(dusk_bytes::Error::InvalidData.into());
+        }
+
         let expected_len = u64::SIZE
             .checked_add(
                 len.checked_mul(G1Affine::RAW_SIZE)
@@ -905,6 +909,14 @@ mod test {
             Err(Error::NotEnoughBytes)
         ));
         Ok(())
+    }
+
+    #[test]
+    fn commit_key_bytes_raw_checked_rejects_empty() {
+        assert!(matches!(
+            CommitKey::from_raw_var_bytes(&0u64.to_le_bytes()),
+            Err(Error::BytesError(dusk_bytes::Error::InvalidData))
+        ));
     }
 
     #[test]

--- a/src/compiler/prover.rs
+++ b/src/compiler/prover.rs
@@ -689,6 +689,40 @@ mod tests {
     }
 
     #[test]
+    fn prover_try_from_bytes_rejects_empty_inner_commit_key() {
+        let mut rng = StdRng::seed_from_u64(44);
+        let pp = PublicParameters::setup(1 << 10, &mut rng)
+            .expect("public parameters should build");
+        let (prover, _) = Compiler::compile::<MinimalCircuit>(&pp, b"p1.4-3")
+            .expect("circuit should compile");
+        let bytes = prover.to_bytes();
+
+        let label_len = u64::from_be_bytes(
+            bytes[..u64::SIZE].try_into().expect("header is complete"),
+        ) as usize;
+        let prover_key_len = u64::from_be_bytes(
+            bytes[u64::SIZE..2 * u64::SIZE]
+                .try_into()
+                .expect("header is complete"),
+        ) as usize;
+        let commit_key_len = u64::from_be_bytes(
+            bytes[2 * u64::SIZE..3 * u64::SIZE]
+                .try_into()
+                .expect("header is complete"),
+        ) as usize;
+        let commit_key_offset = 6 * u64::SIZE + label_len + prover_key_len;
+        let verifier_key_offset = commit_key_offset + commit_key_len;
+
+        let mut malformed = bytes[..commit_key_offset].to_vec();
+        malformed.extend_from_slice(&0u64.to_le_bytes());
+        malformed.extend_from_slice(&bytes[verifier_key_offset..]);
+        malformed[2 * u64::SIZE..3 * u64::SIZE]
+            .copy_from_slice(&(u64::SIZE as u64).to_be_bytes());
+
+        assert_deserialization_error_without_panic(&malformed);
+    }
+
+    #[test]
     fn prover_try_from_bytes_rejects_malformed_inner_key_without_panicking() {
         let mut rng = StdRng::seed_from_u64(43);
         let pp = PublicParameters::setup(1 << 10, &mut rng)


### PR DESCRIPTION
## Summary

Reject empty commitment keys during checked `Prover` deserialization so malformed artifacts cannot reach `CommitKey::max_degree` and panic.

## Validation

- `make fmt`
- `make clippy`
- `make no-std`
- `make test`

Resolves #897
