### PR TITLE
Handle fixed-buffer serialization errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Size serialized `ProverKey` buffers from each polynomial's actual length
+  [#959]
 - Normalize unrepresentable serialized prover-key lengths as invalid data
   [#937]
 - Bound compressed-circuit decompression and reconstruction allocation by the
@@ -786,6 +788,7 @@ is necessary since `rkyv/validation` was required as a bound.
 - Proof system module.
 
 <!-- ISSUES -->
+[#959]: https://github.com/dusk-network/plonk/issues/959
 [#953]: https://github.com/dusk-network/plonk/issues/953
 [#951]: https://github.com/dusk-network/plonk/issues/951
 [#950]: https://github.com/dusk-network/plonk/issues/950

--- a/src/buffer_writer.rs
+++ b/src/buffer_writer.rs
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_bytes::Write;
+
+pub(crate) struct BufferWriter<'a> {
+    buffer: &'a mut [u8],
+}
+
+impl<'a> BufferWriter<'a> {
+    pub(crate) fn new(buffer: &'a mut [u8]) -> Self {
+        Self { buffer }
+    }
+
+    pub(crate) fn write(&mut self, bytes: &[u8]) {
+        self.buffer
+            .write(bytes)
+            .expect("serialization buffer is too small");
+    }
+
+    pub(crate) fn finish(self) {
+        assert!(
+            self.buffer.is_empty(),
+            "serialization buffer was not fully written"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "serialization buffer is too small")]
+    fn oversized_write_panics() {
+        BufferWriter::new(&mut [0u8; 1]).write(&[0u8; 2]);
+    }
+
+    #[test]
+    #[should_panic(expected = "serialization buffer was not fully written")]
+    fn incomplete_write_panics() {
+        let mut buffer = [0u8; 2];
+        let mut writer = BufferWriter::new(&mut buffer);
+        writer.write(&[0u8; 1]);
+        writer.finish();
+    }
+}

--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -29,7 +29,7 @@ use super::proof::Proof;
 use crate::error::Error;
 use crate::fft::Polynomial;
 use crate::transcript::TranscriptProtocol;
-use crate::util;
+use crate::{BufferWriter, util};
 
 /// CommitKey is used to commit to a polynomial which is bounded by the
 /// max_degree.
@@ -593,15 +593,13 @@ fn batch_challenge(
 impl Serializable<{ G1Affine::SIZE + G2Affine::SIZE * 2 }> for OpeningKey {
     type Error = dusk_bytes::Error;
 
-    #[allow(unused_must_use)]
     fn to_bytes(&self) -> [u8; Self::SIZE] {
-        use dusk_bytes::Write;
         let mut buf = [0u8; Self::SIZE];
-        let mut writer = &mut buf[..];
-        // This can't fail therefore we don't care about the Result nor use it.
+        let mut writer = BufferWriter::new(&mut buf);
         writer.write(&self.g.to_bytes());
         writer.write(&self.h.to_bytes());
         writer.write(&self.x_h.to_bytes());
+        writer.finish();
 
         buf
     }

--- a/src/compiler/prover.rs
+++ b/src/compiler/prover.rs
@@ -1185,6 +1185,44 @@ mod tests {
     }
 
     #[test]
+    fn prover_roundtrip_accepts_uneven_polynomial_lengths() {
+        let mut rng = StdRng::seed_from_u64(50);
+        let pp = PublicParameters::setup(1 << 10, &mut rng)
+            .expect("public parameters should build");
+        let (prover, _) = Compiler::compile::<MinimalCircuit>(&pp, b"p1.4-5")
+            .expect("circuit should compile");
+        let mut bytes = prover.to_bytes();
+
+        let label_len = u64::from_be_bytes(
+            bytes[..u64::SIZE].try_into().expect("header is complete"),
+        ) as usize;
+        let prover_key_len = u64::from_be_bytes(
+            bytes[u64::SIZE..2 * u64::SIZE]
+                .try_into()
+                .expect("header is complete"),
+        ) as usize;
+        let q_m_len_offset = 6 * u64::SIZE + label_len + 2 * u64::SIZE;
+        let q_m_len =
+            u64::from_slice(&bytes[q_m_len_offset..q_m_len_offset + u64::SIZE])
+                .expect("q_m length should decode") as usize;
+        assert!(q_m_len > 1);
+
+        bytes[q_m_len_offset..q_m_len_offset + u64::SIZE]
+            .copy_from_slice(&((q_m_len - 1) as u64).to_bytes());
+        let first_q_m_coefficient = q_m_len_offset + u64::SIZE;
+        bytes.drain(
+            first_q_m_coefficient..first_q_m_coefficient + BlsScalar::SIZE,
+        );
+        bytes[u64::SIZE..2 * u64::SIZE].copy_from_slice(
+            &((prover_key_len - BlsScalar::SIZE) as u64).to_be_bytes(),
+        );
+
+        let decoded = Prover::try_from_bytes(&bytes)
+            .expect("prover with uneven polynomial lengths should decode");
+        assert_eq!(decoded.to_bytes(), bytes);
+    }
+
+    #[test]
     fn prover_try_from_bytes_rejects_overflow_lengths_without_panicking() {
         let mut bytes = Vec::with_capacity(48);
         bytes.extend_from_slice(&0u64.to_be_bytes()); // label_len

--- a/src/fft/domain.rs
+++ b/src/fft/domain.rs
@@ -22,6 +22,8 @@ use rkyv::{
     ser::{ScratchSpace, Serializer},
 };
 
+use crate::BufferWriter;
+
 /// Defines a domain over which finite field (I)FFTs can be performed. Works
 /// only for fields that have a large multiplicative subgroup of size that is
 /// a power-of-2.
@@ -61,12 +63,9 @@ impl Serializable<{ u64::SIZE + u32::SIZE + 5 * BlsScalar::SIZE }>
 {
     type Error = dusk_bytes::Error;
 
-    #[allow(unused_must_use)]
     fn to_bytes(&self) -> [u8; Self::SIZE] {
-        use dusk_bytes::Write;
-
         let mut buf = [0u8; Self::SIZE];
-        let mut writer = &mut buf[..];
+        let mut writer = BufferWriter::new(&mut buf);
         writer.write(&self.size.to_bytes());
         writer.write(&self.log_size_of_group.to_bytes());
         writer.write(&self.size_as_field_element.to_bytes());
@@ -74,6 +73,7 @@ impl Serializable<{ u64::SIZE + u32::SIZE + 5 * BlsScalar::SIZE }>
         writer.write(&self.group_gen.to_bytes());
         writer.write(&self.group_gen_inv.to_bytes());
         writer.write(&self.generator_inv.to_bytes());
+        writer.finish();
 
         buf
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,8 @@
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub(crate) use buffer_writer::BufferWriter;
+
 cfg_if::cfg_if!(
 if #[cfg(feature = "alloc")] {
     /// `macro_use` will declare `vec!`. However, if `libstd` is present, then this
@@ -72,6 +74,7 @@ if #[cfg(feature = "alloc")] {
 #[cfg(feature = "debug")]
 pub(crate) mod debugger;
 
+mod buffer_writer;
 mod commitment_scheme;
 mod error;
 mod fft;

--- a/src/proof_system/linearization_poly.rs
+++ b/src/proof_system/linearization_poly.rs
@@ -14,6 +14,7 @@ use rkyv::{
     ser::{ScratchSpace, Serializer},
 };
 
+use crate::BufferWriter;
 #[cfg(feature = "alloc")]
 use crate::{
     fft::{EvaluationDomain, Polynomial},
@@ -98,12 +99,9 @@ pub(crate) struct LinearizationChallenges {
 impl Serializable<{ 15 * BlsScalar::SIZE }> for ProofEvaluations {
     type Error = dusk_bytes::Error;
 
-    #[allow(unused_must_use)]
     fn to_bytes(&self) -> [u8; Self::SIZE] {
-        use dusk_bytes::Write;
-
         let mut buf = [0u8; Self::SIZE];
-        let mut writer = &mut buf[..];
+        let mut writer = BufferWriter::new(&mut buf);
         writer.write(&self.a_eval.to_bytes());
         writer.write(&self.b_eval.to_bytes());
         writer.write(&self.c_eval.to_bytes());
@@ -119,6 +117,7 @@ impl Serializable<{ 15 * BlsScalar::SIZE }> for ProofEvaluations {
         writer.write(&self.s_sigma_2_eval.to_bytes());
         writer.write(&self.s_sigma_3_eval.to_bytes());
         writer.write(&self.z_eval.to_bytes());
+        writer.finish();
 
         buf
     }

--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -12,6 +12,7 @@ use dusk_bytes::{DeserializableSlice, Serializable};
 use rayon::prelude::*;
 
 use super::linearization_poly::ProofEvaluations;
+use crate::BufferWriter;
 use crate::commitment_scheme::Commitment;
 
 // Number of (unshifted) polynomials opened at `z`, excluding the linearization
@@ -139,12 +140,9 @@ impl Serializable<{ 11 * Commitment::SIZE + ProofEvaluations::SIZE }>
 {
     type Error = dusk_bytes::Error;
 
-    #[allow(unused_must_use)]
     fn to_bytes(&self) -> [u8; Self::SIZE] {
-        use dusk_bytes::Write;
-
         let mut buf = [0u8; Self::SIZE];
-        let mut writer = &mut buf[..];
+        let mut writer = BufferWriter::new(&mut buf);
         writer.write(&self.a_comm.to_bytes());
         writer.write(&self.b_comm.to_bytes());
         writer.write(&self.c_comm.to_bytes());
@@ -157,6 +155,7 @@ impl Serializable<{ 11 * Commitment::SIZE + ProofEvaluations::SIZE }>
         writer.write(&self.w_z_chall_comm.to_bytes());
         writer.write(&self.w_z_chall_w_comm.to_bytes());
         writer.write(&self.evaluations.to_bytes());
+        writer.finish();
 
         buf
     }

--- a/src/proof_system/widget.rs
+++ b/src/proof_system/widget.rs
@@ -6,6 +6,7 @@
 
 use dusk_bytes::{DeserializableSlice, Serializable};
 
+use crate::BufferWriter;
 use crate::commitment_scheme::Commitment;
 
 pub mod arithmetic;
@@ -84,11 +85,9 @@ impl<C> CheckBytes<C> for ArchivedVerifierKey {
 impl Serializable<{ 20 * Commitment::SIZE + u64::SIZE }> for VerifierKey {
     type Error = dusk_bytes::Error;
 
-    #[allow(unused_must_use)]
     fn to_bytes(&self) -> [u8; Self::SIZE] {
-        use dusk_bytes::Write;
         let mut buff = [0u8; Self::SIZE];
-        let mut writer = &mut buff[..];
+        let mut writer = BufferWriter::new(&mut buff);
 
         writer.write(&(self.n as u64).to_bytes());
         writer.write(&self.arithmetic.q_m.to_bytes());
@@ -106,6 +105,9 @@ impl Serializable<{ 20 * Commitment::SIZE + u64::SIZE }> for VerifierKey {
         writer.write(&self.permutation.s_sigma_2.to_bytes());
         writer.write(&self.permutation.s_sigma_3.to_bytes());
         writer.write(&self.permutation.s_sigma_4.to_bytes());
+        // Preserve the five legacy lookup-commitment slots as zero padding.
+        writer.write(&[0u8; 5 * Commitment::SIZE]);
+        writer.finish();
 
         buff
     }
@@ -313,22 +315,40 @@ pub(crate) mod alloc {
     }
 
     impl ProverKey {
+        fn evaluations_serialization_size(&self) -> usize {
+            self.arithmetic.q_m.1.evals.len() * BlsScalar::SIZE
+                + EvaluationDomain::SIZE
+        }
+
         /// Returns the size of the ProverKey for serialization.
         ///
         /// Note:
         /// Duplicate polynomials of the ProverKey (e.g. `q_L`, `q_R` and `q_C`)
         /// are only counted once.
         fn serialization_size(&self) -> usize {
-            // Fetch size in bytes of each Polynomial
-            let poly_size = self.arithmetic.q_m.0.len() * BlsScalar::SIZE;
+            let polynomial_lengths = [
+                self.arithmetic.q_m.0.len(),
+                self.arithmetic.q_l.0.len(),
+                self.arithmetic.q_r.0.len(),
+                self.arithmetic.q_o.0.len(),
+                self.arithmetic.q_f.0.len(),
+                self.arithmetic.q_c.0.len(),
+                self.arithmetic.q_arith.0.len(),
+                self.logic.q_logic.0.len(),
+                self.range.q_range.0.len(),
+                self.fixed_base.q_fixed_group_add.0.len(),
+                self.variable_base.q_variable_group_add.0.len(),
+                self.permutation.s_sigma_1.0.len(),
+                self.permutation.s_sigma_2.0.len(),
+                self.permutation.s_sigma_3.0.len(),
+                self.permutation.s_sigma_4.0.len(),
+            ];
+            let poly_size =
+                polynomial_lengths.into_iter().sum::<usize>() * BlsScalar::SIZE;
             // Fetch size in bytes of each Evaluations
-            let eval_size = self.arithmetic.q_m.1.evals.len() * BlsScalar::SIZE
-                + EvaluationDomain::SIZE;
+            let eval_size = self.evaluations_serialization_size();
 
-            // The amount of distinct polynomials in `ProverKey`
-            // 7 (arithmetic) + 1 (logic) + 1 (range) + 1 (fixed_base)
-            // + 1 (variable_base) + 4 (permutation)
-            let poly_num = 15;
+            let poly_num = polynomial_lengths.len();
 
             // The amount of distinct evaluations in `ProverKey`
             // poly_num + 1 (permutation) + 1 (v_h_coset_8n)
@@ -339,20 +359,17 @@ pub(crate) mod alloc {
             let i64_num = poly_num + 2;
 
             // Calculate the amount of bytes needed to serialize `ProverKey`
-            poly_size * poly_num + eval_size * eval_num + u64::SIZE * i64_num
+            poly_size + eval_size * eval_num + u64::SIZE * i64_num
         }
 
         /// Serializes a [`ProverKey`] struct into a Vec of bytes.
-        #[allow(unused_must_use)]
         pub fn to_var_bytes(&self) -> Vec<u8> {
-            use dusk_bytes::Write;
             let size = self.serialization_size();
-            let eval_size = self.arithmetic.q_m.1.evals.len() * BlsScalar::SIZE
-                + EvaluationDomain::SIZE;
+            let eval_size = self.evaluations_serialization_size();
 
             let mut bytes = vec![0u8; size];
 
-            let mut writer = &mut bytes[..];
+            let mut writer = BufferWriter::new(&mut bytes);
             writer.write(&(self.n as u64).to_bytes());
             // Write Evaluation len in bytes.
             writer.write(&(eval_size as u64).to_bytes());
@@ -439,6 +456,7 @@ pub(crate) mod alloc {
             writer.write(&self.permutation.linear_evaluations.to_var_bytes());
 
             writer.write(&self.v_h_coset_8n.to_var_bytes());
+            writer.finish();
 
             bytes
         }
@@ -753,6 +771,18 @@ mod test {
     }
 
     #[test]
+    #[should_panic(expected = "serialization buffer was not fully written")]
+    fn prover_key_serialization_rejects_short_evaluations() {
+        let n = 1 << 3;
+        let evaluations_domain =
+            EvaluationDomain::new(8 * n).expect("8n domain should be valid");
+        let mut prover_key = prover_key(n, evaluations_domain);
+        prover_key.arithmetic.q_l.1.evals.pop();
+
+        prover_key.to_var_bytes();
+    }
+
+    #[test]
     fn prover_key_rejects_malformed_serialized_lengths() {
         let n = 1 << 3;
         let evaluations_domain =
@@ -971,6 +1001,12 @@ mod test {
         let verifier_key_bytes = verifier_key.to_bytes();
         let got = VerifierKey::from_bytes(&verifier_key_bytes).unwrap();
 
+        let padding_start = u64::SIZE + 15 * Commitment::SIZE;
+        assert!(
+            verifier_key_bytes[padding_start..]
+                .iter()
+                .all(|byte| *byte == 0)
+        );
         assert_eq!(got, verifier_key);
     }
 

--- a/src/proof_system/widget/arithmetic/verifierkey.rs
+++ b/src/proof_system/widget/arithmetic/verifierkey.rs
@@ -13,6 +13,7 @@ use rkyv::{
     ser::{ScratchSpace, Serializer},
 };
 
+use crate::BufferWriter;
 use crate::commitment_scheme::Commitment;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
@@ -42,11 +43,9 @@ pub(crate) struct VerifierKey {
 impl Serializable<{ 7 * Commitment::SIZE }> for VerifierKey {
     type Error = dusk_bytes::Error;
 
-    #[allow(unused_must_use)]
     fn to_bytes(&self) -> [u8; Self::SIZE] {
-        use dusk_bytes::Write;
         let mut buff = [0u8; Self::SIZE];
-        let mut writer = &mut buff[..];
+        let mut writer = BufferWriter::new(&mut buff);
         writer.write(&self.q_m.to_bytes());
         writer.write(&self.q_l.to_bytes());
         writer.write(&self.q_r.to_bytes());
@@ -54,6 +53,7 @@ impl Serializable<{ 7 * Commitment::SIZE }> for VerifierKey {
         writer.write(&self.q_f.to_bytes());
         writer.write(&self.q_c.to_bytes());
         writer.write(&self.q_arith.to_bytes());
+        writer.finish();
 
         buff
     }


### PR DESCRIPTION
### Summary

Handle fixed-buffer serialization failures explicitly instead of silently ignoring `dusk_bytes::Write` errors.

-  adds a crate-local `BufferWriter` that fails fast if a serialization buffer is undersized
- removes `unused_must_use` suppressions from fixed-size serializers
- fixes `ProverKey` serialization sizing to account for actual polynomial lengths
- adds regression coverage for uneven polynomial lengths

Public API shape is unchanged. Valid serialization behavior is preserved, while previously silent buffer-size mismatches now fail as invariant failures

Resolves #959 