### PR TITLE
Cache deterministic quotient-domain prover data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parallelizing large FFT stages and independent work [#921]
 - Parallelize independent quotient coset FFTs when `std` is enabled while
   retaining the serial `no_std` path [#925]
+- Cache deterministic quotient-domain prover data across proofs [#919]
 - Change RKYV `CommitKey` and `PublicParameters` archives to store canonical
   compressed commitment- and opening-key source points and rebuild prepared
   pairing values during deserialization. Existing RKYV parameter archives
@@ -768,6 +769,7 @@ is necessary since `rkyv/validation` was required as a bound.
 [#925]: https://github.com/dusk-network/plonk/issues/925
 [#921]: https://github.com/dusk-network/plonk/issues/921
 [#920]: https://github.com/dusk-network/plonk/issues/920
+[#919]: https://github.com/dusk-network/plonk/issues/919
 [#916]: https://github.com/dusk-network/plonk/issues/916
 [#914]: https://github.com/dusk-network/plonk/issues/914
 [#913]: https://github.com/dusk-network/plonk/issues/913

--- a/src/compiler/prover.rs
+++ b/src/compiler/prover.rs
@@ -23,6 +23,7 @@ use crate::proof_system::{
     ProverKey, VerifierKey, linearization_poly, quotient_poly,
 };
 use crate::transcript::TranscriptProtocol;
+use crate::util::batch_inversion;
 
 /// Turbo Prover with processed keys
 #[derive(Clone)]
@@ -33,6 +34,9 @@ pub struct Prover {
     pub(crate) verifier_key: VerifierKey,
     pub(crate) transcript: Transcript,
     sigma_evaluations: [Vec<BlsScalar>; 4],
+    domain: EvaluationDomain,
+    quotient_domain: EvaluationDomain,
+    vanishing_coset_inverses: [BlsScalar; 8],
     pub(crate) size: usize,
     pub(crate) constraints: usize,
 }
@@ -54,9 +58,40 @@ impl Prover {
         size: usize,
         constraints: usize,
     ) -> Result<Self, Error> {
+        if constraints.checked_next_power_of_two() != Some(size)
+            || prover_key.n != size
+        {
+            return Err(dusk_bytes::Error::InvalidData.into());
+        }
+
+        let domain = EvaluationDomain::new(constraints)?;
+        let quotient_size = domain
+            .size()
+            .checked_mul(8)
+            .ok_or(dusk_bytes::Error::InvalidData)?;
+        let quotient_domain = EvaluationDomain::new(quotient_size)?;
+
+        // Compilation constructs these evaluations for this exact quotient
+        // domain, while checked decoding validates their domain, length, and
+        // values before construction reaches here. Keep the checks local too,
+        // so malformed source data can never become cached proving state.
+        let vanishing_evaluations = &prover_key.v_h_coset_8n().evals;
+        if vanishing_evaluations.len() != quotient_domain.size()
+            || vanishing_evaluations
+                .iter()
+                .any(|evaluation| *evaluation == BlsScalar::zero())
+        {
+            return Err(dusk_bytes::Error::InvalidData.into());
+        }
+        let first_period = vanishing_evaluations
+            .get(..8)
+            .ok_or(dusk_bytes::Error::InvalidData)?;
+        let mut vanishing_coset_inverses = [BlsScalar::zero(); 8];
+        vanishing_coset_inverses.copy_from_slice(first_period);
+        batch_inversion(&mut vanishing_coset_inverses);
+
         let transcript =
             Transcript::base(label.as_slice(), &verifier_key, constraints);
-        let domain = EvaluationDomain::new(constraints)?;
         let sigma_evaluations = [
             domain.fft(&prover_key.permutation.s_sigma_1.0),
             domain.fft(&prover_key.permutation.s_sigma_2.0),
@@ -71,6 +106,9 @@ impl Prover {
             verifier_key,
             transcript,
             sigma_evaluations,
+            domain,
+            quotient_domain,
+            vanishing_coset_inverses,
             size,
             constraints,
         })
@@ -174,6 +212,8 @@ impl Prover {
     fn prepare_serialize(
         &self,
     ) -> (usize, Vec<u8>, Vec<u8>, [u8; VerifierKey::SIZE]) {
+        // Quotient caches are derived state. Omitting them preserves the
+        // format and ensures checked decoding always rebuilds fresh values.
         let prover_key = self.prover_key.to_var_bytes();
         let commit_key = self.commit_key.to_raw_var_bytes();
         let verifier_key = self.verifier_key.to_bytes();
@@ -384,10 +424,8 @@ impl Prover {
     {
         let prover = Composer::prove(self.constraints, circuit)?;
 
-        let constraints = self.constraints;
         let size = self.size;
-
-        let domain = EvaluationDomain::new(constraints)?;
+        let domain = self.domain;
 
         let mut transcript = self.transcript_for_version(version);
 
@@ -494,11 +532,12 @@ impl Prover {
             var_base_sep_challenge,
         );
         let t_poly = quotient_poly::compute(
-            &domain,
+            &self.quotient_domain,
             &self.prover_key,
             &z_poly,
             wires,
             &pi_poly,
+            &self.vanishing_coset_inverses,
             args,
         )?;
 
@@ -752,6 +791,95 @@ mod tests {
             result.expect("checked above").is_err(),
             "malformed input must be rejected"
         );
+    }
+
+    #[test]
+    fn prover_rebuilds_quotient_cache_after_checked_round_trip() {
+        let mut setup_rng = StdRng::seed_from_u64(47);
+        let pp = PublicParameters::setup(1 << 10, &mut setup_rng)
+            .expect("public parameters should build");
+        let (prover, _) = Compiler::compile::<MinimalCircuit>(&pp, b"p1.4-3")
+            .expect("circuit should compile");
+
+        let bytes = prover.to_bytes();
+        let decoded = Prover::try_from_bytes(&bytes)
+            .expect("checked prover bytes should decode");
+
+        assert_eq!(decoded.to_bytes(), bytes);
+        assert_eq!(decoded.domain, prover.domain);
+        assert_eq!(decoded.quotient_domain, prover.quotient_domain);
+        assert_eq!(
+            decoded.vanishing_coset_inverses,
+            prover.vanishing_coset_inverses
+        );
+        assert_eq!(decoded.vanishing_coset_inverses.len(), 8);
+
+        for (i, evaluation) in
+            decoded.prover_key.v_h_coset_8n().evals.iter().enumerate()
+        {
+            assert_eq!(
+                decoded.vanishing_coset_inverses[i & 7],
+                evaluation.invert().unwrap()
+            );
+        }
+
+        let mut original_rng = StdRng::seed_from_u64(48);
+        let mut decoded_rng = StdRng::seed_from_u64(48);
+        let original_proof = prover
+            .prove(&mut original_rng, &MinimalCircuit)
+            .expect("compiled prover should prove");
+        let decoded_proof = decoded
+            .prove(&mut decoded_rng, &MinimalCircuit)
+            .expect("decoded prover should prove");
+        assert_eq!(decoded_proof, original_proof);
+    }
+
+    #[test]
+    fn prover_rejects_malformed_derived_cache_inputs() {
+        let mut setup_rng = StdRng::seed_from_u64(49);
+        let pp = PublicParameters::setup(1 << 10, &mut setup_rng)
+            .expect("public parameters should build");
+        let (prover, _) = Compiler::compile::<MinimalCircuit>(&pp, b"p1.4-4")
+            .expect("circuit should compile");
+
+        let rebuild = |prover_key, size, constraints| {
+            Prover::new(
+                prover.label.clone(),
+                prover_key,
+                prover.commit_key.clone(),
+                prover.verifier_key,
+                size,
+                constraints,
+            )
+        };
+        let assert_invalid_data = |result| {
+            assert!(matches!(
+                result,
+                Err(Error::BytesError(dusk_bytes::Error::InvalidData))
+            ));
+        };
+
+        let mut short_evaluations = prover.prover_key.clone();
+        short_evaluations.v_h_coset_8n.evals.pop();
+        assert_invalid_data(rebuild(
+            short_evaluations,
+            prover.size,
+            prover.constraints,
+        ));
+
+        let mut zero_evaluation = prover.prover_key.clone();
+        zero_evaluation.v_h_coset_8n.evals[0] = BlsScalar::zero();
+        assert_invalid_data(rebuild(
+            zero_evaluation,
+            prover.size,
+            prover.constraints,
+        ));
+
+        assert_invalid_data(rebuild(
+            prover.prover_key.clone(),
+            prover.size,
+            prover.size + 1,
+        ));
     }
 
     #[test]

--- a/src/proof_system/quotient_poly.rs
+++ b/src/proof_system/quotient_poly.rs
@@ -13,11 +13,12 @@ use rayon::prelude::*;
 use crate::error::Error;
 use crate::fft::{EvaluationDomain, Polynomial};
 use crate::proof_system::ProverKey;
+use crate::util::batch_inversion;
 
 /// Computes the Quotient [`Polynomial`] given the [`EvaluationDomain`], a
 /// [`ProverKey`] and some other info.
 pub(crate) fn compute(
-    domain: &EvaluationDomain,
+    quotient_domain: &EvaluationDomain,
     prover_key: &ProverKey,
     z_poly: &Polynomial,
     (a_poly, b_poly, c_poly, d_poly): (
@@ -27,6 +28,7 @@ pub(crate) fn compute(
         &Polynomial,
     ),
     public_inputs_poly: &Polynomial,
+    vanishing_coset_inverses: &[BlsScalar; 8],
     (
         alpha,
         beta,
@@ -45,9 +47,6 @@ pub(crate) fn compute(
         BlsScalar,
     ),
 ) -> Result<Polynomial, Error> {
-    // Compute 8n evals
-    let domain_8n = EvaluationDomain::new(8 * domain.size())?;
-
     let [
         mut z_eval_8n,
         mut a_eval_8n,
@@ -55,7 +54,7 @@ pub(crate) fn compute(
         c_eval_8n,
         mut d_eval_8n,
     ] = compute_coset_evaluations(
-        &domain_8n,
+        quotient_domain,
         [z_poly, a_poly, b_poly, c_poly, d_poly],
     );
 
@@ -68,7 +67,7 @@ pub(crate) fn compute(
     }
 
     let t_1 = compute_circuit_satisfiability_equation(
-        domain,
+        quotient_domain,
         (
             range_challenge,
             logic_challenge,
@@ -81,7 +80,7 @@ pub(crate) fn compute(
     );
 
     let t_2 = compute_permutation_checks(
-        domain,
+        quotient_domain,
         prover_key,
         (&a_eval_8n, &b_eval_8n, &c_eval_8n, &d_eval_8n),
         &z_eval_8n,
@@ -89,20 +88,19 @@ pub(crate) fn compute(
     );
 
     #[cfg(not(feature = "std"))]
-    let range = (0..domain_8n.size()).into_iter();
+    let range = (0..quotient_domain.size()).into_iter();
 
     #[cfg(feature = "std")]
-    let range = (0..domain_8n.size()).into_par_iter();
+    let range = (0..quotient_domain.size()).into_par_iter();
 
     let quotient: Vec<_> = range
         .map(|i| {
             let numerator = t_1[i] + t_2[i];
-            let denominator = prover_key.v_h_coset_8n()[i];
-            numerator * denominator.invert().unwrap()
+            numerator * vanishing_coset_inverses[i & 7]
         })
         .collect();
 
-    let coset = domain_8n.coset_ifft(&quotient);
+    let coset = quotient_domain.coset_ifft(&quotient);
     let quotient_poly = Polynomial::from_coefficients_vec(coset);
 
     // A satisfied assignment yields a numerator divisible by the vanishing
@@ -131,7 +129,7 @@ pub(crate) fn compute(
     // degree in constant time instead of rescanning the coefficients, and
     // `degree() >= 7n` becomes `len() > 7n` (the empty polynomial passes
     // either way).
-    if quotient_poly.len() > 7 * domain.size() {
+    if quotient_poly.len() > 7 * (quotient_domain.size() / 8) {
         return Err(Error::CircuitUnsatisfied);
     }
 
@@ -160,7 +158,7 @@ fn compute_coset_evaluations(
 
 // Ensures that the circuit is satisfied
 fn compute_circuit_satisfiability_equation(
-    domain: &EvaluationDomain,
+    quotient_domain: &EvaluationDomain,
     (
         range_challenge,
         logic_challenge,
@@ -176,14 +174,13 @@ fn compute_circuit_satisfiability_equation(
     ),
     pi_poly: &Polynomial,
 ) -> Vec<BlsScalar> {
-    let domain_8n = EvaluationDomain::new(8 * domain.size()).unwrap();
-    let public_eval_8n = domain_8n.coset_fft(pi_poly);
+    let public_eval_8n = quotient_domain.coset_fft(pi_poly);
 
     #[cfg(not(feature = "std"))]
-    let range = (0..domain_8n.size()).into_iter();
+    let range = (0..quotient_domain.size()).into_iter();
 
     #[cfg(feature = "std")]
-    let range = (0..domain_8n.size()).into_par_iter();
+    let range = (0..quotient_domain.size()).into_par_iter();
 
     let t: Vec<_> = range
         .map(|i| {
@@ -254,7 +251,7 @@ fn compute_circuit_satisfiability_equation(
 }
 
 fn compute_permutation_checks(
-    domain: &EvaluationDomain,
+    quotient_domain: &EvaluationDomain,
     prover_key: &ProverKey,
     (a_eval_8n, b_eval_8n, c_eval_8n, d_eval_8n): (
         &[BlsScalar],
@@ -265,16 +262,32 @@ fn compute_permutation_checks(
     z_eval_8n: &[BlsScalar],
     (alpha, beta, gamma): (&BlsScalar, &BlsScalar, &BlsScalar),
 ) -> Vec<BlsScalar> {
-    let domain_8n = EvaluationDomain::new(8 * domain.size()).unwrap();
-    let l1_poly_alpha =
-        compute_first_lagrange_poly_scaled(domain, alpha.square());
-    let l1_alpha_sq_evals = domain_8n.coset_fft(&l1_poly_alpha);
+    let l1_alpha_sq = alpha.square();
+    let mut first_lagrange_coset_evaluations: Vec<_> = prover_key
+        .permutation
+        .linear_evaluations
+        .evals
+        .iter()
+        .map(|evaluation| *evaluation - BlsScalar::one())
+        .collect();
+    batch_inversion(&mut first_lagrange_coset_evaluations);
+
+    // The quotient domain has size 8n, while L1 is defined over the n-sized
+    // proving domain: L1(x) = (x^n - 1) / (n * (x - 1)).
+    let proving_domain_size_inv =
+        quotient_domain.size_inv * BlsScalar::from(8u64);
+    first_lagrange_coset_evaluations
+        .iter_mut()
+        .zip(&prover_key.v_h_coset_8n().evals)
+        .for_each(|(denominator_inv, vanishing)| {
+            *denominator_inv *= vanishing * proving_domain_size_inv;
+        });
 
     #[cfg(not(feature = "std"))]
-    let range = (0..domain_8n.size()).into_iter();
+    let range = (0..quotient_domain.size()).into_iter();
 
     #[cfg(feature = "std")]
-    let range = (0..domain_8n.size()).into_par_iter();
+    let range = (0..quotient_domain.size()).into_par_iter();
 
     let t: Vec<_> = range
         .map(|i| {
@@ -287,7 +300,7 @@ fn compute_permutation_checks(
                 &z_eval_8n[i],
                 &z_eval_8n[i + 8],
                 alpha,
-                &l1_alpha_sq_evals[i],
+                &(first_lagrange_coset_evaluations[i] * l1_alpha_sq),
                 beta,
                 gamma,
             )
@@ -295,16 +308,6 @@ fn compute_permutation_checks(
         .collect();
     t
 }
-fn compute_first_lagrange_poly_scaled(
-    domain: &EvaluationDomain,
-    scale: BlsScalar,
-) -> Polynomial {
-    let mut x_evals = vec![BlsScalar::zero(); domain.size()];
-    x_evals[0] = scale;
-    domain.ifft_in_place(&mut x_evals);
-    Polynomial::from_coefficients_vec(x_evals)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- cache the base and `8n` quotient evaluation domains on `Prover`
- cache the eight-value period of the validated vanishing-coset inverses
- derive first-Lagrange coset evaluations from their closed form with one batch inversion per proof instead of retaining another `8n` vector
- rebuild all retained derived state after checked deserialization without changing prover serialization

## Safety and compatibility

The caches are private derived state and are not serialized. `Prover::try_from_bytes` still performs checked prover-key decoding, including exact evaluation-domain, linear-coset and vanishing-evaluation validation, before cache construction. The constructor also rejects inconsistent circuit sizes, wrong cache-source lengths and zero vanishing evaluations before they can become proving state.

The first-Lagrange values are reconstructed as `L1(x) = (x^n - 1) / (n * (x - 1))` from those validated coset evaluations. This adds no unchecked API and does not change proof encoding, transcript inputs, verifier keys or serialized prover bytes. The deterministic V3 proof digest remains byte-identical to the public base behavior.

## Performance

Measured against current `master` at `0630625c06f916f79804be765b8eb2a47c4bb6a3` on the designated CPX42 reference worker. The workload is a production-shaped four-input Phoenix transfer with 131,024 constraints and a `2^17` proving domain. Each variant ran in three separate processes, with one warm-up and one measured proof per process; order was rotated across rounds.

| Variant | Median proof | Proof range | Median peak RSS |
| --- | ---: | ---: | ---: |
| current `master` | 52.141s | 51.737–53.058s | 2,151,112 KiB |
| retain full `8n` L1 vector | 40.204s | 40.124–40.953s | 2,184,020 KiB |
| this PR: closed-form L1 | 40.660s | 40.529–41.025s | 2,151,372 KiB |

The selected design reduces median proving time by **22.02%** relative to current `master`. Retaining the full vector was only 1.13% faster, but added 32.14 MiB of measured peak RSS. The selected closed form was within 0.25 MiB of baseline peak RSS and avoids permanently retaining a 32 MiB vector per `2^17` prover.

Across Rusk's one `2^16` and three `2^17` Phoenix provers, retaining that vector would cost exactly 112 MiB. Compilation and verification showed no material change between variants.

## Validation

- rebased directly onto current `master`, preserving the merged #923 and #926 implementations
- `make test`
- `make fmt`
- `make clippy`
- `make no-std`
- focused checked-deserialization, malformed-constructor and cache round-trip tests
- deterministic V3 proof digest compatibility fixture
- three-way production-shaped Phoenix benchmark on the CPX42 reference worker

Resolves #919
