### PR TITLE
Derive and test compressed-circuit bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Cover compressed-circuit encoding and compilation-capacity bounds [#942]
 - Add `Composer::assert_torsion_free_point` [#870]
 - Add `TorsionFreeWitnessPoint` [#870]
 - Add `Error::JubJubPointNotTorsionFree` [#870]
@@ -811,6 +812,7 @@ is necessary since `rkyv/validation` was required as a bound.
 [#949]: https://github.com/dusk-network/plonk/issues/949
 [#948]: https://github.com/dusk-network/plonk/issues/948
 [#943]: https://github.com/dusk-network/plonk/issues/943
+[#942]: https://github.com/dusk-network/plonk/issues/942
 [#940]: https://github.com/dusk-network/plonk/issues/940
 [#937]: https://github.com/dusk-network/plonk/issues/937
 [#935]: https://github.com/dusk-network/plonk/issues/935

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -461,3 +461,51 @@ impl Compiler {
         Ok((prover, verifier))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    use super::*;
+    use crate::prelude::Constraint;
+
+    #[derive(Default)]
+    struct FilledCircuit<const N: usize>;
+
+    impl<const N: usize> Circuit for FilledCircuit<N> {
+        fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
+            while composer.constraints() < N {
+                composer.gate_add(Constraint::new().left(1).a(Composer::ONE));
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn compressed_compilation_uses_exact_parameter_capacity() {
+        const CAPACITY: usize = 32;
+        const LIMIT: usize = CAPACITY - Compiler::CIRCUIT_SIZE_PADDING;
+        let mut rng = StdRng::seed_from_u64(942);
+        let exact = FilledCircuit::<LIMIT>::compress().unwrap();
+        let excessive = FilledCircuit::<{ LIMIT + 1 }>::compress().unwrap();
+        // Non-power-of-two budgets must round down, including the last
+        // degree before the next domain becomes available.
+        for degree in [CAPACITY, CAPACITY + 1, 2 * CAPACITY - 1] {
+            let pp = PublicParameters::setup(degree, &mut rng).unwrap();
+            assert_eq!(
+                pp.max_degree() - PublicParameters::ADDED_BLINDING_DEGREE,
+                degree
+            );
+            assert!(pp.trim(CAPACITY).is_ok());
+            assert!(pp.trim(2 * CAPACITY).is_err());
+            assert_eq!(Compiler::max_constraints(&pp), LIMIT);
+            Compiler::compile_with_compressed(&pp, b"capacity", &exact)
+                .unwrap();
+            assert!(matches!(
+                Compiler::compile_with_compressed(&pp, b"capacity", &excessive),
+                Err(Error::InvalidCompressedCircuit)
+            ));
+        }
+    }
+}

--- a/src/composer/compress.rs
+++ b/src/composer/compress.rs
@@ -43,7 +43,9 @@ pub struct CompressedPolynomial {
 }
 
 impl CompressedPolynomial {
-    fn scalar_indices(&self) -> [usize; 11] {
+    fn scalar_indices(
+        &self,
+    ) -> [usize; CompressedCircuit::SELECTORS_PER_POLYNOMIAL] {
         [
             self.q_m,
             self.q_l,
@@ -95,14 +97,21 @@ pub struct CompressedCircuit {
 }
 
 impl CompressedCircuit {
-    // Canonical MessagePack uses at most nine bytes per usize, two per u8,
-    // and five for each vector header. For every constraint, the encoder can
-    // add one public-input index, eleven 32-byte scalars, one polynomial with
-    // eleven indices, and one constraint with five indices.
-    const PACKED_FIXED_BYTES: usize = 30;
-    const PACKED_BYTES_PER_CONSTRAINT: usize = 857;
-
+    // Bounds for the pinned msgpacker encoding. Structs and fixed arrays
+    // concatenate fields; only Vec adds an array header.
+    const PACKED_USIZE_BYTES: usize = 1 + u64::SIZE;
+    const PACKED_U8_BYTES: usize = 2;
+    const PACKED_VECTOR_HEADER_BYTES: usize = 1 + u32::SIZE;
     const SELECTORS_PER_POLYNOMIAL: usize = 11;
+    const INDICES_PER_CONSTRAINT: usize = 5;
+    const PACKED_FIXED_BYTES: usize =
+        1 + Self::PACKED_USIZE_BYTES + 4 * Self::PACKED_VECTOR_HEADER_BYTES;
+    const PACKED_BYTES_PER_CONSTRAINT: usize = Self::PACKED_USIZE_BYTES
+        + Self::SELECTORS_PER_POLYNOMIAL
+            * BlsScalar::SIZE
+            * Self::PACKED_U8_BYTES
+        + Self::SELECTORS_PER_POLYNOMIAL * Self::PACKED_USIZE_BYTES
+        + Self::INDICES_PER_CONSTRAINT * Self::PACKED_USIZE_BYTES;
 
     fn validate_indices(&self, base_scalars: usize) -> Result<(), Error> {
         let scalar_count = base_scalars
@@ -590,6 +599,79 @@ mod tests {
     }
 
     #[test]
+    fn packed_constraint_fits_derived_bound() {
+        let polynomial = CompressedPolynomial {
+            q_m: usize::MAX,
+            q_l: usize::MAX,
+            q_r: usize::MAX,
+            q_o: usize::MAX,
+            q_f: usize::MAX,
+            q_c: usize::MAX,
+            q_arith: usize::MAX,
+            q_range: usize::MAX,
+            q_logic: usize::MAX,
+            q_fixed_group_add: usize::MAX,
+            q_variable_group_add: usize::MAX,
+        };
+        let constraint = CompressedConstraint {
+            polynomial: usize::MAX,
+            a: usize::MAX,
+            b: usize::MAX,
+            c: usize::MAX,
+            d: usize::MAX,
+        };
+        let mut packed = Vec::new();
+        usize::MAX.pack(&mut packed);
+        for _ in 0..CompressedCircuit::SELECTORS_PER_POLYNOMIAL {
+            [u8::MAX; BlsScalar::SIZE].pack(&mut packed);
+        }
+        polynomial.pack(&mut packed);
+        constraint.pack(&mut packed);
+        assert!(packed.len() <= CompressedCircuit::PACKED_BYTES_PER_CONSTRAINT);
+        let worst = CompressedCircuit {
+            hades_optimization: true,
+            public_inputs: vec![usize::MAX],
+            witnesses: usize::MAX,
+            scalars: vec![
+                [u8::MAX; BlsScalar::SIZE];
+                CompressedCircuit::SELECTORS_PER_POLYNOMIAL
+            ],
+            polynomials: vec![polynomial],
+            constraints: vec![constraint],
+        };
+        packed.clear();
+        worst.pack(&mut packed);
+        assert!(
+            packed.len() <= CompressedCircuit::packed_size_limit(1).unwrap()
+        );
+        #[cfg(target_pointer_width = "64")]
+        assert_eq!(
+            packed.len()
+                + 4 * (CompressedCircuit::PACKED_VECTOR_HEADER_BYTES - 1),
+            CompressedCircuit::packed_size_limit(1).unwrap()
+        );
+
+        // Unit values emit no payload, isolating the array32 header.
+        packed.clear();
+        msgpacker::pack_array(&mut packed, vec![(); usize::from(u16::MAX) + 1]);
+        assert_eq!(packed, [0xdd, 0, 1, 0, 0]);
+        assert_eq!(packed.len(), CompressedCircuit::PACKED_VECTOR_HEADER_BYTES);
+    }
+
+    #[test]
+    fn raw_array_headers_are_bounded() {
+        for bytes in [&[0xc0][..], &[], &[0xdc], &[0xdc, 0], &[0xdd, 0, 0, 0]] {
+            assert!(matches!(
+                PackedCircuitReader::new(bytes).unpack_vec::<usize>(2),
+                Err(Error::InvalidCompressedCircuit)
+            ));
+        }
+        let mut reader = PackedCircuitReader::new(&[0xdd, 0, 0, 0, 2, 0, 1]);
+        assert_eq!(reader.unpack_vec::<usize>(2).unwrap(), vec![0, 1]);
+        assert!(reader.is_empty());
+    }
+
+    #[test]
     fn capacity_limits_are_inclusive() {
         let mut circuit = circuit();
         circuit.public_inputs = vec![0, 1];
@@ -726,7 +808,8 @@ mod tests {
 
     #[test]
     fn invalid_scalar_indices_are_rejected_without_panicking() {
-        let setters: [fn(&mut CompressedPolynomial, usize); 11] = [
+        let setters: [fn(&mut CompressedPolynomial, usize);
+            CompressedCircuit::SELECTORS_PER_POLYNOMIAL] = [
             |polynomial, invalid| polynomial.q_m = invalid,
             |polynomial, invalid| polynomial.q_l = invalid,
             |polynomial, invalid| polynomial.q_r = invalid,


### PR DESCRIPTION
## Summary

- Derive the existing packed-size limits from named encoding/structure components and reuse the selector count. The limits remain 30 fixed bytes plus 857 per constraint.
- Test worst-case packing, malformed raw array headers and the in-bounds array32 path.
- Test exact compilation capacity and capacity-plus-one rejection using real public parameters, including non-power-of-two budgets.

Fixes #942.

Independently based on master, not stacked on #968.

## Validation

Rust 1.96.1, separate build directory for this branch:

- `make test` after rebasing onto merged #968: 194 default + 210 all-feature release tests passed.
- Earlier i686-unknown-linux-musl release run with defaults + `rkyv-impl,legacy-proving`: 203 passed. The added header regression passed on 64-bit; a fresh i686 build was blocked by missing local musl C tooling.
- Negative controls fail as intended: reducing the packed bound by one, reducing the array32 header allowance, reducing the fixed overhead and removing capacity floor rounding.
- `make fmt`, `make clippy`, `make no-std`, internal docs and committed diff checks passed; existing no-alloc dead-code warnings remain.
- Existing direct/compressed serialization parity and proof verification tests pass.

No runtime parser/compilation algorithm, public API, wire-format, dependency or workflow changes.
