### PR TITLE
Check serialized lengths before narrowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Reject serialized lengths and indexes that exceed the target pointer width [#940]
+- Report verifier byte-length arithmetic overflow as `BytesError(InvalidData)`
+  instead of `NotEnoughBytes` [#940]
 - Validate verifier size metadata and public-input row layouts on construction
   and deserialization, and reject trailing serialized data [#960]
 - Size serialized `ProverKey` buffers from each polynomial's actual length

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reject serialized lengths and indexes that exceed the target pointer width [#940]
 - Validate verifier size metadata and public-input row layouts on construction
   and deserialization, and reject trailing serialized data [#960]
 - Size serialized `ProverKey` buffers from each polynomial's actual length
@@ -808,6 +809,7 @@ is necessary since `rkyv/validation` was required as a bound.
 [#949]: https://github.com/dusk-network/plonk/issues/949
 [#948]: https://github.com/dusk-network/plonk/issues/948
 [#943]: https://github.com/dusk-network/plonk/issues/943
+[#940]: https://github.com/dusk-network/plonk/issues/940
 [#937]: https://github.com/dusk-network/plonk/issues/937
 [#935]: https://github.com/dusk-network/plonk/issues/935
 [#931]: https://github.com/dusk-network/plonk/issues/931

--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -264,7 +264,8 @@ impl CommitKey {
 
         let mut len = [0u8; u64::SIZE];
         len.copy_from_slice(&bytes[..u64::SIZE]);
-        let len = u64::from_le_bytes(len) as usize;
+        let len = usize::try_from(u64::from_le_bytes(len))
+            .map_err(|_| dusk_bytes::Error::InvalidData)?;
 
         if len == 0 {
             return Err(dusk_bytes::Error::InvalidData.into());

--- a/src/compiler/verifier.rs
+++ b/src/compiler/verifier.rs
@@ -128,7 +128,7 @@ impl Verifier {
         bytes
     }
 
-    /// Attempt to deserialize the prover from bytes generated via
+    /// Attempt to deserialize the verifier from bytes generated via
     /// [`Self::to_bytes`]
     pub fn try_from_bytes<B>(bytes: B) -> Result<Self, Error>
     where
@@ -141,35 +141,43 @@ impl Verifier {
         }
 
         let label_len = <[u8; 8]>::try_from(&bytes[..8]).expect("checked len");
-        let label_len = u64::from_be_bytes(label_len) as usize;
+        let label_len = usize::try_from(u64::from_be_bytes(label_len))
+            .map_err(|_| dusk_bytes::Error::InvalidData)?;
         bytes = &bytes[8..];
 
         let verifier_key_len =
             <[u8; 8]>::try_from(&bytes[..8]).expect("checked len");
-        let verifier_key_len = u64::from_be_bytes(verifier_key_len) as usize;
+        let verifier_key_len =
+            usize::try_from(u64::from_be_bytes(verifier_key_len))
+                .map_err(|_| dusk_bytes::Error::InvalidData)?;
         bytes = &bytes[8..];
 
         let opening_key_len =
             <[u8; 8]>::try_from(&bytes[..8]).expect("checked len");
-        let opening_key_len = u64::from_be_bytes(opening_key_len) as usize;
+        let opening_key_len =
+            usize::try_from(u64::from_be_bytes(opening_key_len))
+                .map_err(|_| dusk_bytes::Error::InvalidData)?;
         bytes = &bytes[8..];
 
         let public_input_indexes_len =
             <[u8; 8]>::try_from(&bytes[..8]).expect("checked len");
         let public_input_indexes_len =
-            u64::from_be_bytes(public_input_indexes_len) as usize;
+            usize::try_from(u64::from_be_bytes(public_input_indexes_len))
+                .map_err(|_| dusk_bytes::Error::InvalidData)?;
         bytes = &bytes[8..];
         let public_input_indexes_bytes_len = public_input_indexes_len
             .checked_mul(8)
             .ok_or(Error::NotEnoughBytes)?;
 
         let size = <[u8; 8]>::try_from(&bytes[..8]).expect("checked len");
-        let size = u64::from_be_bytes(size) as usize;
+        let size = usize::try_from(u64::from_be_bytes(size))
+            .map_err(|_| dusk_bytes::Error::InvalidData)?;
         bytes = &bytes[8..];
 
         let constraints =
             <[u8; 8]>::try_from(&bytes[..8]).expect("checked len");
-        let constraints = u64::from_be_bytes(constraints) as usize;
+        let constraints = usize::try_from(u64::from_be_bytes(constraints))
+            .map_err(|_| dusk_bytes::Error::InvalidData)?;
         bytes = &bytes[8..];
 
         if public_input_indexes_len > constraints {
@@ -204,11 +212,15 @@ impl Verifier {
         let verifier_key = VerifierKey::from_slice(verifier_key)?;
         let opening_key = OpeningKey::from_slice(opening_key)?;
         let public_input_indexes = public_input_indexes
-            .chunks_exact(8)
-            .map(|c| <[u8; 8]>::try_from(c).expect("checked len"))
-            .map(u64::from_be_bytes)
-            .map(|n| n as usize)
-            .collect();
+            .as_chunks::<{ u64::SIZE }>()
+            .0
+            .iter()
+            .map(|bytes| {
+                let index = u64::from_be_bytes(*bytes);
+                usize::try_from(index)
+                    .map_err(|_| dusk_bytes::Error::InvalidData)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         Self::new(
             label,
@@ -352,7 +364,14 @@ mod tests {
             result.is_ok(),
             "try_from_bytes panicked on overflow lengths"
         );
-        assert!(matches!(result.unwrap(), Err(Error::NotEnoughBytes)));
+        if usize::BITS == 32 {
+            assert!(matches!(
+                result.unwrap(),
+                Err(Error::BytesError(dusk_bytes::Error::InvalidData))
+            ));
+        } else {
+            assert!(matches!(result.unwrap(), Err(Error::NotEnoughBytes)));
+        }
     }
 
     #[test]
@@ -374,10 +393,15 @@ mod tests {
         let result =
             std::panic::catch_unwind(|| Verifier::try_from_bytes(&bytes));
         assert!(result.is_ok(), "deserializer should never panic");
-        assert!(matches!(
-            result.expect("checked above"),
-            Err(Error::InvalidEvalDomainSize { .. })
-        ));
+        let result = result.expect("checked above");
+        if usize::BITS == 32 {
+            assert!(matches!(
+                result,
+                Err(Error::BytesError(dusk_bytes::Error::InvalidData))
+            ));
+        } else {
+            assert!(matches!(result, Err(Error::InvalidEvalDomainSize { .. })));
+        }
     }
 
     #[test]

--- a/src/compiler/verifier.rs
+++ b/src/compiler/verifier.rs
@@ -129,7 +129,12 @@ impl Verifier {
     }
 
     /// Attempt to deserialize the verifier from bytes generated via
-    /// [`Self::to_bytes`]
+    /// [`Self::to_bytes`].
+    ///
+    /// Serialized values and byte-length arithmetic that overflow `usize`
+    /// return [`Error::BytesError`] containing
+    /// [`dusk_bytes::Error::InvalidData`]. Short reads retain
+    /// [`Error::NotEnoughBytes`] or nested [`dusk_bytes::Error::BadLength`].
     pub fn try_from_bytes<B>(bytes: B) -> Result<Self, Error>
     where
         B: AsRef<[u8]>,
@@ -167,7 +172,7 @@ impl Verifier {
         bytes = &bytes[8..];
         let public_input_indexes_bytes_len = public_input_indexes_len
             .checked_mul(8)
-            .ok_or(Error::NotEnoughBytes)?;
+            .ok_or(dusk_bytes::Error::InvalidData)?;
 
         let size = <[u8; 8]>::try_from(&bytes[..8]).expect("checked len");
         let size = usize::try_from(u64::from_be_bytes(size))
@@ -188,7 +193,7 @@ impl Verifier {
             .checked_add(verifier_key_len)
             .and_then(|len| len.checked_add(opening_key_len))
             .and_then(|len| len.checked_add(public_input_indexes_bytes_len))
-            .ok_or(Error::NotEnoughBytes)?;
+            .ok_or(dusk_bytes::Error::InvalidData)?;
 
         if bytes.len() < required_len {
             return Err(Error::NotEnoughBytes);
@@ -364,14 +369,10 @@ mod tests {
             result.is_ok(),
             "try_from_bytes panicked on overflow lengths"
         );
-        if usize::BITS == 32 {
-            assert!(matches!(
-                result.unwrap(),
-                Err(Error::BytesError(dusk_bytes::Error::InvalidData))
-            ));
-        } else {
-            assert!(matches!(result.unwrap(), Err(Error::NotEnoughBytes)));
-        }
+        assert!(matches!(
+            result.unwrap(),
+            Err(Error::BytesError(dusk_bytes::Error::InvalidData))
+        ));
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -74,7 +74,9 @@ pub enum Error {
     PairingCheckFailure,
 
     // Serialization errors
-    /// Dusk-bytes serialization error
+    /// Dusk-bytes serialization error. Reads through dusk-bytes readers
+    /// retain `BadLength { found, expected }` diagnostics. Slice-length checks
+    /// in this crate return [`Error::NotEnoughBytes`] at any nesting depth.
     BytesError(DuskBytesError),
     /// This error occurs when there are not enough bytes to read out of a
     /// slice during deserialization.

--- a/src/proof_system/widget.rs
+++ b/src/proof_system/widget.rs
@@ -116,7 +116,8 @@ impl Serializable<{ 20 * Commitment::SIZE + u64::SIZE }> for VerifierKey {
         let mut buffer = &buf[..];
 
         Ok(Self::from_polynomial_commitments(
-            u64::from_reader(&mut buffer)? as usize,
+            usize::try_from(u64::from_reader(&mut buffer)?)
+                .map_err(|_| dusk_bytes::Error::InvalidData)?,
             Commitment::from_reader(&mut buffer)?,
             Commitment::from_reader(&mut buffer)?,
             Commitment::from_reader(&mut buffer)?,
@@ -788,6 +789,15 @@ mod test {
         let evaluations_domain =
             EvaluationDomain::new(8 * n).expect("8n domain should be valid");
         let bytes = prover_key(n, evaluations_domain).to_var_bytes();
+
+        // The three initial u64 headers retain the byte reader's diagnostic.
+        for end in 0..3 * u64::SIZE {
+            assert!(matches!(
+                ProverKey::from_slice(&bytes[..end]),
+                Err(Error::BytesError(dusk_bytes::Error::BadLength { found, expected }))
+                    if found == end % u64::SIZE && expected == u64::SIZE
+            ));
+        }
 
         let mut oversized_evaluations = bytes.clone();
         oversized_evaluations[u64::SIZE..2 * u64::SIZE]

--- a/tests/plonk_versioning.rs
+++ b/tests/plonk_versioning.rs
@@ -26,6 +26,60 @@ impl Circuit for MulCircuit {
 }
 
 #[test]
+fn verifier_truncation_preserves_top_level_error() {
+    let bytes = include_bytes!("fixtures/merlin-3/verifier.bin");
+    assert_eq!(Verifier::try_from_bytes(bytes).unwrap().to_bytes(), bytes);
+    for end in 0..bytes.len() {
+        assert!(matches!(
+            Verifier::try_from_bytes(&bytes[..end]),
+            Err(Error::NotEnoughBytes)
+        ));
+    }
+}
+
+#[cfg(target_pointer_width = "32")]
+#[test]
+fn verifier_rejects_truncated_high_bits() {
+    let bytes = include_bytes!("fixtures/merlin-3/verifier.bin");
+    Verifier::try_from_bytes(bytes).unwrap();
+    let word = |offset| {
+        u64::from_be_bytes(bytes[offset..offset + 8].try_into().unwrap())
+    };
+    // Six big-endian outer words, a little-endian inner key size, and
+    // a big-endian public-input index must all reject discarded high bits.
+    let key_start = 48 + word(0) as usize;
+    let index_start = key_start + word(8) as usize + word(16) as usize;
+    for offset in [3, 11, 19, 27, 35, 43, key_start + 4, index_start + 3] {
+        let mut mutated = bytes.to_vec();
+        mutated[offset] |= 1;
+        assert!(matches!(
+            Verifier::try_from_bytes(mutated),
+            Err(Error::BytesError(dusk_bytes::Error::InvalidData))
+        ));
+    }
+}
+
+#[cfg(target_pointer_width = "32")]
+#[test]
+fn prover_rejects_truncated_commit_key_length_high_bits() {
+    let mut rng = StdRng::seed_from_u64(63);
+    let pp = PublicParameters::setup(1 << 5, &mut rng).unwrap();
+    let (prover, _) = Compiler::compile::<MulCircuit>(&pp, b"length").unwrap();
+    let mut bytes = prover.to_bytes();
+    assert_eq!(Prover::try_from_bytes(&bytes).unwrap().to_bytes(), bytes);
+    let word = |offset| {
+        u64::from_be_bytes(bytes[offset..offset + 8].try_into().unwrap())
+            as usize
+    };
+    let commit_start = 56 + word(8) + word(16);
+    bytes[commit_start + 4] |= 1;
+    assert!(matches!(
+        Prover::try_from_bytes(bytes),
+        Err(Error::BytesError(dusk_bytes::Error::InvalidData))
+    ));
+}
+
+#[test]
 fn upstream_merlin_3_proofs_remain_valid() {
     let verifier = Verifier::try_from_bytes(include_bytes!(
         "fixtures/merlin-3/verifier.bin"

--- a/tests/plonk_versioning.rs
+++ b/tests/plonk_versioning.rs
@@ -26,7 +26,7 @@ impl Circuit for MulCircuit {
 }
 
 #[test]
-fn verifier_truncation_preserves_top_level_error() {
+fn verifier_length_errors_distinguish_overflow_from_truncation() {
     let bytes = include_bytes!("fixtures/merlin-3/verifier.bin");
     assert_eq!(Verifier::try_from_bytes(bytes).unwrap().to_bytes(), bytes);
     for end in 0..bytes.len() {
@@ -34,6 +34,34 @@ fn verifier_truncation_preserves_top_level_error() {
             Verifier::try_from_bytes(&bytes[..end]),
             Err(Error::NotEnoughBytes)
         ));
+    }
+
+    // Each word fits usize on both 32- and 64-bit targets. Only the
+    // byte-length multiplication or one of the three additions overflows.
+    let max = usize::MAX as u64;
+    for (header, overflows) in [
+        ([0, 0, 0, max / 8 + 1, 0, max], true),
+        ([max, 1, 0, 0, 0, 0], true),
+        ([0, max, 1, 0, 0, 0], true),
+        ([0, 0, max, 1, 0, 1], true),
+        // At the representable boundary the missing payload is a short read.
+        ([0, 0, 0, max / 8, 0, max], false),
+        ([max, 0, 0, 0, 0, 0], false),
+        ([0, max, 0, 0, 0, 0], false),
+        ([0, 0, max - 8, 1, 0, 1], false),
+    ] {
+        let bytes: Vec<_> =
+            header.into_iter().flat_map(u64::to_be_bytes).collect();
+        let expected = if overflows {
+            Error::BytesError(dusk_bytes::Error::InvalidData)
+        } else {
+            Error::NotEnoughBytes
+        };
+        assert_eq!(
+            Verifier::try_from_bytes(bytes).err(),
+            Some(expected),
+            "header: {header:?}"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- Check serialized verifier sizes/indexes and raw commitment-key counts before narrowing to `usize`, matching the existing prover conversion policy.
- Report verifier byte-length multiplication/addition overflow as `BytesError(InvalidData)` instead of `NotEnoughBytes`, including on 64-bit targets. Preserve actual short-read errors and nested `BadLength { found, expected }` diagnostics.
- Keep fixed-length/retired-slot canonicality (#965), archived-key validation (#941), and compressed-circuit bounds (#942) out of this change.

Fixes #940.

## Validation

Rust 1.96.1, separate build directory for this branch:

- `make test`: 191 default + 207 all-feature release tests passed.
- Earlier i686-unknown-linux-musl release run with defaults + `rkyv-impl,legacy-proving`: 203 passed. The current documentation-only amendment passed the native suite; an extra i686 rerun was blocked by missing local musl C tooling.
- Both new 32-bit high-bit regressions fail against unchanged master and pass here.
- The extended public decoder regression covers multiplication, all three length additions, their representable short-read boundaries, and every truncated prefix of the frozen verifier. Separate 32-/64-bit negative controls reject the old multiplication policy and a multiplication-only fix that leaves addition overflow misclassified.
- `make fmt`, `make clippy`, `make no-std`, internal docs and committed diff checks passed; existing no-alloc dead-code warnings remain.
- Frozen upstream-Merlin V2/V3 fixtures pass. A local valid-proof probe confirms existing padded-key/retired-slot aliases remain accepted; no #965 policy change is included.

## Compatibility

The overflow error variant is an intentional public API behavior change, recorded in #940 and the changelog. Input acceptance is unchanged by this follow-up. Downstream callers and tests matching the previous overflow variant need adjustment, including Rusk's decoder-error regression. No Rusk source or dependency rollout is included, and no full Rusk replay was run.

No dependency, workflow, proof-version or serialization-writer changes.
