### PR TITLE
Update benchmark dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update Criterion to 0.8 and align the dev-only `itertools` dependency [#953]
 - Raise the MSRV to Rust 1.96.1 [#951]
 - Update `blake2b_simd` to 1.0.5 [#950]
 - Replace the deprecated `tempdir` development dependency with `tempfile`
@@ -785,6 +786,7 @@ is necessary since `rkyv/validation` was required as a bound.
 - Proof system module.
 
 <!-- ISSUES -->
+[#953]: https://github.com/dusk-network/plonk/issues/953
 [#951]: https://github.com/dusk-network/plonk/issues/951
 [#950]: https://github.com/dusk-network/plonk/issues/950
 [#949]: https://github.com/dusk-network/plonk/issues/949

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,10 @@ dusk-cdf = {version = "0.5", optional = true}
 zeroize = { version = "1", optional = true }
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = "0.8"
 tempfile = "3"
 rand = "0.8"
-itertools = {version = "0.9", default-features = false}
+itertools = {version = "0.13", default-features = false}
 rkyv = {version = "0.7", default-features = false, features = ["size_32", "validation"]}
 
 [features]

--- a/benches/plonk.rs
+++ b/benches/plonk.rs
@@ -6,7 +6,9 @@
 
 #![allow(clippy::many_single_char_names)]
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use dusk_plonk::prelude::*;
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
Closes #953.\n\nUpdates Criterion to 0.8, aligns the dev-only itertools dependency with Criterion 0.13 and replaces Criterion's deprecated black_box re-export.\n\nStacked on #952.