### PR TITLE
Align hashbrown with the rkyv dependency graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Align `hashbrown` with the version used by the optional RKYV dependency graph
+  [#943]
 - Improve prover hot-path performance by reusing sigma evaluations, batching
   permutation inversions, reducing opening-polynomial allocations, and
   parallelizing large FFT stages and independent work [#921]
@@ -777,6 +779,7 @@ is necessary since `rkyv/validation` was required as a bound.
 - Proof system module.
 
 <!-- ISSUES -->
+[#943]: https://github.com/dusk-network/plonk/issues/943
 [#937]: https://github.com/dusk-network/plonk/issues/937
 [#935]: https://github.com/dusk-network/plonk/issues/935
 [#931]: https://github.com/dusk-network/plonk/issues/931

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ dusk-bytes = "0.1"
 dusk-bls12_381 = {version = "0.14", default-features = false, features = ["groups", "pairings"]}
 dusk-jubjub = {version = "0.15", default-features = false}
 ff = {version = "0.13", default-features = false}
-hashbrown = {version = "0.9", default-features=false, features = ["ahash"]}
+hashbrown = {version = "0.12", default-features=false, features = ["ahash"]}
 msgpacker = {version = "=0.4.8", default-features=false, features = ["alloc", "derive"], optional=true}
 miniz_oxide = {version = "0.7", default-features=false, features = ["with-alloc"], optional = true}
 rayon = {version = "1.3", optional = true}


### PR DESCRIPTION
## Summary

- update the direct `hashbrown` dependency from 0.9 to 0.12
- align rkyv-enabled builds on one hashbrown/ahash generation
- preserve the existing features, public API, `no_std` behavior, proof format, transcript, and serialization

Resolves #943.

## Reference benchmark

Counterbalanced measurements on `dusk-compute-fsn1-11` (CPX42, AMD EPYC-Genoa, 8 shared vCPUs) compared exact base `944a6cba` with this dependency-only candidate.

- proving: nominally 0.9% faster, but the paired interval crosses zero; treated as unchanged
- verification: +0.15%; unchanged
- circuit compilation: inconclusive/noisy
- map-heavy circuit construction: 3.6% faster on this host
- allocation counts and allocated bytes: identical
- runtime peak memory: unchanged

This is dependency hygiene, not a performance claim. A minimal default consumer gains one package and its benchmark binary was 1.8% larger. The dependency reduction applies to rkyv-enabled consumers, where the old hashbrown/ahash line disappears.

## Validation

- `make test`
- `make fmt`
- `make clippy`
- `make no-std`
- deterministic V3 proof digest remains unchanged
- rkyv-enabled duplicate dependency check

All passed locally. The reference Nomad batch exited successfully with zero restarts and did not modify existing workloads.