### PR TITLE
Parallelize quotient coset FFTs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve prover hot-path performance by reusing sigma evaluations, batching
   permutation inversions, reducing opening-polynomial allocations, and
   parallelizing large FFT stages and independent work [#921]
+- Parallelize independent quotient coset FFTs when `std` is enabled while
+  retaining the serial `no_std` path [#925]
 - Change RKYV `CommitKey` and `PublicParameters` archives to store canonical
   compressed commitment- and opening-key source points and rebuild prepared
   pairing values during deserialization. Existing RKYV parameter archives
@@ -761,6 +763,7 @@ is necessary since `rkyv/validation` was required as a bound.
 
 <!-- ISSUES -->
 [#930]: https://github.com/dusk-network/plonk/issues/930
+[#925]: https://github.com/dusk-network/plonk/issues/925
 [#921]: https://github.com/dusk-network/plonk/issues/921
 [#920]: https://github.com/dusk-network/plonk/issues/920
 [#914]: https://github.com/dusk-network/plonk/issues/914

--- a/src/proof_system/quotient_poly.rs
+++ b/src/proof_system/quotient_poly.rs
@@ -48,12 +48,16 @@ pub(crate) fn compute(
     // Compute 8n evals
     let domain_8n = EvaluationDomain::new(8 * domain.size())?;
 
-    let mut z_eval_8n = domain_8n.coset_fft(z_poly);
-
-    let mut a_eval_8n = domain_8n.coset_fft(a_poly);
-    let mut b_eval_8n = domain_8n.coset_fft(b_poly);
-    let c_eval_8n = domain_8n.coset_fft(c_poly);
-    let mut d_eval_8n = domain_8n.coset_fft(d_poly);
+    let [
+        mut z_eval_8n,
+        mut a_eval_8n,
+        mut b_eval_8n,
+        c_eval_8n,
+        mut d_eval_8n,
+    ] = compute_coset_evaluations(
+        &domain_8n,
+        [z_poly, a_poly, b_poly, c_poly, d_poly],
+    );
 
     for i in 0..8 {
         z_eval_8n.push(z_eval_8n[i]);
@@ -132,6 +136,26 @@ pub(crate) fn compute(
     }
 
     Ok(quotient_poly)
+}
+
+fn compute_coset_evaluations(
+    domain: &EvaluationDomain,
+    polynomials: [&Polynomial; 5],
+) -> [Vec<BlsScalar>; 5] {
+    #[cfg(not(feature = "std"))]
+    let evaluations = polynomials.map(|poly| domain.coset_fft(poly));
+
+    #[cfg(feature = "std")]
+    let evaluations = {
+        let mut evaluations: [Vec<BlsScalar>; 5] = Default::default();
+        evaluations
+            .par_iter_mut()
+            .zip(&polynomials[..])
+            .for_each(|(slot, poly)| *slot = domain.coset_fft(poly));
+        evaluations
+    };
+
+    evaluations
 }
 
 // Ensures that the circuit is satisfied
@@ -279,4 +303,26 @@ fn compute_first_lagrange_poly_scaled(
     x_evals[0] = scale;
     domain.ifft_in_place(&mut x_evals);
     Polynomial::from_coefficients_vec(x_evals)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coset_evaluations_preserve_input_order() {
+        let domain = EvaluationDomain::new(8).unwrap();
+        let polynomials = core::array::from_fn(|index| {
+            Polynomial::from_coefficients_vec(vec![
+                BlsScalar::from(index as u64 + 1),
+                BlsScalar::from(index as u64 + 6),
+            ])
+        });
+        let expected =
+            polynomials.each_ref().map(|poly| domain.coset_fft(poly));
+
+        let actual = compute_coset_evaluations(&domain, polynomials.each_ref());
+
+        assert_eq!(actual, expected);
+    }
 }


### PR DESCRIPTION
Resolves #925

## Summary

- compute the five independent quotient coset FFTs concurrently when `std` is enabled
- retain the existing ordered serial path for `no_std` builds
- pin exact output equivalence and ordering with a focused regression

This does not change the quotient arithmetic, transcript, proof format, serialization, or public API. Native Rusk proving enables `dusk-plonk/std`; portable Phoenix and browser builds remain `no_std` and do not pull in Rayon.

## Phoenix benchmark

Production-shaped four-input transfer, 131,024 constraints, 2^17 proving domain, CPX42 with eight shared vCPUs, `RAYON_NUM_THREADS=8`. Each pass used one warm-up and five measured proofs; the order was baseline, candidate, candidate, baseline.

Directly against public `master`:

| Variant | Median pass A | Median pass B | Average median |
| --- | ---: | ---: | ---: |
| `master` | 15.794 s | 15.778 s | 15.786 s |
| Candidate | 12.809 s | 12.779 s | 12.794 s |

That is an 18.953% reduction. Verification latency and peak RSS were unchanged.

On top of #923 and #924, the same change reduced the average median from 10.988 s to 8.062 s, a 26.628% reduction.

## Validation

- `make test`
- `make clippy`
- `make no-std`
- `make doc`
- nightly formatting and diff checks
- mutation check: swapping two parallel outputs makes the ordering regression fail
- every measured Phoenix proof was verified by the unchanged verifier