### PR TITLE
Avoid per-scalar serialization allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Avoid per-element allocations when serializing polynomials, evaluations,
   and commitment keys [#964]
+- Bind proof construction to the public-input rows recorded at compile time [#957]
+- Reject serialized provers that predate the compiled public-input row layout [#957]
 - Update Criterion to 0.8 and align the dev-only `itertools` dependency [#953]
 - Raise the MSRV to Rust 1.96.1 [#951]
 - Update `blake2b_simd` to 1.0.5 [#950]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Avoid per-element allocations when serializing polynomials, evaluations,
+  and commitment keys [#964]
 - Update Criterion to 0.8 and align the dev-only `itertools` dependency [#953]
 - Raise the MSRV to Rust 1.96.1 [#951]
 - Update `blake2b_simd` to 1.0.5 [#950]
@@ -788,11 +790,9 @@ is necessary since `rkyv/validation` was required as a bound.
 - Proof system module.
 
 <!-- ISSUES -->
-<<<<<<< HEAD
+[#964]: https://github.com/dusk-network/plonk/issues/964
 [#959]: https://github.com/dusk-network/plonk/issues/959
-=======
 [#957]: https://github.com/dusk-network/plonk/issues/957
->>>>>>> 7fdedc29 (Bind proofs to compiled public-input rows)
 [#953]: https://github.com/dusk-network/plonk/issues/953
 [#951]: https://github.com/dusk-network/plonk/issues/951
 [#950]: https://github.com/dusk-network/plonk/issues/950

--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -301,10 +301,12 @@ impl CommitKey {
 
     /// Serializes the [`CommitKey`] into a byte slice.
     pub fn to_var_bytes(&self) -> Vec<u8> {
-        self.powers_of_g
-            .iter()
-            .flat_map(|item| item.to_bytes().to_vec())
-            .collect()
+        let mut bytes =
+            Vec::with_capacity(self.powers_of_g.len() * G1Affine::SIZE);
+        for point in &self.powers_of_g {
+            bytes.extend_from_slice(&point.to_bytes());
+        }
+        bytes
     }
 
     /// Deserialize a slice of bytes into a [`CommitKey`] struct performing

--- a/src/fft/evaluations.rs
+++ b/src/fft/evaluations.rs
@@ -50,12 +50,13 @@ pub(crate) struct Evaluations {
 impl Evaluations {
     /// Given an `Evaluations` struct, return it in it's byte representation.
     pub fn to_var_bytes(&self) -> Vec<u8> {
-        let mut bytes: Vec<u8> = self.domain.to_bytes().to_vec();
-        bytes.extend(
-            self.evals
-                .iter()
-                .flat_map(|scalar| scalar.to_bytes().to_vec()),
+        let mut bytes = Vec::with_capacity(
+            EvaluationDomain::SIZE + self.evals.len() * BlsScalar::SIZE,
         );
+        bytes.extend_from_slice(&self.domain.to_bytes());
+        for scalar in &self.evals {
+            bytes.extend_from_slice(&scalar.to_bytes());
+        }
 
         bytes
     }

--- a/src/fft/polynomial.rs
+++ b/src/fft/polynomial.rs
@@ -139,13 +139,12 @@ impl Polynomial {
     /// Given a [`Polynomial`], return it in it's bytes representation
     /// coefficient by coefficient.
     pub fn to_var_bytes(&self) -> Vec<u8> {
-        let degree = self.degree();
-        self.coeffs
-            .iter()
-            .enumerate()
-            .filter(|(i, _)| *i <= degree)
-            .flat_map(|(_, item)| item.to_bytes().to_vec())
-            .collect()
+        let len = self.coeffs.len().min(self.degree() + 1);
+        let mut bytes = Vec::with_capacity(len * BlsScalar::SIZE);
+        for scalar in &self.coeffs[..len] {
+            bytes.extend_from_slice(&scalar.to_bytes());
+        }
+        bytes
     }
 
     /// Generate a Polynomial from a slice of bytes.


### PR DESCRIPTION
This PR avoids per-scalar allocations when serializing polynomials and evaluations. It replaces temporary `Vec` allocations for each scalar with a single preallocated output buffer and direct byte copies.

The serialized format and behavior remain unchanged.

Resolves #964 
