### PR TITLE
Prevent malformed point witnesses from panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deserialization [#902]
 - Validate nonempty, canonically encoded, on-curve, prime-order KZG commitment
   keys during checked RKYV `PublicParameters` deserialization [#903]
+- Prevent malformed variable-base point witnesses from panicking during affine
+  projection; the circuit now rejects them as unsatisfied [#906]
 - Reject zero vanishing-coset evaluations during checked `Prover`
   deserialization [#898]
 - Reject empty commitment keys during checked `Prover` deserialization [#897]
@@ -746,6 +748,7 @@ is necessary since `rkyv/validation` was required as a bound.
 <!-- ISSUES -->
 [#902]: https://github.com/dusk-network/plonk/issues/902
 [#903]: https://github.com/dusk-network/plonk/issues/903
+[#906]: https://github.com/dusk-network/plonk/issues/906
 [#898]: https://github.com/dusk-network/plonk/issues/898
 [#897]: https://github.com/dusk-network/plonk/issues/897
 [#895]: https://github.com/dusk-network/plonk/issues/895

--- a/src/composer/point.rs
+++ b/src/composer/point.rs
@@ -372,7 +372,15 @@ impl Composer {
         let p1 = JubJubAffine::from_raw_unchecked(self[x_1], self[y_1]);
         let p2 = JubJubAffine::from_raw_unchecked(self[x_2], self[y_2]);
 
-        let point: JubJubAffine = (JubJubExtended::from(p1) + p2).into();
+        let sum = JubJubExtended::from(p1) + p2;
+        // Malformed witness coordinates can produce an extended sum with no
+        // affine image. Keep witness generation total and let the gates reject
+        // the assignment. Honest curve additions always take the other arm.
+        let point = if sum.get_z() == BlsScalar::zero() {
+            JubJubAffine::identity()
+        } else {
+            sum.into()
+        };
 
         let x_3 = point.get_u();
         let y_3 = point.get_v();

--- a/src/composer/tests/soundness/point.rs
+++ b/src/composer/tests/soundness/point.rs
@@ -342,6 +342,69 @@ fn torsion_free_layout_matches_golden() {
     );
 }
 
+struct MulPointCircuit {
+    scalar: JubJubScalar,
+    point: JubJubAffine,
+}
+
+impl Default for MulPointCircuit {
+    fn default() -> Self {
+        Self {
+            scalar: JubJubScalar::from(3u64),
+            point: prime_order_point(),
+        }
+    }
+}
+
+impl Circuit for MulPointCircuit {
+    fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
+        let scalar = composer.append_witness(self.scalar);
+        let point = composer.append_point(self.point)?;
+        let point = composer.assert_torsion_free_point(point);
+        composer.component_mul_point(scalar, point);
+
+        Ok(())
+    }
+}
+
+#[test]
+fn mul_point_rejects_malformed_base_without_panicking() {
+    let mut rng = StdRng::seed_from_u64(0x906);
+    let pp = PublicParameters::setup(1 << 11, &mut rng).expect("setup");
+    let (prover, verifier) =
+        Compiler::compile::<MulPointCircuit>(&pp, b"mul-point-malformed-base")
+            .expect("compile");
+
+    let accepted = MulPointCircuit::default();
+    assert_verifies(&prover, &verifier, &mut rng, &accepted);
+
+    let x = BlsScalar::from_raw([
+        0x3218_5d43_5879_5954,
+        0x018f_1597_d916_ddf5,
+        0xf49c_53d3_e92b_3582,
+        0x3c71_775e_c64c_fc69,
+    ]);
+    let rejected = MulPointCircuit {
+        scalar: JubJubScalar::from(3u64),
+        point: JubJubAffine::from_raw_unchecked(x, BlsScalar::one()),
+    };
+
+    // Pin the fixture to the affine-projection failure: doubling remains
+    // projectable, while the final 2P + P addition has no affine image.
+    let point = JubJubExtended::from(rejected.point);
+    let doubled = point + rejected.point;
+    assert_ne!(doubled.get_z(), BlsScalar::zero());
+    assert_eq!((doubled + rejected.point).get_z(), BlsScalar::zero());
+
+    assert_rejected(
+        &prover,
+        &mut rng,
+        &accepted,
+        &rejected,
+        "malformed variable-base scalar-multiplication base",
+    );
+}
+
 // `component_mul_point` promises consumers an unchanged layout now that
 // `component_select_identity` constrains its bit: the loop must keep calling
 // the raw `select_identity_gates` seam. Routing it through the public method


### PR DESCRIPTION
## Summary

- keep variable-base point witness generation total when an intermediate extended sum has no affine image
- preserve the circuit shape and let the existing constraints reject malformed assignments
- cover the denominator-zero regression with an honest proving control

## Validation

- `cargo test --release --lib composer::tests::soundness::point::mul_point_rejects_malformed_base_without_panicking -- --exact --nocapture`
- `cargo test --release --lib composer::tests::soundness::point::mul_point_layout_matches_golden -- --exact`
- `make fmt`
- `make clippy`
- `make no-std`
- `make test`

Resolves #906
