### PR TITLE
chore(ci): Gate coverage on stable revisions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,32 @@
+name: Coverage
+
+on:
+  pull_request:
+    types: [labeled]
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    if: github.event_name != 'pull_request' || github.event.label.name == 'ci:coverage'
+    name: Coverage
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - run: sudo apt install -y kcov
+      - run: RUSTFLAGS='-Cdebuginfo=2 -Cllvm-args=--inline-threshold=0 -Clink-dead-code' cargo test --release --no-run --all-features
+      - name: Collect coverage
+        run: >
+          find target/release/deps -type f -executable ! -name "*.*" |
+          xargs -n1 kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -5,6 +5,10 @@ on:
 
 name: Continuous integration
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Code Analysis
@@ -62,20 +66,3 @@ jobs:
       - uses: dsherret/rust-toolchain-file@v1
       - uses: Swatinem/rust-cache@v2
       - run: make test
-
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - run: sudo apt install -y kcov
-      - run: RUSTFLAGS='-Cdebuginfo=2 -Cllvm-args=--inline-threshold=0 -Clink-dead-code' cargo test --release --no-run --all-features
-      - name: Collect coverage
-        run: >
-          find target/release/deps -type f -executable ! -name "*.*" |
-          xargs -n1 kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov
-      - name: Upload coverage
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{secrets.CODECOV_TOKEN}}


### PR DESCRIPTION
Resolves #917

## Summary

- move coverage out of ordinary pull-request CI
- run coverage automatically on `master`, manually through Actions, or once for a stable PR head with the `ci:coverage` label
- cancel superseded CI and coverage runs for the same pull request

The kcov and Codecov steps are unchanged.

## Validation

- `actionlint` 1.7.12
- `git diff --check`
- confirmed that no branch-protection rule currently requires coverage
