### PR TITLE
Validate cached vanishing evaluations when decoding Provers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Validate cached vanishing-coset evaluations during checked `Prover`
+  deserialization [#902]
 - Reject zero vanishing-coset evaluations during checked `Prover`
   deserialization [#898]
 - Reject empty commitment keys during checked `Prover` deserialization [#897]
@@ -739,6 +741,7 @@ is necessary since `rkyv/validation` was required as a bound.
 - Proof system module.
 
 <!-- ISSUES -->
+[#902]: https://github.com/dusk-network/plonk/issues/902
 [#898]: https://github.com/dusk-network/plonk/issues/898
 [#897]: https://github.com/dusk-network/plonk/issues/897
 [#895]: https://github.com/dusk-network/plonk/issues/895

--- a/src/compiler/prover.rs
+++ b/src/compiler/prover.rs
@@ -821,6 +821,45 @@ mod tests {
     }
 
     #[test]
+    fn prover_try_from_bytes_rejects_incorrect_nonzero_vanishing_evaluation() {
+        let mut rng = StdRng::seed_from_u64(45);
+        let pp = PublicParameters::setup(1 << 10, &mut rng)
+            .expect("public parameters should build");
+        let (prover, _) = Compiler::compile::<MinimalCircuit>(&pp, b"p1.4-3")
+            .expect("circuit should compile");
+        let mut bytes = prover.to_bytes();
+
+        let label_len = u64::from_be_bytes(
+            bytes[..u64::SIZE].try_into().expect("header is complete"),
+        ) as usize;
+        let prover_key_len = u64::from_be_bytes(
+            bytes[u64::SIZE..2 * u64::SIZE]
+                .try_into()
+                .expect("header is complete"),
+        ) as usize;
+        let prover_key_offset = 6 * u64::SIZE + label_len;
+        let evaluations_size = u64::from_slice(
+            &bytes[prover_key_offset + u64::SIZE
+                ..prover_key_offset + 2 * u64::SIZE],
+        )
+        .expect("serialized evaluation size should decode")
+            as usize;
+        let first_vanishing_evaluation = prover_key_offset + prover_key_len
+            - evaluations_size
+            + EvaluationDomain::SIZE;
+        let second_vanishing_evaluation =
+            first_vanishing_evaluation + BlsScalar::SIZE;
+        let replacement = bytes[second_vanishing_evaluation
+            ..second_vanishing_evaluation + BlsScalar::SIZE]
+            .to_vec();
+        bytes[first_vanishing_evaluation
+            ..first_vanishing_evaluation + BlsScalar::SIZE]
+            .copy_from_slice(&replacement);
+
+        assert_deserialization_error_without_panic(&bytes);
+    }
+
+    #[test]
     fn prover_try_from_bytes_rejects_overflow_lengths_without_panicking() {
         let mut bytes = Vec::with_capacity(48);
         bytes.extend_from_slice(&0u64.to_be_bytes()); // label_len

--- a/src/fft/domain.rs
+++ b/src/fft/domain.rs
@@ -295,21 +295,36 @@ pub(crate) mod alloc {
             &self,            // domain to evaluate over
             poly_degree: u64, // degree of the vanishing polynomial
         ) -> Evaluations {
-            assert!((self.size() as u64) > poly_degree);
-            let coset_gen = GENERATOR.pow(&[poly_degree, 0, 0, 0]);
-            let v_h: Vec<_> = (0..self.size())
-                .map(|i| {
-                    (coset_gen
-                        * self.group_gen.pow(&[
-                            poly_degree * i as u64,
-                            0,
-                            0,
-                            0,
-                        ]))
-                        - BlsScalar::one()
-                })
-                .collect();
+            let v_h = self.vanishing_poly_over_coset(poly_degree).collect();
             Evaluations::from_vec_and_domain(v_h, *self)
+        }
+
+        pub(crate) fn matches_vanishing_poly_over_coset(
+            &self,
+            poly_degree: u64,
+            evaluations: &[BlsScalar],
+        ) -> bool {
+            poly_degree < self.size() as u64
+                && evaluations.len() == self.size()
+                && evaluations
+                    .iter()
+                    .copied()
+                    .eq(self.vanishing_poly_over_coset(poly_degree))
+        }
+
+        fn vanishing_poly_over_coset(
+            &self,
+            poly_degree: u64,
+        ) -> impl Iterator<Item = BlsScalar> {
+            assert!((self.size() as u64) > poly_degree);
+            let mut point = GENERATOR.pow(&[poly_degree, 0, 0, 0]);
+            let step = self.group_gen.pow(&[poly_degree, 0, 0, 0]);
+
+            (0..self.size()).map(move |_| {
+                let evaluation = point - BlsScalar::one();
+                point *= step;
+                evaluation
+            })
         }
 
         /// Return an iterator over the elements of the domain.
@@ -402,6 +417,8 @@ pub(crate) mod alloc {
 #[cfg(test)]
 #[cfg(feature = "alloc")]
 mod tests {
+    use dusk_bls12_381::GENERATOR;
+
     use super::*;
 
     #[test]
@@ -423,6 +440,36 @@ mod tests {
                 assert_eq!(element, domain.group_gen.pow(&[i as u64, 0, 0, 0]));
             }
         }
+    }
+
+    #[test]
+    fn vanishing_coset_evaluations_match_closed_form() {
+        let domain = EvaluationDomain::new(1 << 8).unwrap();
+        let poly_degree = 1 << 5;
+        let evaluations = domain.compute_vanishing_poly_over_coset(poly_degree);
+        let coset_generator = GENERATOR.pow(&[poly_degree, 0, 0, 0]);
+
+        for (i, evaluation) in evaluations.evals.iter().enumerate() {
+            let expected = coset_generator
+                * domain.group_gen.pow(&[poly_degree * i as u64, 0, 0, 0])
+                - BlsScalar::one();
+            assert_eq!(*evaluation, expected);
+        }
+    }
+
+    #[test]
+    fn vanishing_coset_evaluations_reject_invalid_degree() {
+        let domain = EvaluationDomain::new(1 << 8).unwrap();
+        let evaluations = vec![BlsScalar::zero(); domain.size()];
+
+        assert!(!domain.matches_vanishing_poly_over_coset(
+            domain.size() as u64,
+            &evaluations,
+        ));
+        assert!(!domain.matches_vanishing_poly_over_coset(
+            domain.size() as u64 + 1,
+            &evaluations,
+        ));
     }
 
     #[test]

--- a/src/proof_system/widget.rs
+++ b/src/proof_system/widget.rs
@@ -554,7 +554,12 @@ pub(crate) mod alloc {
             let perm_linear_evaluations = evals_from_reader(&mut buffer)?;
 
             let v_h_coset_8n = evals_from_reader(&mut buffer)?;
-            if v_h_coset_8n.evals.contains(&BlsScalar::zero()) {
+            let poly_degree =
+                u64::try_from(n).map_err(|_| dusk_bytes::Error::InvalidData)?;
+            if !evaluations_domain.matches_vanishing_poly_over_coset(
+                poly_degree,
+                &v_h_coset_8n.evals,
+            ) {
                 return Err(dusk_bytes::Error::InvalidData.into());
             }
 
@@ -661,7 +666,8 @@ mod test {
         let s_sigma_4 = poly_eval(n, evaluations_domain);
         let linear_evaluations = evaluations(evaluations_domain);
 
-        let v_h_coset_8n = evaluations(evaluations_domain);
+        let v_h_coset_8n =
+            evaluations_domain.compute_vanishing_poly_over_coset(n as u64);
 
         let arithmetic = arithmetic::ProverKey {
             q_m,
@@ -756,6 +762,38 @@ mod test {
             EvaluationDomain::new(8 * n).expect("8n domain should be valid");
         let mut prover_key = prover_key(n, evaluations_domain);
         prover_key.v_h_coset_8n.evals[0] = BlsScalar::zero();
+
+        assert!(matches!(
+            ProverKey::from_slice(&prover_key.to_var_bytes()),
+            Err(Error::BytesError(dusk_bytes::Error::InvalidData))
+        ));
+    }
+
+    #[test]
+    fn prover_key_rejects_incorrect_nonzero_vanishing_evaluation() {
+        let n = 1 << 3;
+        let evaluations_domain =
+            EvaluationDomain::new(8 * n).expect("8n domain should be valid");
+        let mut prover_key = prover_key(n, evaluations_domain);
+        prover_key.v_h_coset_8n.evals[0] = prover_key.v_h_coset_8n.evals[1];
+
+        assert!(matches!(
+            ProverKey::from_slice(&prover_key.to_var_bytes()),
+            Err(Error::BytesError(dusk_bytes::Error::InvalidData))
+        ));
+    }
+
+    #[test]
+    fn prover_key_rejects_scaled_vanishing_evaluations() {
+        let n = 1 << 3;
+        let evaluations_domain =
+            EvaluationDomain::new(8 * n).expect("8n domain should be valid");
+        let mut prover_key = prover_key(n, evaluations_domain);
+        prover_key
+            .v_h_coset_8n
+            .evals
+            .iter_mut()
+            .for_each(|evaluation| *evaluation *= BlsScalar::from(2u64));
 
         assert!(matches!(
             ProverKey::from_slice(&prover_key.to_var_bytes()),


### PR DESCRIPTION
## Summary

Validate cached vanishing-coset evaluations against the values derived from the reconstructed domain during checked `Prover` deserialization. The shared recurrence avoids allocating a second evaluation table and replaces the previous per-entry exponentiation used during compilation.

## Validation

- `make fmt`
- `make clippy`
- `make no-std`
- `make test`

Resolves #902
