### PR TITLE
Cache verifier public-input roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove the `Copy` derive from `Error` [#884]
 - Speed up proof verification by grouping the final pairing-input MSM terms
   and batch-normalizing its G1 inputs [#920]
+- Cache verifier domains and public-input roots and batch their denominator
+  inversions during proof verification [#927]
 - Change `component_add_point`, `component_sub_point` and `component_mul_point` to `TorsionFreeWitnessPoint` [#870]
 - Change `component_neg_point` and `component_select_identity` to `TorsionFreeWitnessPoint` [#870]
 - Change `component_select_identity` to constrain its `bit` to boolean [#870]
@@ -79,6 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reject unrepresentable evaluation domain sizes during verifier construction
+  and checked deserialization [#927]
 - Reject invalid witness, polynomial, selector and public-input indices when
   deserializing compressed circuits [#930]
 - Reject trailing data when deserializing compressed circuits [#913]
@@ -768,6 +772,7 @@ is necessary since `rkyv/validation` was required as a bound.
 [#930]: https://github.com/dusk-network/plonk/issues/930
 [#925]: https://github.com/dusk-network/plonk/issues/925
 [#921]: https://github.com/dusk-network/plonk/issues/921
+[#927]: https://github.com/dusk-network/plonk/issues/927
 [#920]: https://github.com/dusk-network/plonk/issues/920
 [#919]: https://github.com/dusk-network/plonk/issues/919
 [#916]: https://github.com/dusk-network/plonk/issues/916

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -434,7 +434,7 @@ impl Compiler {
             public_input_indexes,
             size,
             constraints,
-        );
+        )?;
 
         Ok((prover, verifier))
     }

--- a/src/compiler/verifier.rs
+++ b/src/compiler/verifier.rs
@@ -13,6 +13,7 @@ use merlin::Transcript;
 use super::PlonkVersion;
 use crate::commitment_scheme::OpeningKey;
 use crate::error::Error;
+use crate::fft::EvaluationDomain;
 use crate::proof_system::{Proof, VerifierKey};
 use crate::transcript::TranscriptProtocol;
 /// Verify proofs of a given circuit
@@ -21,6 +22,8 @@ pub struct Verifier {
     verifier_key: VerifierKey,
     opening_key: OpeningKey,
     public_input_indexes: Vec<usize>,
+    public_input_roots: Vec<BlsScalar>,
+    domain: EvaluationDomain,
     transcript: Transcript,
     size: usize,
     constraints: usize,
@@ -34,19 +37,26 @@ impl Verifier {
         public_input_indexes: Vec<usize>,
         size: usize,
         constraints: usize,
-    ) -> Self {
+    ) -> Result<Self, Error> {
+        let domain = EvaluationDomain::new(verifier_key.n)?;
+        let public_input_roots = public_input_indexes
+            .iter()
+            .map(|index| domain.group_gen_inv.pow(&[*index as u64, 0, 0, 0]))
+            .collect();
         let transcript =
             Transcript::base(label.as_slice(), &verifier_key, constraints);
 
-        Self {
+        Ok(Self {
             label,
             verifier_key,
             opening_key,
             public_input_indexes,
+            public_input_roots,
+            domain,
             transcript,
             size,
             constraints,
-        }
+        })
     }
 
     fn prepare_serialize(
@@ -181,14 +191,14 @@ impl Verifier {
             .map(|n| n as usize)
             .collect();
 
-        Ok(Self::new(
+        Self::new(
             label,
             verifier_key,
             opening_key,
             public_input_indexes,
             size,
             constraints,
-        ))
+        )
     }
 
     /// Verify a generated proof using the current (latest) verification
@@ -226,14 +236,16 @@ impl Verifier {
                 &self.verifier_key,
                 &mut transcript,
                 &self.opening_key,
-                &self.public_input_indexes,
+                &self.domain,
+                &self.public_input_roots,
                 public_inputs,
             ),
             PlonkVersion::V2 | PlonkVersion::V3 => proof.verify(
                 &self.verifier_key,
                 &mut transcript,
                 &self.opening_key,
-                &self.public_input_indexes,
+                &self.domain,
+                &self.public_input_roots,
                 public_inputs,
             ),
         }
@@ -253,7 +265,27 @@ impl Verifier {
 
 #[cfg(test)]
 mod tests {
+    use dusk_bls12_381::BlsScalar;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
     use super::*;
+    use crate::prelude::{Circuit, Compiler, Composer, PublicParameters};
+
+    #[derive(Default)]
+    struct MinimalCircuit;
+
+    impl Circuit for MinimalCircuit {
+        fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
+            let witness = composer.append_witness(BlsScalar::from(7u64));
+            composer.assert_equal_constant(
+                witness,
+                BlsScalar::from(7u64),
+                None,
+            );
+            Ok(())
+        }
+    }
 
     #[test]
     fn verifier_try_from_bytes_rejects_overflow_lengths_without_panicking() {
@@ -272,5 +304,30 @@ mod tests {
             "try_from_bytes panicked on overflow lengths"
         );
         assert!(matches!(result.unwrap(), Err(Error::NotEnoughBytes)));
+    }
+
+    #[test]
+    fn verifier_try_from_bytes_rejects_oversized_domain_without_panicking() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let pp = PublicParameters::setup(1 << 5, &mut rng)
+            .expect("public parameters should build");
+        let (_, verifier) =
+            Compiler::compile::<MinimalCircuit>(&pp, b"oversized-domain")
+                .expect("circuit should compile");
+
+        let mut bytes = verifier.to_bytes();
+        let label_len = u64::from_be_bytes(
+            bytes[..u64::SIZE].try_into().expect("header is complete"),
+        ) as usize;
+        let verifier_key_offset = 48 + label_len;
+        bytes[verifier_key_offset..verifier_key_offset + u64::SIZE].fill(0xff);
+
+        let result =
+            std::panic::catch_unwind(|| Verifier::try_from_bytes(&bytes));
+        assert!(result.is_ok(), "deserializer should never panic");
+        assert!(matches!(
+            result.expect("checked above"),
+            Err(Error::InvalidEvalDomainSize { .. })
+        ));
     }
 }

--- a/src/fft/domain.rs
+++ b/src/fft/domain.rs
@@ -121,7 +121,12 @@ pub(crate) mod alloc {
         /// polynomial having `num_coeffs` coefficients.
         pub(crate) fn new(num_coeffs: usize) -> Result<Self, Error> {
             // Compute the size of our evaluation domain
-            let size = num_coeffs.next_power_of_two() as u64;
+            let size = num_coeffs.checked_next_power_of_two().ok_or(
+                Error::InvalidEvalDomainSize {
+                    log_size_of_group: usize::BITS,
+                    adacity: TWO_ADACITY,
+                },
+            )? as u64;
             let log_size_of_group = size.trailing_zeros();
 
             if log_size_of_group >= TWO_ADACITY {

--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -220,11 +220,10 @@ pub(crate) mod alloc {
             verifier_key: &VerifierKey,
             transcript: &mut Transcript,
             opening_key: &OpeningKey,
-            public_input_indexes: &[usize],
+            domain: &EvaluationDomain,
+            public_input_roots: &[BlsScalar],
             pub_inputs: &[BlsScalar],
         ) -> Result<(), Error> {
-            let domain = EvaluationDomain::new(verifier_key.n)?;
-
             // Subgroup checks are done when the proof is deserialized.
 
             // In order for the Verifier and Prover to have the same view in the
@@ -314,20 +313,17 @@ pub(crate) mod alloc {
             // Compute zero polynomial evaluated at challenge `z`
             let z_h_eval = domain.evaluate_vanishing_polynomial(&z_challenge);
 
-            // Compute first lagrange polynomial evaluated at challenge `z`
-            let l1_eval = compute_first_lagrange_evaluation(
-                &domain,
-                &z_h_eval,
-                &z_challenge,
-            );
-
-            // Evaluate public inputs
-            let pi_eval = compute_barycentric_eval_sparse(
-                public_input_indexes,
-                pub_inputs,
-                &z_challenge,
-                &domain,
-            );
+            // Evaluate the first Lagrange polynomial and public inputs with a
+            // single batch inversion. The public-input roots are fixed for a
+            // verifier and are precomputed when it is constructed.
+            let (l1_eval, pi_eval) =
+                compute_lagrange_and_barycentric_evaluations(
+                    public_input_roots,
+                    pub_inputs,
+                    &z_challenge,
+                    &z_h_eval,
+                    domain,
+                )?;
 
             // Compute r_0
             let r_0_eval = pi_eval
@@ -527,11 +523,10 @@ pub(crate) mod alloc {
             verifier_key: &VerifierKey,
             transcript: &mut Transcript,
             opening_key: &OpeningKey,
-            public_input_indexes: &[usize],
+            domain: &EvaluationDomain,
+            public_input_roots: &[BlsScalar],
             pub_inputs: &[BlsScalar],
         ) -> Result<(), Error> {
-            let domain = EvaluationDomain::new(verifier_key.n)?;
-
             // Subgroup checks are done when the proof is deserialized.
 
             // In order for the Verifier and Prover to have the same view in the
@@ -621,20 +616,17 @@ pub(crate) mod alloc {
             // Compute zero polynomial evaluated at challenge `z`
             let z_h_eval = domain.evaluate_vanishing_polynomial(&z_challenge);
 
-            // Compute first lagrange polynomial evaluated at challenge `z`
-            let l1_eval = compute_first_lagrange_evaluation(
-                &domain,
-                &z_h_eval,
-                &z_challenge,
-            );
-
-            // Evaluate public inputs
-            let pi_eval = compute_barycentric_eval_sparse(
-                public_input_indexes,
-                pub_inputs,
-                &z_challenge,
-                &domain,
-            );
+            // Evaluate the first Lagrange polynomial and public inputs with a
+            // single batch inversion. The public-input roots are fixed for a
+            // verifier and are precomputed when it is constructed.
+            let (l1_eval, pi_eval) =
+                compute_lagrange_and_barycentric_evaluations(
+                    public_input_roots,
+                    pub_inputs,
+                    &z_challenge,
+                    &z_h_eval,
+                    domain,
+                )?;
 
             // Compute r_0
             let r_0_eval = pi_eval
@@ -1002,14 +994,49 @@ pub(crate) mod alloc {
         assert_eq!(*grouped, expected);
     }
 
-    fn compute_first_lagrange_evaluation(
-        domain: &EvaluationDomain,
+    fn compute_lagrange_and_barycentric_evaluations(
+        public_input_roots: &[BlsScalar],
+        evaluations: &[BlsScalar],
+        point: &BlsScalar,
         z_h_eval: &BlsScalar,
-        z_challenge: &BlsScalar,
-    ) -> BlsScalar {
-        let n_fr = BlsScalar::from(domain.size() as u64);
-        let denom = n_fr * (z_challenge - BlsScalar::one());
-        z_h_eval * denom.invert().unwrap()
+        domain: &EvaluationDomain,
+    ) -> Result<(BlsScalar, BlsScalar), Error> {
+        let non_zero_inputs: Vec<_> = public_input_roots
+            .iter()
+            .copied()
+            .zip(evaluations.iter().copied())
+            .filter(|(_, evaluation)| *evaluation != BlsScalar::zero())
+            .collect();
+
+        let mut denominators = Vec::with_capacity(non_zero_inputs.len() + 1);
+        denominators
+            .push(domain.size_as_field_element * (point - BlsScalar::one()));
+
+        denominators.extend(
+            non_zero_inputs
+                .iter()
+                .map(|(root, _)| (*root * point) - BlsScalar::one()),
+        );
+
+        if denominators
+            .iter()
+            .any(|denominator| denominator == &BlsScalar::zero())
+        {
+            return Err(Error::ProofVerificationError);
+        }
+
+        batch_inversion(&mut denominators);
+
+        let l1_eval = z_h_eval * denominators[0];
+        let pi_eval: BlsScalar = non_zero_inputs
+            .iter()
+            .zip(&denominators[1..])
+            .map(|((_, evaluation), inverse)| *inverse * *evaluation)
+            .sum::<BlsScalar>()
+            * z_h_eval
+            * domain.size_inv;
+
+        Ok((l1_eval, pi_eval))
     }
 
     pub(crate) fn compute_barycentric_eval(
@@ -1066,7 +1093,8 @@ pub(crate) mod alloc {
         result * numerator
     }
 
-    pub(crate) fn compute_barycentric_eval_sparse(
+    #[cfg(test)]
+    fn compute_barycentric_eval_sparse(
         indexes: &[usize],
         evaluations: &[BlsScalar],
         point: &BlsScalar,
@@ -1107,6 +1135,85 @@ pub(crate) mod alloc {
             .sum();
 
         result * numerator
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn fused_lagrange_and_sparse_evaluation_matches_separate_formulas() {
+            let domain = EvaluationDomain::new(1 << 5).unwrap();
+            let indexes = [0usize, 3, 17, 31];
+            let evaluations = [
+                BlsScalar::from(2u64),
+                BlsScalar::zero(),
+                BlsScalar::from(5u64),
+                BlsScalar::from(9u64),
+            ];
+            let roots: Vec<_> = indexes
+                .iter()
+                .map(|index| {
+                    domain.group_gen_inv.pow(&[*index as u64, 0, 0, 0])
+                })
+                .collect();
+            let point = BlsScalar::from(7u64);
+            let z_h_eval = domain.evaluate_vanishing_polynomial(&point);
+
+            let (l1_eval, pi_eval) =
+                compute_lagrange_and_barycentric_evaluations(
+                    &roots,
+                    &evaluations,
+                    &point,
+                    &z_h_eval,
+                    &domain,
+                )
+                .unwrap();
+
+            let l1_denominator =
+                domain.size_as_field_element * (point - BlsScalar::one());
+            let expected_l1 = z_h_eval * l1_denominator.invert().unwrap();
+            let expected_pi = compute_barycentric_eval_sparse(
+                &indexes,
+                &evaluations,
+                &point,
+                &domain,
+            );
+
+            assert_eq!(l1_eval, expected_l1);
+            assert_eq!(pi_eval, expected_pi);
+        }
+
+        #[test]
+        fn fused_evaluation_rejects_a_domain_point() {
+            let domain = EvaluationDomain::new(1 << 5).unwrap();
+            let result = compute_lagrange_and_barycentric_evaluations(
+                &[],
+                &[],
+                &BlsScalar::one(),
+                &BlsScalar::zero(),
+                &domain,
+            );
+
+            assert!(matches!(result, Err(Error::ProofVerificationError)));
+        }
+
+        #[test]
+        fn fused_evaluation_rejects_a_public_input_domain_point() {
+            let domain = EvaluationDomain::new(1 << 5).unwrap();
+            let index = 3u64;
+            let point = domain.group_gen.pow(&[index, 0, 0, 0]);
+            let root = domain.group_gen_inv.pow(&[index, 0, 0, 0]);
+            let result = compute_lagrange_and_barycentric_evaluations(
+                &[root],
+                &[BlsScalar::one()],
+                &point,
+                &BlsScalar::zero(),
+                &domain,
+            );
+
+            assert!(matches!(result, Err(Error::ProofVerificationError)));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- cache the fixed evaluation domain and public-input roots in each compiled or checked-deserialized verifier
- reuse the vanishing-polynomial evaluation and batch the first-Lagrange and nonzero public-input denominators into one inversion pass
- preserve verifier serialization, proof/transcript equations, and the public API
- return `ProofVerificationError` for singular evaluation points instead of reaching the previous inversion unwrap
- reject evaluation-domain sizes that cannot be represented without unwinding during checked deserialization

## Performance

On the designated CPX42 reference worker, a production-shaped four-input Phoenix transfer proof at a `2^17` domain was measured in interleaved base/candidate/candidate/base order with 2,000 verifications per pass:

| Variant | Average median verification |
| --- | ---: |
| Grouped-MSM verifier | 5.5491 ms |
| This PR | 4.9137 ms |

That is an 11.45% reduction. The two individual comparisons were 11.05% and 11.85%. Compilation, proving, peak RSS, proof bytes, and verifier serialization were unchanged within run variance.

Two bounded MSM follow-ups were rejected rather than included: a larger 30-point MSM window was 19.5% slower in isolation, and splitting fixed points into cached WNAF tables was roughly 3.5x slower than the grouped MSM.

## Validation

- rebased directly onto current `master`
- full default and all-feature release tests
- Clippy and `no_std` builds
- formatting and diff checks
- differential coverage against the old separate L1 and sparse public-input formulas
- singular-point regressions for both `z = 1` and a nonzero public-input domain point
- debug regression proving oversized checked verifier input returns an error without unwinding
- mutation check: removing the domain-size inverse fails the differential regression
- real four-input Phoenix proofs generated and verified on both benchmark variants

Resolves #927
