### PR TITLE
Replace tempdir with tempfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `blake2b_simd` to 1.0.5 [#950]
+- Replace the deprecated `tempdir` development dependency with `tempfile`
+  [#949]
 - Align `hashbrown` with the version used by the optional RKYV dependency graph
   [#943]
 - Improve prover hot-path performance by reusing sigma evaluations, batching
@@ -781,6 +783,7 @@ is necessary since `rkyv/validation` was required as a bound.
 
 <!-- ISSUES -->
 [#950]: https://github.com/dusk-network/plonk/issues/950
+[#949]: https://github.com/dusk-network/plonk/issues/949
 [#943]: https://github.com/dusk-network/plonk/issues/943
 [#937]: https://github.com/dusk-network/plonk/issues/937
 [#935]: https://github.com/dusk-network/plonk/issues/935

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ zeroize = { version = "1", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"
-tempdir = "0.3"
+tempfile = "3"
 rand = "0.8"
 itertools = {version = "0.9", default-features = false}
 rkyv = {version = "0.7", default-features = false, features = ["size_32", "validation"]}

--- a/tests/debugger.rs
+++ b/tests/debugger.rs
@@ -22,7 +22,7 @@ impl Circuit for EmptyCircuit {
 fn generate_cdf_works() -> io::Result<()> {
     let rng = &mut rand::thread_rng();
 
-    let dir = tempdir::TempDir::new("plonk-cdf")?;
+    let dir = tempfile::Builder::new().prefix("plonk-cdf").tempdir()?;
     let path = dir.path().canonicalize()?.join("test.cdf");
 
     let label = b"transcript-arguments";


### PR DESCRIPTION
## Summary

- replace the deprecated `tempdir` development dependency with `tempfile`
- preserve the debugger CDF temporary-directory lifecycle
- remove the vulnerable `remove_dir_all 0.5.3` dependency path reported by Cargo Audit

This is test-only and does not affect production builds.

## Validation

- `cargo test --release --test debugger generate_cdf_works`
- `cargo fmt --all -- --check`
- Cargo Audit no longer reports `tempdir` or `remove_dir_all`

Resolves #949.