### PR TITLE
Validate commitment keys in RKYV public parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change RKYV `PublicParameters` archives to store only canonical opening-key
-  source points and rebuild prepared pairing values during deserialization.
-  Existing RKYV parameter archives must be regenerated [#890]
+- Change RKYV `CommitKey` and `PublicParameters` archives to store canonical
+  compressed commitment- and opening-key source points and rebuild prepared
+  pairing values during deserialization. Existing RKYV parameter archives
+  must be regenerated [#890] [#903]
 - Mark `Error` as `#[non_exhaustive]` [#884]
 - Remove the `Copy` derive from `Error` [#884]
 - Change `component_add_point`, `component_sub_point` and `component_mul_point` to `TorsionFreeWitnessPoint` [#870]
@@ -66,6 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Validate cached vanishing-coset evaluations during checked `Prover`
   deserialization [#902]
+- Validate nonempty, canonically encoded, on-curve, prime-order KZG commitment
+  keys during checked RKYV `PublicParameters` deserialization [#903]
 - Reject zero vanishing-coset evaluations during checked `Prover`
   deserialization [#898]
 - Reject empty commitment keys during checked `Prover` deserialization [#897]
@@ -742,6 +745,7 @@ is necessary since `rkyv/validation` was required as a bound.
 
 <!-- ISSUES -->
 [#902]: https://github.com/dusk-network/plonk/issues/902
+[#903]: https://github.com/dusk-network/plonk/issues/903
 [#898]: https://github.com/dusk-network/plonk/issues/898
 [#897]: https://github.com/dusk-network/plonk/issues/897
 [#895]: https://github.com/dusk-network/plonk/issues/895

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ std = [
 ]
 alloc = ["dusk-bls12_381/alloc", "msgpacker", "miniz_oxide", "sha2"]
 debug = ["dusk-cdf", "backtrace"]
-rkyv-impl = ["dusk-bls12_381/rkyv-impl", "dusk-jubjub/rkyv-impl", "rkyv", "bytecheck"]
+rkyv-impl = ["dusk-bls12_381/rkyv-impl", "dusk-jubjub/rkyv-impl", "rkyv", "rkyv/validation", "bytecheck"]
 
 [profile.release]
 panic = "abort"

--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -19,6 +19,8 @@ use merlin::Transcript;
 use rkyv::{
     Archive, Deserialize, Fallible, Serialize,
     ser::{ScratchSpace, Serializer},
+    validation::ArchiveContext,
+    vec::ArchivedVec,
     with::{ArchiveWith, DeserializeWith, SerializeWith},
 };
 
@@ -32,17 +34,169 @@ use crate::util;
 /// CommitKey is used to commit to a polynomial which is bounded by the
 /// max_degree.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "rkyv-impl",
-    derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
-    archive_attr(derive(CheckBytes))
-)]
 pub struct CommitKey {
     /// Group elements of the form `{ \beta^i G }`, where `i` ranges from 0 to
     /// `degree`.
-    #[cfg_attr(feature = "rkyv-impl", omit_bounds)]
     pub(crate) powers_of_g: Vec<G1Affine>,
+}
+
+#[cfg(feature = "rkyv-impl")]
+#[derive(Archive, Serialize)]
+#[archive(bound(serialize = "__S: Serializer + ScratchSpace"))]
+#[doc(hidden)]
+pub struct CommitKeyArchive {
+    pub(crate) powers_of_g: Vec<[u8; G1Affine::SIZE]>,
+}
+
+#[cfg(feature = "rkyv-impl")]
+impl From<&CommitKey> for CommitKeyArchive {
+    fn from(key: &CommitKey) -> Self {
+        Self {
+            powers_of_g: key
+                .powers_of_g
+                .iter()
+                .map(G1Affine::to_bytes)
+                .collect(),
+        }
+    }
+}
+
+#[cfg(feature = "rkyv-impl")]
+#[derive(Debug)]
+pub struct InvalidArchivedCommitKey;
+
+#[cfg(feature = "rkyv-impl")]
+impl core::fmt::Display for InvalidArchivedCommitKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("invalid archived KZG commitment key")
+    }
+}
+
+#[cfg(feature = "rkyv-impl")]
+impl core::error::Error for InvalidArchivedCommitKey {}
+
+#[cfg(feature = "rkyv-impl")]
+fn archived_g1_is_valid(bytes: &[u8; G1Affine::SIZE]) -> bool {
+    G1Affine::from_slice(bytes).is_ok()
+}
+
+#[cfg(feature = "rkyv-impl")]
+fn decode_validated_archived_g1(bytes: &[u8; G1Affine::SIZE]) -> G1Affine {
+    // `CheckBytes` has already established subgroup membership. Rebuilding
+    // through the canonical encoding still checks its field and flag format,
+    // while avoiding a duplicate subgroup check.
+    Option::from(G1Affine::from_compressed_unchecked(bytes))
+        .expect("commitment key archive must be validated")
+}
+
+#[cfg(all(feature = "rkyv-impl", feature = "std"))]
+fn archived_commit_key_points_are_valid(
+    powers: &ArchivedVec<[u8; G1Affine::SIZE]>,
+) -> bool {
+    use rayon::prelude::*;
+
+    powers.par_iter().all(archived_g1_is_valid)
+}
+
+#[cfg(all(feature = "rkyv-impl", not(feature = "std")))]
+fn archived_commit_key_points_are_valid(
+    powers: &ArchivedVec<[u8; G1Affine::SIZE]>,
+) -> bool {
+    powers.iter().all(archived_g1_is_valid)
+}
+
+#[cfg(feature = "rkyv-impl")]
+impl<C> CheckBytes<C> for ArchivedCommitKeyArchive
+where
+    C: ArchiveContext + ?Sized,
+    C::Error: bytecheck::Error,
+{
+    type Error = InvalidArchivedCommitKey;
+
+    unsafe fn check_bytes<'a>(
+        value: *const Self,
+        context: &mut C,
+    ) -> Result<&'a Self, Self::Error> {
+        let powers = unsafe {
+            ArchivedVec::<[u8; G1Affine::SIZE]>::check_bytes(
+                core::ptr::addr_of!((*value).powers_of_g),
+                context,
+            )
+        }
+        .map_err(|_| InvalidArchivedCommitKey)?;
+
+        if powers.is_empty() {
+            return Err(InvalidArchivedCommitKey);
+        }
+
+        if !archived_commit_key_points_are_valid(powers) {
+            return Err(InvalidArchivedCommitKey);
+        }
+
+        Ok(unsafe { &*value })
+    }
+}
+
+#[cfg(feature = "rkyv-impl")]
+impl Archive for CommitKey {
+    type Archived = ArchivedCommitKeyArchive;
+    type Resolver = CommitKeyArchiveResolver;
+
+    unsafe fn resolve(
+        &self,
+        pos: usize,
+        resolver: Self::Resolver,
+        out: *mut Self::Archived,
+    ) {
+        let (field_pos, field_out) = rkyv::out_field!(out.powers_of_g);
+        unsafe {
+            ArchivedVec::resolve_from_len(
+                self.powers_of_g.len(),
+                pos + field_pos,
+                resolver.powers_of_g,
+                field_out,
+            );
+        }
+    }
+}
+
+#[cfg(feature = "rkyv-impl")]
+impl<S> Serialize<S> for CommitKey
+where
+    S: Serializer + ScratchSpace + ?Sized,
+{
+    fn serialize(
+        &self,
+        serializer: &mut S,
+    ) -> Result<Self::Resolver, S::Error> {
+        CommitKeyArchive::from(self).serialize(serializer)
+    }
+}
+
+#[cfg(feature = "rkyv-impl")]
+impl<D> Deserialize<CommitKey, D> for ArchivedCommitKeyArchive
+where
+    D: Fallible + ?Sized,
+{
+    fn deserialize(&self, _: &mut D) -> Result<CommitKey, D::Error> {
+        #[cfg(feature = "std")]
+        let powers_of_g = {
+            use rayon::prelude::*;
+
+            self.powers_of_g
+                .par_iter()
+                .map(decode_validated_archived_g1)
+                .collect()
+        };
+        #[cfg(not(feature = "std"))]
+        let powers_of_g = self
+            .powers_of_g
+            .iter()
+            .map(decode_validated_archived_g1)
+            .collect();
+
+        Ok(CommitKey { powers_of_g })
+    }
 }
 
 impl CommitKey {
@@ -862,6 +1016,47 @@ mod test {
 
         assert_eq!(commit_key.powers_of_g, ck_bytes_safe.powers_of_g);
         Ok(())
+    }
+
+    #[cfg(feature = "rkyv-impl")]
+    #[test]
+    fn commit_key_rkyv_round_trip_rejects_malformed_points() {
+        const BASE_FIELD_MODULUS: [u64; 6] = [
+            0xb9fe_ffff_ffff_aaab,
+            0x1eab_fffe_b153_ffff,
+            0x6730_d2a0_f6b0_f624,
+            0x6477_4b84_f385_12bf,
+            0x4b1b_a7b6_434b_acd7,
+            0x1a01_11ea_397f_e69a,
+        ];
+
+        let (commit_key, _) = setup_test(11).unwrap();
+        let mut bytes = rkyv::to_bytes::<_, 256>(&commit_key).unwrap();
+        let archived = unsafe { rkyv::archived_root::<CommitKey>(&bytes) };
+        let point = &archived.powers_of_g[0];
+        let point_offset = point as *const _ as usize - bytes.as_ptr() as usize;
+
+        let decoded = rkyv::from_bytes::<CommitKey>(&bytes).unwrap();
+        assert_eq!(decoded, commit_key);
+
+        bytes[point_offset] &= 0x7f;
+        let result =
+            std::panic::catch_unwind(|| rkyv::from_bytes::<CommitKey>(&bytes));
+        assert!(result.is_ok(), "checked deserialization must not panic");
+        assert!(result.expect("checked above").is_err());
+
+        let point = &mut bytes[point_offset..point_offset + G1Affine::SIZE];
+        for (chunk, limb) in point
+            .chunks_exact_mut(8)
+            .zip(BASE_FIELD_MODULUS.iter().rev())
+        {
+            chunk.copy_from_slice(&limb.to_be_bytes());
+        }
+        point[0] |= 0x80;
+        let result =
+            std::panic::catch_unwind(|| rkyv::from_bytes::<CommitKey>(&bytes));
+        assert!(result.is_ok(), "checked deserialization must not panic");
+        assert!(result.expect("checked above").is_err());
     }
 
     #[test]

--- a/src/commitment_scheme/kzg10/srs.rs
+++ b/src/commitment_scheme/kzg10/srs.rs
@@ -217,6 +217,21 @@ mod test {
     use super::*;
     #[cfg(feature = "rkyv-impl")]
     use crate::fft::Polynomial;
+    #[cfg(feature = "rkyv-impl")]
+    use crate::prelude::{Circuit, Compiler, Composer};
+
+    #[cfg(feature = "rkyv-impl")]
+    #[derive(Default)]
+    struct ArchivedParametersCircuit;
+
+    #[cfg(feature = "rkyv-impl")]
+    impl Circuit for ArchivedParametersCircuit {
+        fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
+            let bit = composer.append_witness(BlsScalar::one());
+            composer.component_boolean(bit);
+            Ok(())
+        }
+    }
 
     #[cfg(feature = "rkyv-impl")]
     #[derive(Archive, Serialize)]
@@ -245,6 +260,25 @@ mod test {
     }
 
     #[cfg(feature = "rkyv-impl")]
+    #[derive(Archive, Serialize)]
+    #[archive(bound(serialize = "__S: Serializer + ScratchSpace"))]
+    struct RawCommitKey {
+        #[omit_bounds]
+        powers_of_g: Vec<G1Affine>,
+    }
+
+    #[cfg(feature = "rkyv-impl")]
+    #[derive(Archive, Serialize)]
+    #[archive(bound(serialize = "__S: Serializer + ScratchSpace"))]
+    struct RawPublicParameters {
+        #[omit_bounds]
+        commit_key: RawCommitKey,
+        #[omit_bounds]
+        #[with(OpeningKeyRkyv)]
+        opening_key: OpeningKey,
+    }
+
+    #[cfg(feature = "rkyv-impl")]
     impl From<&PublicParameters> for LegacyPublicParameters {
         fn from(parameters: &PublicParameters) -> Self {
             let key = &parameters.opening_key;
@@ -257,6 +291,18 @@ mod test {
                     prepared_h: key.prepared_h.clone(),
                     prepared_x_h: key.prepared_x_h.clone(),
                 },
+            }
+        }
+    }
+
+    #[cfg(feature = "rkyv-impl")]
+    impl From<&PublicParameters> for RawPublicParameters {
+        fn from(parameters: &PublicParameters) -> Self {
+            Self {
+                commit_key: RawCommitKey {
+                    powers_of_g: parameters.commit_key.powers_of_g.clone(),
+                },
+                opening_key: parameters.opening_key.clone(),
             }
         }
     }
@@ -315,6 +361,47 @@ mod test {
 
         let bytes = rkyv::to_bytes::<_, 256>(&pp).unwrap();
         assert!(rkyv::from_bytes::<PublicParameters>(&bytes).is_err());
+    }
+
+    #[cfg(feature = "rkyv-impl")]
+    fn assert_archived_commit_key_rejected(
+        mutate: impl FnOnce(&mut CommitKey),
+    ) {
+        let mut pp = PublicParameters::setup(8, &mut OsRng).unwrap();
+        mutate(&mut pp.commit_key);
+
+        let bytes = rkyv::to_bytes::<_, 256>(&pp).unwrap();
+        assert_archived_parameters_rejected_without_panic(&bytes);
+    }
+
+    #[cfg(feature = "rkyv-impl")]
+    fn first_archived_commitment_point_offset(bytes: &[u8]) -> usize {
+        let parameters =
+            unsafe { rkyv::archived_root::<PublicParameters>(bytes) };
+        let point = &parameters.commit_key.powers_of_g[0];
+        point as *const _ as usize - bytes.as_ptr() as usize
+    }
+
+    #[cfg(feature = "rkyv-impl")]
+    fn assert_archived_parameters_rejected_without_panic(bytes: &[u8]) {
+        let result = std::panic::catch_unwind(|| {
+            rkyv::from_bytes::<PublicParameters>(bytes)
+        });
+        assert!(result.is_ok(), "checked deserialization must not panic");
+        assert!(
+            result.expect("checked above").is_err(),
+            "malformed parameters must be rejected"
+        );
+    }
+
+    #[cfg(feature = "rkyv-impl")]
+    #[test]
+    fn rkyv_rejects_legacy_raw_commitment_key_layout_without_panicking() {
+        let pp = PublicParameters::setup(8, &mut OsRng).unwrap();
+        let bytes =
+            rkyv::to_bytes::<_, 256>(&RawPublicParameters::from(&pp)).unwrap();
+
+        assert_archived_parameters_rejected_without_panic(&bytes);
     }
 
     #[cfg(feature = "rkyv-impl")]
@@ -391,6 +478,41 @@ mod test {
         assert_eq!(pp.opening_key.g, pp_p.opening_key.g);
         assert_eq!(pp.opening_key.h, pp_p.opening_key.h);
         assert_eq!(pp.opening_key.x_h, pp_p.opening_key.x_h);
+    }
+
+    #[cfg(feature = "rkyv-impl")]
+    #[test]
+    fn rkyv_rejects_empty_archived_commit_key() {
+        assert_archived_commit_key_rejected(|key| key.powers_of_g.clear());
+    }
+
+    #[cfg(feature = "rkyv-impl")]
+    #[test]
+    fn rkyv_rejects_invalid_archived_commit_key_points() {
+        let pp = PublicParameters::setup(8, &mut OsRng).unwrap();
+        let mut bytes = rkyv::to_bytes::<_, 256>(&pp).unwrap();
+        let point = first_archived_commitment_point_offset(&bytes);
+        bytes[point] &= 0x7f;
+        assert_archived_parameters_rejected_without_panic(&bytes);
+
+        assert_archived_commit_key_rejected(|key| {
+            key.powers_of_g[0] = non_torsion_g1();
+        });
+    }
+
+    #[cfg(feature = "rkyv-impl")]
+    #[test]
+    fn rkyv_commit_key_round_trip_compiles_circuit() {
+        let pp = PublicParameters::setup(16, &mut OsRng).unwrap();
+        let bytes = rkyv::to_bytes::<_, 256>(&pp).unwrap();
+        let decoded = rkyv::from_bytes::<PublicParameters>(&bytes).unwrap();
+
+        assert_eq!(decoded.commit_key, pp.commit_key);
+        Compiler::compile::<ArchivedParametersCircuit>(
+            &decoded,
+            b"archived-commit-key",
+        )
+        .expect("validated public parameters must compile a circuit");
     }
 
     #[cfg(feature = "rkyv-impl")]


### PR DESCRIPTION
## Summary

- archive commitment-key points as canonical compressed encodings
- reject empty, malformed, off-curve, and non-prime-order commitment keys before constructing live points
- keep semantic point validation parallel under `std` and sequential under `no_std`
- cover direct `CommitKey` and complete `PublicParameters` round-trips, malformed raw archives, and circuit compilation

## Validation

- `make fmt`
- `make clippy`
- `make no-std`
- `cargo check --lib --no-default-features --features alloc,rkyv-impl,rkyv/size_32`
- `cargo clippy --lib --features rkyv-impl,rkyv/size_32 -- -D warnings`
- `cargo doc --no-deps --features rkyv-impl,rkyv/size_32`
- `make test`

Checked RKYV decode benchmark (release, 262,144 G1 points): approximately 2.25 s and a 12,583,160-byte archive. The first draft's raw-point validation took approximately 1.85 s and produced a 27,263,224-byte archive; canonical encoding therefore adds about 0.4 s while reducing archive size by roughly 54%. Master took approximately 9 ms because it performed no semantic point validation.

This is a checked parameter-load cost only. Circuit gates, proving, and verification are unchanged.

Resolves #903