### PR TITLE
Update miniz_oxide to 0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `blake2b_simd` to 1.0.5 [#950]
 - Replace the deprecated `tempdir` development dependency with `tempfile`
   [#949]
+- Update `miniz_oxide` to 0.9 and replace the unmaintained `adler` dependency
+  with `adler2` [#948]
 - Align `hashbrown` with the version used by the optional RKYV dependency graph
   [#943]
 - Improve prover hot-path performance by reusing sigma evaluations, batching
@@ -784,6 +786,7 @@ is necessary since `rkyv/validation` was required as a bound.
 <!-- ISSUES -->
 [#950]: https://github.com/dusk-network/plonk/issues/950
 [#949]: https://github.com/dusk-network/plonk/issues/949
+[#948]: https://github.com/dusk-network/plonk/issues/948
 [#943]: https://github.com/dusk-network/plonk/issues/943
 [#937]: https://github.com/dusk-network/plonk/issues/937
 [#935]: https://github.com/dusk-network/plonk/issues/935

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `blake2b_simd` to 1.0.5 [#950]
+- Replace the deprecated `tempdir` development dependency with `tempfile`
+  [#949]
 - Align `hashbrown` with the version used by the optional RKYV dependency graph
   [#943]
 - Improve prover hot-path performance by reusing sigma evaluations, batching
@@ -781,6 +783,7 @@ is necessary since `rkyv/validation` was required as a bound.
 
 <!-- ISSUES -->
 [#950]: https://github.com/dusk-network/plonk/issues/950
+[#949]: https://github.com/dusk-network/plonk/issues/949
 [#943]: https://github.com/dusk-network/plonk/issues/943
 [#937]: https://github.com/dusk-network/plonk/issues/937
 [#935]: https://github.com/dusk-network/plonk/issues/935

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ zeroize = { version = "1", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"
-tempdir = "0.3"
+tempfile = "3"
 rand = "0.8"
 itertools = {version = "0.9", default-features = false}
 rkyv = {version = "0.7", default-features = false, features = ["size_32", "validation"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ dusk-jubjub = {version = "0.15", default-features = false}
 ff = {version = "0.13", default-features = false}
 hashbrown = {version = "0.12", default-features=false, features = ["ahash"]}
 msgpacker = {version = "=0.4.8", default-features=false, features = ["alloc", "derive"], optional=true}
-miniz_oxide = {version = "0.7", default-features=false, features = ["with-alloc"], optional = true}
+miniz_oxide = {version = "0.9", default-features=false, features = ["with-alloc"], optional = true}
 rayon = {version = "1.3", optional = true}
 sha2 = {version = "0.10", default-features = false, optional = true}
 cfg-if = "1.0"

--- a/tests/debugger.rs
+++ b/tests/debugger.rs
@@ -22,7 +22,7 @@ impl Circuit for EmptyCircuit {
 fn generate_cdf_works() -> io::Result<()> {
     let rng = &mut rand::thread_rng();
 
-    let dir = tempdir::TempDir::new("plonk-cdf")?;
+    let dir = tempfile::Builder::new().prefix("plonk-cdf").tempdir()?;
     let path = dir.path().canonicalize()?.join("test.cdf");
 
     let label = b"transcript-arguments";


### PR DESCRIPTION
## Summary

- update `miniz_oxide` from 0.7 to 0.9
- replace the unmaintained `adler` dependency with `adler2`
- preserve compressed-circuit output and compatibility with existing artifacts

A deterministic 65,536-constraint circuit produced byte-identical 622,467-byte compressed artifacts with both versions. The 0.9 build also reconstructed a prover and verifier from the 0.7 artifact. Compression time and peak allocation remained effectively unchanged.

## Validation

- `cargo test --release`
- `cargo build --release --no-default-features --features alloc`
- deterministic V3 proof digest
- cross-version compressed-circuit fixture reconstruction
- compression and decompression allocation measurements

Resolves #948.