### PR TITLE
Optimize prover hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improve prover hot-path performance by reusing sigma evaluations, batching
+  permutation inversions, reducing opening-polynomial allocations, and
+  parallelizing large FFT stages and independent work [#921]
 - Change RKYV `CommitKey` and `PublicParameters` archives to store canonical
   compressed commitment- and opening-key source points and rebuild prepared
   pairing values during deserialization. Existing RKYV parameter archives
@@ -758,6 +761,7 @@ is necessary since `rkyv/validation` was required as a bound.
 
 <!-- ISSUES -->
 [#930]: https://github.com/dusk-network/plonk/issues/930
+[#921]: https://github.com/dusk-network/plonk/issues/921
 [#920]: https://github.com/dusk-network/plonk/issues/920
 [#914]: https://github.com/dusk-network/plonk/issues/914
 [#913]: https://github.com/dusk-network/plonk/issues/913

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ dusk-bytes = "0.1"
 dusk-bls12_381 = {version = "0.14", default-features = false, features = ["groups", "pairings"]}
 dusk-jubjub = {version = "0.15", default-features = false}
 ff = {version = "0.13", default-features = false}
-itertools = {version = "0.9", default-features = false}
 hashbrown = {version = "0.9", default-features=false, features = ["ahash"]}
 msgpacker = {version = "=0.4.8", default-features=false, features = ["alloc", "derive"], optional=true}
 miniz_oxide = {version = "0.7", default-features=false, features = ["with-alloc"], optional = true}
@@ -41,6 +40,7 @@ zeroize = { version = "1", optional = true }
 criterion = "0.5"
 tempdir = "0.3"
 rand = "0.8"
+itertools = {version = "0.9", default-features = false}
 rkyv = {version = "0.7", default-features = false, features = ["size_32", "validation"]}
 
 [features]
@@ -50,7 +50,6 @@ std = [
     "rand_core/std",
     "dusk-bls12_381/default",  # Includes `parallel`
     "dusk-jubjub/default",
-    "itertools/default",
     "hashbrown/default",
     "msgpacker/std",
     "miniz_oxide/std",

--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -392,20 +392,28 @@ impl CommitKey {
     /// We apply the same optimization mentioned in when computing each witness;
     /// removing f(z).
     pub(crate) fn compute_aggregate_witness(
-        polynomials: &[Polynomial],
+        polynomials: &[&Polynomial],
         point: &BlsScalar,
         v_challenge: &BlsScalar,
     ) -> Polynomial {
-        let powers = util::powers_of(v_challenge, polynomials.len() - 1);
+        if polynomials.is_empty() {
+            return Polynomial::zero();
+        }
 
-        assert_eq!(powers.len(), polynomials.len());
+        let max_len = polynomials.iter().map(|poly| poly.len()).max().unwrap();
+        let mut coefficients = vec![BlsScalar::zero(); max_len];
+        let mut power = BlsScalar::one();
 
-        let numerator: Polynomial = polynomials
-            .iter()
-            .zip(powers.iter())
-            .map(|(poly, v_challenge)| poly * v_challenge)
-            .sum();
-        numerator.ruffini(*point)
+        for polynomial in polynomials {
+            for (coefficient, term) in
+                coefficients.iter_mut().zip(polynomial.iter())
+            {
+                *coefficient += *term * power;
+            }
+            power *= v_challenge;
+        }
+
+        Polynomial::from_coefficients_vec(coefficients).ruffini(*point)
     }
 }
 
@@ -767,8 +775,9 @@ mod test {
         let v_challenge = transcript.challenge_scalar(b"v_challenge");
 
         // Compute the aggregate witness for polynomials
+        let polynomial_refs: Vec<_> = polynomials.iter().collect();
         let witness_poly = CommitKey::compute_aggregate_witness(
-            polynomials,
+            &polynomial_refs,
             point,
             &v_challenge,
         );

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -425,7 +425,7 @@ impl Compiler {
             verifier_key,
             size,
             constraints,
-        );
+        )?;
 
         let verifier = Verifier::new(
             label,

--- a/src/compiler/prover.rs
+++ b/src/compiler/prover.rs
@@ -32,6 +32,7 @@ pub struct Prover {
     pub(crate) commit_key: CommitKey,
     pub(crate) verifier_key: VerifierKey,
     pub(crate) transcript: Transcript,
+    sigma_evaluations: [Vec<BlsScalar>; 4],
     pub(crate) size: usize,
     pub(crate) constraints: usize,
 }
@@ -52,19 +53,27 @@ impl Prover {
         verifier_key: VerifierKey,
         size: usize,
         constraints: usize,
-    ) -> Self {
+    ) -> Result<Self, Error> {
         let transcript =
             Transcript::base(label.as_slice(), &verifier_key, constraints);
+        let domain = EvaluationDomain::new(constraints)?;
+        let sigma_evaluations = [
+            domain.fft(&prover_key.permutation.s_sigma_1.0),
+            domain.fft(&prover_key.permutation.s_sigma_2.0),
+            domain.fft(&prover_key.permutation.s_sigma_3.0),
+            domain.fft(&prover_key.permutation.s_sigma_4.0),
+        ];
 
-        Self {
+        Ok(Self {
             label,
             prover_key,
             commit_key,
             verifier_key,
             transcript,
+            sigma_evaluations,
             size,
             constraints,
-        }
+        })
     }
 
     /// adds blinding scalars to a witness vector
@@ -222,14 +231,14 @@ impl Prover {
 
         let verifier_key = VerifierKey::from_slice(verifier_key)?;
 
-        Ok(Self::new(
+        Self::new(
             label,
             prover_key,
             commit_key,
             verifier_key,
             size,
             constraints,
-        ))
+        )
     }
 
     /// Prove the circuit using the current (latest) proving behavior.
@@ -370,10 +379,10 @@ impl Prover {
 
         let gamma = transcript.challenge_scalar(b"gamma");
         let sigma = [
-            &self.prover_key.permutation.s_sigma_1.0,
-            &self.prover_key.permutation.s_sigma_2.0,
-            &self.prover_key.permutation.s_sigma_3.0,
-            &self.prover_key.permutation.s_sigma_4.0,
+            self.sigma_evaluations[0].as_slice(),
+            self.sigma_evaluations[1].as_slice(),
+            self.sigma_evaluations[2].as_slice(),
+            self.sigma_evaluations[3].as_slice(),
         ];
         let wires = [
             a_scalars.as_slice(),

--- a/src/compiler/prover.rs
+++ b/src/compiler/prover.rs
@@ -595,21 +595,21 @@ impl Prover {
         // compute the opening proof polynomial 'W_z(X)'
         let aggregate_witness = CommitKey::compute_aggregate_witness(
             &[
-                r_poly,
-                a_poly.clone(),
-                b_poly.clone(),
-                c_poly,
-                d_poly.clone(),
-                self.prover_key.permutation.s_sigma_1.0.clone(),
-                self.prover_key.permutation.s_sigma_2.0.clone(),
-                self.prover_key.permutation.s_sigma_3.0.clone(),
+                &r_poly,
+                &a_poly,
+                &b_poly,
+                &c_poly,
+                &d_poly,
+                &self.prover_key.permutation.s_sigma_1.0,
+                &self.prover_key.permutation.s_sigma_2.0,
+                &self.prover_key.permutation.s_sigma_3.0,
                 // Bind selector evaluations (q_*) used inside the verifier
                 // linearization commitment to their committed polynomials
                 // by including them in the same batched opening at `z`.
-                self.prover_key.arithmetic.q_arith.0.clone(),
-                self.prover_key.arithmetic.q_c.0.clone(),
-                self.prover_key.arithmetic.q_l.0.clone(),
-                self.prover_key.arithmetic.q_r.0.clone(),
+                &self.prover_key.arithmetic.q_arith.0,
+                &self.prover_key.arithmetic.q_c.0,
+                &self.prover_key.arithmetic.q_l.0,
+                &self.prover_key.arithmetic.q_r.0,
             ],
             &z_challenge,
             &v_challenge,
@@ -621,7 +621,7 @@ impl Prover {
 
         // compute the shifted opening proof polynomial 'W_zw(X)'
         let shifted_aggregate_witness = CommitKey::compute_aggregate_witness(
-            &[z_poly, a_poly, b_poly, d_poly],
+            &[&z_poly, &a_poly, &b_poly, &d_poly],
             &(z_challenge * domain.group_gen),
             &v_w_challenge,
         );

--- a/src/compiler/prover.rs
+++ b/src/compiler/prover.rs
@@ -14,7 +14,7 @@ use merlin::Transcript;
 use rand_core::{CryptoRng, RngCore};
 
 use super::{Circuit, Composer, PlonkVersion};
-use crate::commitment_scheme::CommitKey;
+use crate::commitment_scheme::{CommitKey, Commitment};
 use crate::compiler::prover::linearization_poly::ProofEvaluations;
 use crate::error::Error;
 use crate::fft::{EvaluationDomain, Polynomial};
@@ -92,16 +92,83 @@ impl Prover {
     where
         R: RngCore + CryptoRng,
     {
-        let mut w_vec_inverse = domain.ifft(witnesses);
+        let blinders: Vec<_> = (0..=hiding_degree)
+            .map(|_| BlsScalar::random(&mut *rng))
+            .collect();
+        Self::blind_poly_with_blinders(witnesses, &blinders, domain)
+    }
 
-        for i in 0..hiding_degree + 1 {
-            let blinding_scalar = BlsScalar::random(&mut *rng);
+    fn blind_poly_with_blinders(
+        witnesses: &[BlsScalar],
+        blinders: &[BlsScalar],
+        domain: &EvaluationDomain,
+    ) -> Polynomial {
+        let mut coefficients = domain.ifft(witnesses);
 
-            w_vec_inverse[i] -= blinding_scalar;
-            w_vec_inverse.push(blinding_scalar);
+        for (i, blinding_scalar) in blinders.iter().copied().enumerate() {
+            coefficients[i] -= blinding_scalar;
+            coefficients.push(blinding_scalar);
         }
 
-        Polynomial::from_coefficients_vec(w_vec_inverse)
+        Polynomial::from_coefficients_vec(coefficients)
+    }
+
+    fn sample_wire_blinders<R>(rng: &mut R) -> [[BlsScalar; 2]; 4]
+    where
+        R: RngCore + CryptoRng,
+    {
+        core::array::from_fn(|_| {
+            core::array::from_fn(|_| BlsScalar::random(&mut *rng))
+        })
+    }
+
+    fn blind_wire_polynomials(
+        witnesses: [&[BlsScalar]; 4],
+        blinders: &[[BlsScalar; 2]; 4],
+        domain: &EvaluationDomain,
+    ) -> [Polynomial; 4] {
+        let blind = |i: usize| {
+            let blinders = blinders[i].as_slice();
+            Self::blind_poly_with_blinders(witnesses[i], blinders, domain)
+        };
+        #[cfg(feature = "std")]
+        {
+            let ((a, b), (c, d)) = rayon::join(
+                || rayon::join(|| blind(0), || blind(1)),
+                || rayon::join(|| blind(2), || blind(3)),
+            );
+            [a, b, c, d]
+        }
+
+        #[cfg(not(feature = "std"))]
+        {
+            [blind(0), blind(1), blind(2), blind(3)]
+        }
+    }
+
+    fn commit_polynomials(
+        &self,
+        polynomials: [&Polynomial; 4],
+    ) -> Result<[Commitment; 4], Error> {
+        #[cfg(feature = "std")]
+        {
+            let commit = |i: usize| self.commit_key.commit(polynomials[i]);
+            let ((a, b), (c, d)) = rayon::join(
+                || rayon::join(|| commit(0), || commit(1)),
+                || rayon::join(|| commit(2), || commit(3)),
+            );
+            Ok([a?, b?, c?, d?])
+        }
+
+        #[cfg(not(feature = "std"))]
+        {
+            Ok([
+                self.commit_key.commit(polynomials[0])?,
+                self.commit_key.commit(polynomials[1])?,
+                self.commit_key.commit(polynomials[2])?,
+                self.commit_key.commit(polynomials[3])?,
+            ])
+        }
     }
 
     fn prepare_serialize(
@@ -354,17 +421,18 @@ impl Prover {
                 d_scalars[i] = prover[constraint.d];
             });
 
-        let a_poly = Self::blind_poly(rng, &a_scalars, 1, &domain);
-        let b_poly = Self::blind_poly(rng, &b_scalars, 1, &domain);
-        let c_poly = Self::blind_poly(rng, &c_scalars, 1, &domain);
-        let d_poly = Self::blind_poly(rng, &d_scalars, 1, &domain);
+        let wire_blinders = Self::sample_wire_blinders(rng);
+
+        let [a_poly, b_poly, c_poly, d_poly] = Self::blind_wire_polynomials(
+            [&a_scalars, &b_scalars, &c_scalars, &d_scalars],
+            &wire_blinders,
+            &domain,
+        );
 
         // commit to wire polynomials
         // ([a(x)]_1, [b(x)]_1, [c(x)]_1, [d(x)]_1)
-        let a_comm = self.commit_key.commit(&a_poly)?;
-        let b_comm = self.commit_key.commit(&b_poly)?;
-        let c_comm = self.commit_key.commit(&c_poly)?;
-        let d_comm = self.commit_key.commit(&d_poly)?;
+        let [a_comm, b_comm, c_comm, d_comm] =
+            self.commit_polynomials([&a_poly, &b_poly, &c_poly, &d_poly])?;
 
         // Add wire polynomial commitments to transcript
         transcript.append_commitment(b"a_comm", &a_comm);
@@ -467,10 +535,13 @@ impl Prover {
         let t_fourth_poly = Polynomial::from_coefficients_vec(t_fourth_vec);
 
         // commit to split quotient polynomial
-        let t_low_comm = self.commit_key.commit(&t_low_poly)?;
-        let t_mid_comm = self.commit_key.commit(&t_mid_poly)?;
-        let t_high_comm = self.commit_key.commit(&t_high_poly)?;
-        let t_fourth_comm = self.commit_key.commit(&t_fourth_poly)?;
+        let [t_low_comm, t_mid_comm, t_high_comm, t_fourth_comm] = self
+            .commit_polynomials([
+                &t_low_poly,
+                &t_mid_poly,
+                &t_high_poly,
+                &t_fourth_poly,
+            ])?;
 
         // add quotient polynomial commitments to transcript
         transcript.append_commitment(b"t_low_comm", &t_low_comm);
@@ -905,6 +976,84 @@ mod tests {
             .copy_from_slice(&replacement);
 
         assert_deserialization_error_without_panic(&bytes);
+    }
+
+    #[test]
+    fn precomputed_wire_blinders_preserve_rng_order() {
+        let domain = EvaluationDomain::new(8).unwrap();
+        let witnesses: Vec<_> = (0..domain.size())
+            .map(|i| BlsScalar::from(i as u64))
+            .collect();
+        let mut sequential_rng = StdRng::seed_from_u64(0x51_6d_a);
+        let mut precomputed_rng = sequential_rng.clone();
+
+        let sequential = [
+            Prover::blind_poly(&mut sequential_rng, &witnesses, 1, &domain),
+            Prover::blind_poly(&mut sequential_rng, &witnesses, 1, &domain),
+            Prover::blind_poly(&mut sequential_rng, &witnesses, 1, &domain),
+            Prover::blind_poly(&mut sequential_rng, &witnesses, 1, &domain),
+        ];
+        let blinders = Prover::sample_wire_blinders(&mut precomputed_rng);
+        let precomputed = blinders.map(|blinders| {
+            Prover::blind_poly_with_blinders(&witnesses, &blinders, &domain)
+        });
+
+        assert_eq!(precomputed, sequential);
+    }
+
+    #[test]
+    fn deterministic_v3_proof_matches_base_digest() {
+        let mut setup_rng = StdRng::seed_from_u64(0x9235_e700);
+        let pp = PublicParameters::setup(1 << 10, &mut setup_rng)
+            .expect("public parameters should build");
+        let (prover, _) =
+            Compiler::compile::<MinimalCircuit>(&pp, b"proof-compatibility")
+                .expect("circuit should compile");
+        let mut proving_rng = StdRng::seed_from_u64(0x9235_e701);
+        let (proof, _) = prover
+            .prove_with_version(
+                &mut proving_rng,
+                &MinimalCircuit,
+                crate::compiler::PlonkVersion::V3,
+            )
+            .expect("V3 proof should build");
+
+        // Generated at the PR's base revision, 768cf849. This pins proof
+        // bytes, including transcript challenges and proving RNG order.
+        let expected = [
+            0xe8, 0x56, 0x4e, 0xc2, 0x2d, 0x8c, 0xc0, 0xba, 0x60, 0x36, 0x26,
+            0x02, 0x5d, 0xa3, 0x75, 0x50, 0x77, 0xaa, 0xf0, 0x32, 0x32, 0x61,
+            0x90, 0x8d, 0xab, 0x68, 0xd6, 0x94, 0x73, 0x6f, 0xc2, 0x73, 0xd3,
+            0x1e, 0x25, 0x6c, 0xbd, 0x3a, 0x6a, 0x21, 0xe7, 0xad, 0xe6, 0x31,
+            0x91, 0xac, 0x5c, 0x9d, 0x44, 0xa1, 0x13, 0xac, 0x49, 0x89, 0xa5,
+            0x2e, 0x4b, 0xe3, 0xab, 0xeb, 0x1d, 0x33, 0x32, 0x37,
+        ];
+        let digest = blake2b_simd::blake2b(&proof.to_bytes());
+
+        assert_eq!(digest.as_array(), &expected);
+    }
+
+    #[test]
+    fn prover_roundtrip_reconstructs_sigma_evaluations() {
+        let mut rng = StdRng::seed_from_u64(47);
+        let pp = PublicParameters::setup(1 << 10, &mut rng)
+            .expect("public parameters should build");
+        let (prover, verifier) =
+            Compiler::compile::<MinimalCircuit>(&pp, b"sigma-cache")
+                .expect("circuit should compile");
+        let bytes = prover.to_bytes();
+
+        let decoded = Prover::try_from_bytes(&bytes)
+            .expect("serialized prover should decode");
+        assert_eq!(decoded.sigma_evaluations, prover.sigma_evaluations);
+        assert_eq!(decoded.to_bytes(), bytes);
+
+        let (proof, public_inputs) = decoded
+            .prove(&mut rng, &MinimalCircuit)
+            .expect("decoded prover should prove");
+        verifier
+            .verify(&proof, &public_inputs)
+            .expect("proof from decoded prover should verify");
     }
 
     #[test]

--- a/src/composer/permutation.rs
+++ b/src/composer/permutation.rs
@@ -9,10 +9,12 @@ use alloc::vec::Vec;
 use constants::{K1, K2, K3};
 use dusk_bls12_381::BlsScalar;
 use hashbrown::HashMap;
-use itertools::izip;
+#[cfg(feature = "std")]
+use rayon::prelude::*;
 
 use crate::composer::{WireData, Witness};
 use crate::fft::{EvaluationDomain, Polynomial};
+use crate::util::batch_inversion;
 
 pub(crate) mod constants;
 
@@ -208,94 +210,87 @@ impl Permutation {
         ]
     }
 
-    // Uses a rayon multizip to allow more code flexibility while remaining
-    // parallelizable. This can be adapted into a general product argument
-    // for any number of wires.
     pub(crate) fn compute_permutation_vec(
         &self,
         domain: &EvaluationDomain,
         wires: [&[BlsScalar]; 4],
         beta: &BlsScalar,
         gamma: &BlsScalar,
-        sigma_polys: [&Polynomial; 4],
+        sigma_evaluations: [&[BlsScalar]; 4],
     ) -> Vec<BlsScalar> {
         let n = domain.size();
+        let roots: Vec<_> = domain.elements().collect();
+        let numerators =
+            Self::permutation_numerators(&roots, wires, beta, gamma);
+        let mut denominators = Self::permutation_denominators(
+            wires,
+            sigma_evaluations,
+            beta,
+            gamma,
+        );
 
-        // Constants defining cosets H, k1H, k2H, etc
-        let ks = vec![BlsScalar::one(), K1, K2, K3];
+        assert!(
+            denominators.iter().all(|value| *value != BlsScalar::zero()),
+            "permutation denominator must be nonzero"
+        );
+        batch_inversion(&mut denominators);
 
-        // Transpose wires and sigma values to get "rows" in the form [a_i,
-        // b_i, c_i, d_i] where each row contains the wire and sigma
-        // values for a single gate
-        let gatewise_wires = izip!(wires[0], wires[1], wires[2], wires[3])
-            .map(|(w0, w1, w2, w3)| vec![w0, w1, w2, w3]);
+        let mut permutation = Vec::with_capacity(n);
+        let mut product = BlsScalar::one();
 
-        let gatewise_sigmas: Vec<Vec<BlsScalar>> =
-            sigma_polys.iter().map(|sigma| domain.fft(sigma)).collect();
-        let gatewise_sigmas = izip!(
-            &gatewise_sigmas[0],
-            &gatewise_sigmas[1],
-            &gatewise_sigmas[2],
-            &gatewise_sigmas[3]
-        )
-        .map(|(s0, s1, s2, s3)| vec![s0, s1, s2, s3]);
-
-        // Compute all roots
-        // Non-parallelizable?
-        let roots: Vec<BlsScalar> = domain.elements().collect();
-
-        let product_argument = izip!(roots, gatewise_sigmas, gatewise_wires)
-            // Associate each wire value in a gate with the k defining its coset
-            .map(|(gate_root, gate_sigmas, gate_wires)| {
-                (gate_root, izip!(gate_sigmas, gate_wires, &ks))
-            })
-            // Now the ith element represents gate i and will have the form:
-            //   (root_i, ((w0_i, s0_i, k0), (w1_i, s1_i, k1), ..., (wm_i, sm_i,
-            // km)))   for m different wires, which is all the
-            // information   needed for a single product coefficient
-            // for a single gate Multiply up the numerator and
-            // denominator irreducibles for each gate   and pair the
-            // results
-            .map(|(gate_root, wire_params)| {
-                (
-                    // Numerator product
-                    wire_params
-                        .clone()
-                        .map(|(_sigma, wire, k)| {
-                            wire + beta * k * gate_root + gamma
-                        })
-                        .product::<BlsScalar>(),
-                    // Denominator product
-                    wire_params
-                        .map(|(sigma, wire, _k)| wire + beta * sigma + gamma)
-                        .product::<BlsScalar>(),
-                )
-            })
-            // Divide each pair to get the single scalar representing each gate
-            .map(|(n, d)| n * d.invert().unwrap())
-            // Collect into vector intermediary since rayon does not support
-            // `scan`
-            .collect::<Vec<BlsScalar>>();
-
-        let mut z = Vec::with_capacity(n);
-
-        // First element is one
-        let mut state = BlsScalar::one();
-        z.push(state);
-
-        // Accumulate by successively multiplying the scalars
-        // Non-parallelizable?
-        for s in product_argument {
-            state *= s;
-            z.push(state);
+        for i in 0..n {
+            permutation.push(product);
+            if i + 1 < n {
+                product *= numerators[i] * denominators[i];
+            }
         }
 
-        // Remove the last(n+1'th) element
-        z.remove(n);
+        permutation
+    }
 
-        assert_eq!(n, z.len());
+    fn permutation_numerators(
+        roots: &[BlsScalar],
+        wires: [&[BlsScalar]; 4],
+        beta: &BlsScalar,
+        gamma: &BlsScalar,
+    ) -> Vec<BlsScalar> {
+        #[cfg(not(feature = "std"))]
+        let range = 0..roots.len();
+        #[cfg(feature = "std")]
+        let range = (0..roots.len()).into_par_iter();
 
-        z
+        range
+            .map(|i| {
+                let beta_root = beta * roots[i];
+                let a = wires[0][i] + beta_root + gamma;
+                let b = wires[1][i] + beta_root * K1 + gamma;
+                let c = wires[2][i] + beta_root * K2 + gamma;
+                let d = wires[3][i] + beta_root * K3 + gamma;
+                a * b * c * d
+            })
+            .collect()
+    }
+
+    fn permutation_denominators(
+        wires: [&[BlsScalar]; 4],
+        sigma_evaluations: [&[BlsScalar]; 4],
+        beta: &BlsScalar,
+        gamma: &BlsScalar,
+    ) -> Vec<BlsScalar> {
+        #[cfg(not(feature = "std"))]
+        let range = 0..wires[0].len();
+        #[cfg(feature = "std")]
+        let range = (0..wires[0].len()).into_par_iter();
+
+        range
+            .map(|i| {
+                let a = wires[0][i] + beta * sigma_evaluations[0][i] + gamma;
+                let b = wires[1][i] + beta * sigma_evaluations[1][i] + gamma;
+                let c = wires[2][i] + beta * sigma_evaluations[2][i] + gamma;
+                let d = wires[3][i] + beta * sigma_evaluations[3][i] + gamma;
+                a * b * c * d
+            })
+            .collect()
     }
 }
 
@@ -304,6 +299,7 @@ impl Permutation {
 mod test {
     use dusk_bls12_381::BlsScalar;
     use ff::Field;
+    use itertools::izip;
     use rand_core::OsRng;
 
     use super::*;
@@ -1035,6 +1031,26 @@ mod test {
             ),
         );
         assert_eq!(fast_z_vec, z_vec);
+
+        let sigma_evaluations = [
+            domain.fft(&s_sigma_1_poly),
+            domain.fft(&s_sigma_2_poly),
+            domain.fft(&s_sigma_3_poly),
+            domain.fft(&s_sigma_4_poly),
+        ];
+        let batched_z_vec = perm.compute_permutation_vec(
+            domain,
+            [&a, &b, &c, &d],
+            &beta,
+            &gamma,
+            [
+                &sigma_evaluations[0],
+                &sigma_evaluations[1],
+                &sigma_evaluations[2],
+                &sigma_evaluations[3],
+            ],
+        );
+        assert_eq!(batched_z_vec, z_vec);
 
         // 2. First we perform basic tests on the permutation vector
         //

--- a/src/fft/domain.rs
+++ b/src/fft/domain.rs
@@ -355,8 +355,49 @@ pub(crate) mod alloc {
         }
     }
 
+    #[cfg(not(feature = "std"))]
     fn best_fft(a: &mut [BlsScalar], omega: BlsScalar, log_n: u32) {
         serial_fft(a, omega, log_n)
+    }
+
+    #[cfg(feature = "std")]
+    fn best_fft(a: &mut [BlsScalar], omega: BlsScalar, log_n: u32) {
+        const PARALLEL_FFT_MIN_LEN: usize = 1 << 12;
+        const PARALLEL_FFT_MIN_CHUNKS: usize = 4;
+
+        let n = a.len();
+        if n < PARALLEL_FFT_MIN_LEN {
+            serial_fft(a, omega, log_n);
+            return;
+        }
+
+        let n_u32 = n as u32;
+        assert_eq!(n_u32, 1 << log_n);
+
+        for k in 0..n_u32 {
+            let rk = bitreverse(k, log_n);
+            if k < rk {
+                a.swap(rk as usize, k as usize);
+            }
+        }
+
+        let mut m = 1usize;
+        for _ in 0..log_n {
+            let w_m = omega.pow(&[(n_u32 / (2 * m as u32)) as u64, 0, 0, 0]);
+            let chunk_len = 2 * m;
+            let chunk_count = n / chunk_len;
+
+            if chunk_count >= PARALLEL_FFT_MIN_CHUNKS {
+                a.par_chunks_mut(chunk_len)
+                    .for_each(|chunk| butterfly_chunk(chunk, m, w_m));
+            } else {
+                for chunk in a.chunks_mut(chunk_len) {
+                    butterfly_chunk(chunk, m, w_m);
+                }
+            }
+
+            m *= 2;
+        }
     }
 
     #[inline]
@@ -405,6 +446,23 @@ pub(crate) mod alloc {
             }
 
             m *= 2;
+        }
+    }
+
+    #[cfg(feature = "std")]
+    #[inline]
+    fn butterfly_chunk(chunk: &mut [BlsScalar], m: usize, w_m: BlsScalar) {
+        let (left, right) = chunk.split_at_mut(m);
+        let mut w = BlsScalar::one();
+
+        for j in 0..m {
+            let mut t = right[j];
+            t *= &w;
+            let mut tmp = left[j];
+            tmp -= &t;
+            right[j] = tmp;
+            left[j] += &t;
+            w.mul_assign(&w_m);
         }
     }
 
@@ -458,6 +516,25 @@ mod tests {
                 assert_eq!(element, domain.group_gen.pow(&[i as u64, 0, 0, 0]));
             }
         }
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn parallel_fft_matches_serial_fft_for_large_domain() {
+        let domain = EvaluationDomain::new(1 << 12).unwrap();
+        let parallel = (0..domain.size())
+            .map(|i| BlsScalar::from((i as u64) + 1))
+            .collect::<Vec<_>>();
+        let mut serial = parallel.clone();
+
+        let parallel = domain.fft(&parallel);
+        crate::fft::domain::alloc::serial_fft(
+            &mut serial,
+            domain.group_gen,
+            domain.log_size_of_group,
+        );
+
+        assert_eq!(parallel, serial);
     }
 
     #[test]

--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -1529,14 +1529,14 @@ mod soundness_tests {
 
         let aggregate_witness = CommitKey::compute_aggregate_witness(
             &[
-                r_poly,
-                a_poly.clone(),
-                b_poly.clone(),
-                c_poly.clone(),
-                d_poly.clone(),
-                prover.prover_key.permutation.s_sigma_1.0.clone(),
-                prover.prover_key.permutation.s_sigma_2.0.clone(),
-                prover.prover_key.permutation.s_sigma_3.0.clone(),
+                &r_poly,
+                &a_poly,
+                &b_poly,
+                &c_poly,
+                &d_poly,
+                &prover.prover_key.permutation.s_sigma_1.0,
+                &prover.prover_key.permutation.s_sigma_2.0,
+                &prover.prover_key.permutation.s_sigma_3.0,
             ],
             &z_challenge,
             &v_challenge,
@@ -1547,7 +1547,7 @@ mod soundness_tests {
         let v_w_challenge = transcript.challenge_scalar(b"v_w_challenge");
 
         let shifted_aggregate_witness = CommitKey::compute_aggregate_witness(
-            &[z_poly, a_poly, b_poly, d_poly],
+            &[&z_poly, &a_poly, &b_poly, &d_poly],
             &(z_challenge * domain.group_gen),
             &v_w_challenge,
         );


### PR DESCRIPTION
## Summary

- cache sigma evaluations when a prover is constructed, rebuilding them from the checked prover key after deserialization
- replace per-row permutation inversions with one batch inversion while preserving the product argument
- build aggregate opening witnesses in one coefficient buffer and borrow their source polynomials
- parallelize independent wire polynomial/commitment and quotient commitment work in `std` builds while preserving RNG draw order
- parallelize independent butterfly chunks within large FFT stages in `std` builds; `no_std` keeps the serial implementation

The serialized prover format, proof mathematics, transcript, and RNG draw order are unchanged. No unchecked deserialization path is added. The changes are split into separate commits for the permutation, aggregate-witness, sigma-cache, independent prover-work, and FFT optimizations.

## Memory footprint

Each `Prover` now retains four sigma-evaluation vectors containing `4 * n` BLS scalars, or `128 * n` bytes. At a proving domain of `2^17`, this is 16 MiB per prover and per clone. A consumer retaining four such provers therefore adds approximately 64 MiB of steady-state memory. The cache is not serialized; checked deserialization reconstructs it from the validated prover key.

## Repository benchmark

The repository's Criterion benchmark was run on the exact base and candidate, sequentially on the same machine, for the 131,072-gate proving case. Criterion used its standard three-second warmup and ten measured iterations.

| Revision | Median proving time |
|---|---:|
| Base `768cf849` | 12.950 s |
| Candidate | 6.143 s |

The candidate reduced median proving time by **52.6%** in the repository-native benchmark.

## Phoenix 2^17 benchmark

The final FFT path was also benchmarked on the dedicated CPX42 reference worker (`dusk-compute-fsn1-11`, AMD EPYC Genoa, 8 shared vCPU, 16 GiB RAM) using the production-shaped four-input Phoenix transfer circuit:

- 131,024 constraints
- 131,072-element proving domain
- `RAYON_NUM_THREADS=8`
- one warmup and five measured proofs per run
- alternating order: previous head, amended head, amended head, previous head

| Revision | Run A median | Run B median |
|---|---:|---:|
| Previous PR head `4f5319ef` | 13.208 s | 13.199 s |
| Amended head `6aa1662b` | 8.830 s | 8.858 s |

The large-domain parallel FFT reduced Phoenix proving time by **32.9–33.2%** on the reference worker. Verification remained effectively unchanged, as expected for a prover-only change.

As a same-machine historical control, the exact April private optimization stack measured 3.642 s on an Intel Core Ultra 9 275HX. The current optimization stack with this FFT path measured 3.664 s for today's 2.1%-larger Phoenix circuit, indicating that the previously observed gap was caused by the omitted FFT path rather than the circuit-hardening work.

## Validation

- parallel FFT output equals the serial implementation on a large domain
- deterministic V3 proof bytes match the base revision
- `make test`
- `make no-std`
- `make clippy`
- `make fmt`
- `git diff --check`
- repository Criterion benchmark at 131,072 gates
- production-shaped Phoenix proof generation and verification on the CPX42 reference worker

Further late-stage FFT parallelism and helper deduplication are tracked in #933.

Resolves #921
