### PR TITLE
Update blake2b_simd to 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update `blake2b_simd` to 1.0.5 [#950]
 - Align `hashbrown` with the version used by the optional RKYV dependency graph
   [#943]
 - Improve prover hot-path performance by reusing sigma evaluations, batching
@@ -779,6 +780,7 @@ is necessary since `rkyv/validation` was required as a bound.
 - Proof system module.
 
 <!-- ISSUES -->
+[#950]: https://github.com/dusk-network/plonk/issues/950
 [#943]: https://github.com/dusk-network/plonk/issues/943
 [#937]: https://github.com/dusk-network/plonk/issues/937
 [#935]: https://github.com/dusk-network/plonk/issues/935

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 ]
 
 [dependencies]
-blake2b_simd = { version = "=1.0.3", default-features = false }
+blake2b_simd = { version = "=1.0.5", default-features = false }
 merlin = {version = "3.0", default-features = false}
 rand_core = {version="0.6", default-features=false}
 dusk-bytes = "0.1"


### PR DESCRIPTION
## Summary

- update the exact `blake2b_simd` pin from 1.0.3 to 1.0.5
- retain deterministic proof and transcript output
- remove the now-unneeded `arrayref` dependency from the resolved graph

Direct hash vectors and the complete serialized V3 proof digest are unchanged. Hashing performance and allocation behavior also remained unchanged in local measurements.

## Validation

- `cargo test --release deterministic_v3_proof_matches_base_digest`
- `cargo build --release --no-default-features --features alloc`
- direct 64-byte and 1 MiB hash compatibility checks
- `cargo fmt --all -- --check`

Resolves #950.