### PR TITLE
Parallelize final FFT stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parallelize independent quotient coset FFTs when `std` is enabled while
   retaining the serial `no_std` path [#925]
 - Cache deterministic quotient-domain prover data across proofs [#919]
+- Parallelize the final large-domain FFT stages across Rayon pools with at
+  least four workers [#933]
 - Change RKYV `CommitKey` and `PublicParameters` archives to store canonical
   compressed commitment- and opening-key source points and rebuild prepared
   pairing values during deserialization. Existing RKYV parameter archives
@@ -772,6 +774,7 @@ is necessary since `rkyv/validation` was required as a bound.
 
 <!-- ISSUES -->
 [#935]: https://github.com/dusk-network/plonk/issues/935
+[#933]: https://github.com/dusk-network/plonk/issues/933
 [#930]: https://github.com/dusk-network/plonk/issues/930
 [#925]: https://github.com/dusk-network/plonk/issues/925
 [#921]: https://github.com/dusk-network/plonk/issues/921

--- a/src/fft/domain.rs
+++ b/src/fft/domain.rs
@@ -366,6 +366,20 @@ pub(crate) mod alloc {
     }
 
     #[cfg(feature = "std")]
+    pub(super) const PARALLEL_FINAL_FFT_MIN_LEN: usize = 1 << 12;
+    #[cfg(feature = "std")]
+    pub(super) const PARALLEL_FINAL_FFT_MIN_THREADS: usize = 4;
+
+    #[cfg(feature = "std")]
+    pub(super) fn should_parallelize_final_fft_stages(
+        len: usize,
+        threads: usize,
+    ) -> bool {
+        len >= PARALLEL_FINAL_FFT_MIN_LEN
+            && threads >= PARALLEL_FINAL_FFT_MIN_THREADS
+    }
+
+    #[cfg(feature = "std")]
     fn best_fft(a: &mut [BlsScalar], omega: BlsScalar, log_n: u32) {
         const PARALLEL_FFT_MIN_LEN: usize = 1 << 12;
         const PARALLEL_FFT_MIN_CHUNKS: usize = 4;
@@ -379,12 +393,7 @@ pub(crate) mod alloc {
         let n_u32 = n as u32;
         assert_eq!(n_u32, 1 << log_n);
 
-        for k in 0..n_u32 {
-            let rk = bitreverse(k, log_n);
-            if k < rk {
-                a.swap(rk as usize, k as usize);
-            }
-        }
+        bitreverse_permute(a, log_n);
 
         let mut m = 1usize;
         for _ in 0..log_n {
@@ -395,6 +404,13 @@ pub(crate) mod alloc {
             if chunk_count >= PARALLEL_FFT_MIN_CHUNKS {
                 a.par_chunks_mut(chunk_len)
                     .for_each(|chunk| butterfly_chunk(chunk, m, w_m));
+            } else if should_parallelize_final_fft_stages(
+                n,
+                rayon::current_num_threads(),
+            ) {
+                for chunk in a.chunks_mut(chunk_len) {
+                    parallel_butterfly_chunk(chunk, m, w_m);
+                }
             } else {
                 for chunk in a.chunks_mut(chunk_len) {
                     butterfly_chunk(chunk, m, w_m);
@@ -415,6 +431,15 @@ pub(crate) mod alloc {
         r
     }
 
+    fn bitreverse_permute(a: &mut [BlsScalar], log_n: u32) {
+        for k in 0..a.len() as u32 {
+            let rk = bitreverse(k, log_n);
+            if k < rk {
+                a.swap(rk as usize, k as usize);
+            }
+        }
+    }
+
     pub(crate) fn serial_fft(
         a: &mut [BlsScalar],
         omega: BlsScalar,
@@ -423,52 +448,71 @@ pub(crate) mod alloc {
         let n = a.len() as u32;
         assert_eq!(n, 1 << log_n);
 
-        for k in 0..n {
-            let rk = bitreverse(k, log_n);
-            if k < rk {
-                a.swap(rk as usize, k as usize);
-            }
-        }
+        bitreverse_permute(a, log_n);
 
         let mut m = 1;
         for _ in 0..log_n {
             let w_m = omega.pow(&[(n / (2 * m)) as u64, 0, 0, 0]);
 
-            let mut k = 0;
-            while k < n {
-                let mut w = BlsScalar::one();
-                for j in 0..m {
-                    let mut t = a[(k + j + m) as usize];
-                    t *= &w;
-                    let mut tmp = a[(k + j) as usize];
-                    tmp -= &t;
-                    a[(k + j + m) as usize] = tmp;
-                    a[(k + j) as usize] += &t;
-                    w.mul_assign(&w_m);
-                }
-
-                k += 2 * m;
+            for chunk in a.chunks_mut((2 * m) as usize) {
+                butterfly_chunk(chunk, m as usize, w_m);
             }
 
             m *= 2;
         }
     }
 
-    #[cfg(feature = "std")]
     #[inline]
     fn butterfly_chunk(chunk: &mut [BlsScalar], m: usize, w_m: BlsScalar) {
         let (left, right) = chunk.split_at_mut(m);
-        let mut w = BlsScalar::one();
+        butterfly_range(left, right, w_m, BlsScalar::one());
+    }
 
-        for j in 0..m {
-            let mut t = right[j];
+    #[inline]
+    fn butterfly_range(
+        left: &mut [BlsScalar],
+        right: &mut [BlsScalar],
+        w_m: BlsScalar,
+        mut w: BlsScalar,
+    ) {
+        debug_assert_eq!(left.len(), right.len());
+
+        for (left, right) in left.iter_mut().zip(right) {
+            let mut t = *right;
             t *= &w;
-            let mut tmp = left[j];
+            let mut tmp = *left;
             tmp -= &t;
-            right[j] = tmp;
-            left[j] += &t;
+            *right = tmp;
+            *left += &t;
             w.mul_assign(&w_m);
         }
+    }
+
+    #[cfg(feature = "std")]
+    fn parallel_butterfly_chunk(
+        chunk: &mut [BlsScalar],
+        m: usize,
+        w_m: BlsScalar,
+    ) {
+        let (left, right) = chunk.split_at_mut(m);
+        let range_len = m.div_ceil(rayon::current_num_threads());
+        let range_count = m.div_ceil(range_len);
+        let seed_step = w_m.pow_vartime(&[range_len as u64, 0, 0, 0]);
+        let mut seed = BlsScalar::one();
+        let seeds = (0..range_count)
+            .map(|_| {
+                let current = seed;
+                seed *= &seed_step;
+                current
+            })
+            .collect::<Vec<_>>();
+
+        left.par_chunks_mut(range_len)
+            .zip(right.par_chunks_mut(range_len))
+            .zip(seeds)
+            .for_each(|((left, right), seed)| {
+                butterfly_range(left, right, w_m, seed)
+            });
     }
 
     /// An iterator over the elements of the domain.
@@ -527,19 +571,50 @@ mod tests {
     #[test]
     fn parallel_fft_matches_serial_fft_for_large_domain() {
         let domain = EvaluationDomain::new(1 << 12).unwrap();
-        let parallel = (0..domain.size())
+        let input = (0..domain.size())
             .map(|i| BlsScalar::from((i as u64) + 1))
             .collect::<Vec<_>>();
-        let mut serial = parallel.clone();
-
-        let parallel = domain.fft(&parallel);
+        let mut serial = input.clone();
         crate::fft::domain::alloc::serial_fft(
             &mut serial,
             domain.group_gen,
             domain.log_size_of_group,
         );
 
-        assert_eq!(parallel, serial);
+        assert!(
+            !crate::fft::domain::alloc::should_parallelize_final_fft_stages(
+                1 << 11,
+                8
+            )
+        );
+        assert!(
+            !crate::fft::domain::alloc::should_parallelize_final_fft_stages(
+                1 << 12,
+                3
+            )
+        );
+        assert!(
+            crate::fft::domain::alloc::should_parallelize_final_fft_stages(
+                1 << 12,
+                4
+            )
+        );
+
+        for threads in [3, 4, 9] {
+            let pool = rayon::ThreadPoolBuilder::new()
+                .num_threads(threads)
+                .build()
+                .unwrap();
+            let parallel = pool.install(|| domain.fft(&input));
+
+            assert_eq!(parallel, serial, "failed with {threads} threads");
+
+            let roundtrip = pool.install(|| domain.ifft(&parallel));
+            assert_eq!(
+                roundtrip, input,
+                "roundtrip failed with {threads} threads"
+            );
+        }
     }
 
     #[test]

--- a/src/proof_system/quotient_poly.rs
+++ b/src/proof_system/quotient_poly.rs
@@ -312,20 +312,39 @@ fn compute_permutation_checks(
 mod tests {
     use super::*;
 
+    #[cfg(feature = "std")]
     #[test]
-    fn coset_evaluations_preserve_input_order() {
-        let domain = EvaluationDomain::new(8).unwrap();
+    fn coset_evaluations_preserve_input_order_across_nested_rayon_pools() {
+        let domain = EvaluationDomain::new(1 << 12).unwrap();
         let polynomials = core::array::from_fn(|index| {
-            Polynomial::from_coefficients_vec(vec![
-                BlsScalar::from(index as u64 + 1),
-                BlsScalar::from(index as u64 + 6),
-            ])
+            Polynomial::from_coefficients_vec(
+                (0..domain.size())
+                    .map(|coefficient| {
+                        BlsScalar::from(
+                            (index * domain.size() + coefficient + 1) as u64,
+                        )
+                    })
+                    .collect(),
+            )
         });
-        let expected =
-            polynomials.each_ref().map(|poly| domain.coset_fft(poly));
+        let reference_pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap();
+        let expected = reference_pool.install(|| {
+            polynomials.each_ref().map(|poly| domain.coset_fft(poly))
+        });
 
-        let actual = compute_coset_evaluations(&domain, polynomials.each_ref());
+        for threads in [8, 9] {
+            let pool = rayon::ThreadPoolBuilder::new()
+                .num_threads(threads)
+                .build()
+                .unwrap();
+            let actual = pool.install(|| {
+                compute_coset_evaluations(&domain, polynomials.each_ref())
+            });
 
-        assert_eq!(actual, expected);
+            assert_eq!(actual, expected, "failed with {threads} threads");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- share bit-reversal and butterfly helpers between the serial and parallel FFT paths
- split final stages for domains of at least `2^12` coefficients on Rayon pools with at least four workers
- derive public twiddle seeds with one `pow_vartime(range_len)` step and repeated multiplication, including uneven tails
- compare the nested five-transform quotient path slot-for-slot with independent `domain.coset_fft` results

## Performance

The production-shaped four-input Phoenix proving workload was run on the dedicated CPX42 reference worker (8 vCPU, 16 GiB) with `RAYON_NUM_THREADS=8`. It has 131,024 constraints and a `2^17` proving domain.

This comparison used current `master` at `6e21eff1` and exact candidate `2bc96aec` (tree `1b2fdb05`). Each revision ran in four counterbalanced processes, each with one warm-up and six measured proofs, for 24 measured and verified proofs per revision.

| Revision | Run 1 | Run 2 | Run 3 | Run 4 | Mean median |
| --- | ---: | ---: | ---: | ---: | ---: |
| `master` | 6.9590 s | 6.8645 s | 6.9764 s | 6.8526 s | 6.9131 s |
| Candidate | 6.6582 s | 6.6212 s | 6.7265 s | 6.6852 s | 6.6728 s |

The candidate reduces the mean proof median by 3.48% (240.3 ms) and increases implied throughput by 3.60%. Every paired round favored the candidate, by 2.44% to 4.32%; the paired mean has a 95% t-interval of 2.24% to 4.70%. Across all 24 samples per revision, the raw median reduction is 3.74%.

Mean verification medians and peak RSS were effectively unchanged (3.146 ms versus 3.152 ms; 2,170,086 KiB versus 2,169,854 KiB).

### Final-stage cutoff

Complete FFTs were also benchmarked with only the final-stage policy changed, alternating forced-serial and forced-parallel order. Every measured combination favored final-stage parallelism:

| Domain | Rayon workers | Parallel change |
| --- | --- | ---: |
| `2^12` | 4–8 | -8.42% to -13.33% |
| `2^14` | 4–8 | -13.94% to -26.02% |
| `2^17` | 4–8 | -17.57% to -36.36% |

This supports the `2^12` work-size and four-worker boundary. Smaller domains retain the serial FFT path.

## Validation

- `make fmt`
- `make clippy`
- `make no-std`
- `make test`
- `cargo test --release --all-features`
- serial/parallel equivalence and FFT/IFFT roundtrips at the three-/four-worker boundary and with an uneven nine-way partition
- independent per-slot quotient coset FFT equivalence under one-, eight-, and nine-worker Rayon pools
- mutation controls for slot order, stepped twiddle seed/uneven tail, and work-size cutoff
- production-shaped nested-Rayon Phoenix benchmark with every measured proof verified

Resolves #933
