### PR TITLE
Reject over-degree prover-key polynomials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reject unrepresentable evaluation domain sizes during verifier construction
   and checked deserialization [#927]
+- Reject fixed polynomials with degree at least the circuit domain size during
+  checked `ProverKey` deserialization [#935]
 - Reject invalid witness, polynomial, selector and public-input indices when
   deserializing compressed circuits [#930]
 - Reject trailing data when deserializing compressed circuits [#913]
@@ -769,6 +771,7 @@ is necessary since `rkyv/validation` was required as a bound.
 - Proof system module.
 
 <!-- ISSUES -->
+[#935]: https://github.com/dusk-network/plonk/issues/935
 [#930]: https://github.com/dusk-network/plonk/issues/930
 [#925]: https://github.com/dusk-network/plonk/issues/925
 [#921]: https://github.com/dusk-network/plonk/issues/921

--- a/src/proof_system/widget.rs
+++ b/src/proof_system/widget.rs
@@ -458,16 +458,20 @@ pub(crate) mod alloc {
                 |buf: &mut &[u8]| -> Result<Polynomial, Error> {
                     let serialized_poly_len =
                         usize::try_from(u64::from_reader(buf)?)
-                            .ok()
-                            .and_then(|len| len.checked_mul(BlsScalar::SIZE))
-                            .ok_or(Error::NotEnoughBytes)?;
+                            .map_err(|_| Error::NotEnoughBytes)?;
+                    if serialized_poly_len > n {
+                        return Err(dusk_bytes::Error::InvalidData.into());
+                    }
+                    let serialized_poly_size = serialized_poly_len
+                        .checked_mul(BlsScalar::SIZE)
+                        .ok_or(Error::NotEnoughBytes)?;
                     // If the announced len is zero, simply return an empty poly
                     // and leave the buffer intact.
-                    if serialized_poly_len == 0 {
+                    if serialized_poly_size == 0 {
                         return Ok(Polynomial::zero());
                     }
                     let (a, b) = buf
-                        .split_at_checked(serialized_poly_len)
+                        .split_at_checked(serialized_poly_size)
                         .ok_or(Error::NotEnoughBytes)?;
                     let poly = Polynomial::from_slice(a)?;
                     *buf = b;
@@ -762,6 +766,44 @@ mod test {
             ProverKey::from_slice(truncated),
             Err(Error::NotEnoughBytes)
         ));
+    }
+
+    #[test]
+    fn prover_key_rejects_over_degree_fixed_polynomials() {
+        let n = 1 << 3;
+        let evaluations_domain =
+            EvaluationDomain::new(8 * n).expect("8n domain should be valid");
+        let bytes = prover_key(n, evaluations_domain).to_var_bytes();
+        let evaluations_size =
+            u64::from_reader(&mut &bytes[u64::SIZE..2 * u64::SIZE]).unwrap()
+                as usize;
+        let mut polynomial_header = 2 * u64::SIZE;
+
+        for _ in 0..15 {
+            let polynomial_len = u64::from_reader(
+                &mut &bytes[polynomial_header..polynomial_header + u64::SIZE],
+            )
+            .unwrap() as usize;
+            assert_eq!(polynomial_len, n);
+            let coefficient_end = polynomial_header
+                + u64::SIZE
+                + polynomial_len * BlsScalar::SIZE;
+
+            let mut over_degree = bytes.clone();
+            over_degree[polynomial_header..polynomial_header + u64::SIZE]
+                .copy_from_slice(&((n + 1) as u64).to_bytes());
+            over_degree.splice(
+                coefficient_end..coefficient_end,
+                BlsScalar::one().to_bytes(),
+            );
+
+            assert!(matches!(
+                ProverKey::from_slice(&over_degree),
+                Err(Error::BytesError(dusk_bytes::Error::InvalidData))
+            ));
+
+            polynomial_header = coefficient_end + evaluations_size;
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- bound every serialized fixed-polynomial coefficient vector by the circuit domain size before reading its coefficients
- reject malformed prover keys whose fixed-polynomial degree is at least `n`
- cover all 15 selector and permutation polynomial slots with raw-byte regressions

## Root cause

`ProverKey::from_slice` validated the shared `8n` evaluation domain and derived caches but trusted each serialized polynomial length independently of the circuit size. Canonical compilation interpolates these fixed polynomials from exactly `n` rows, so their degree must be smaller than `n`.

The shared polynomial reader now rejects an announced coefficient count greater than `n` before reading or allocating those coefficients.

## Impact

Malformed or inconsistent local prover artifacts are rejected at the decoding boundary instead of being accepted and failing later during proving or producing unverifiable proofs.

Valid prover-key bytes, proof generation, verification, transcript behavior, and serialization formats are unchanged. The verifier does not deserialize these fixed polynomials.

## Validation

- pre-fix reproduction accepting an over-degree polynomial
- mutation control showing the regression fails without the new bound
- raw-byte rejection coverage for all 15 fixed-polynomial positions
- `make test`
- `make fmt`
- `make clippy`
- `make no-std`

Resolves #935