### PR TITLE
Derive structural rkyv validation for proofs and verifier keys

### DIFF
--- a/src/commitment_scheme/kzg10/key.rs
+++ b/src/commitment_scheme/kzg10/key.rs
@@ -105,6 +105,8 @@ fn archived_commit_key_points_are_valid(
     powers.iter().all(archived_g1_is_valid)
 }
 
+// bytecheck 0.6 derives only structural checks. Keep this custom validator
+// to reject empty keys and invalid subgroup points before deserialization.
 #[cfg(feature = "rkyv-impl")]
 impl<C> CheckBytes<C> for ArchivedCommitKeyArchive
 where
@@ -506,6 +508,8 @@ impl core::fmt::Display for InvalidArchivedOpeningKey {
 #[cfg(feature = "rkyv-impl")]
 impl core::error::Error for InvalidArchivedOpeningKey {}
 
+// bytecheck 0.6 has no derive hook for the curve, subgroup and nonidentity
+// checks required here. Structural validation alone would accept invalid keys.
 #[cfg(feature = "rkyv-impl")]
 impl<C: ?Sized> CheckBytes<C> for ArchivedOpeningKeyArchive {
     type Error = InvalidArchivedOpeningKey;
@@ -1042,7 +1046,7 @@ mod test {
 
         let (commit_key, _) = setup_test(11).unwrap();
         let mut bytes = rkyv::to_bytes::<_, 256>(&commit_key).unwrap();
-        let archived = unsafe { rkyv::archived_root::<CommitKey>(&bytes) };
+        let archived = rkyv::check_archived_root::<CommitKey>(&bytes).unwrap();
         let point = &archived.powers_of_g[0];
         let point_offset = point as *const _ as usize - bytes.as_ptr() as usize;
 

--- a/src/commitment_scheme/kzg10/srs.rs
+++ b/src/commitment_scheme/kzg10/srs.rs
@@ -377,7 +377,7 @@ mod test {
     #[cfg(feature = "rkyv-impl")]
     fn first_archived_commitment_point_offset(bytes: &[u8]) -> usize {
         let parameters =
-            unsafe { rkyv::archived_root::<PublicParameters>(bytes) };
+            rkyv::check_archived_root::<PublicParameters>(bytes).unwrap();
         let point = &parameters.commit_key.powers_of_g[0];
         point as *const _ as usize - bytes.as_ptr() as usize
     }

--- a/src/proof_system/proof.rs
+++ b/src/proof_system/proof.rs
@@ -4,6 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#![forbid(unsafe_code)]
+
 //! A Proof stores the commitments to all of the elements that
 //! are needed to univocally identify a prove of some statement.
 
@@ -30,15 +32,12 @@ const V_MAX_DEGREE: usize = 11;
 const V_MAX_DEGREE_LEGACY: usize = 7;
 
 #[cfg(feature = "rkyv-impl")]
-use bytecheck::{CheckBytes, StructCheckError};
+use bytecheck::CheckBytes;
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
 };
-
-#[cfg(feature = "rkyv-impl")]
-use crate::util::check_field;
 
 /// A Proof is a composition of `Commitment`s to the Witness, Permutation,
 /// Quotient, Shifted and Opening polynomials as well as the
@@ -56,7 +55,8 @@ use crate::util::check_field;
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub struct Proof {
     /// Commitment to the witness polynomial for the left wires.
@@ -98,40 +98,6 @@ pub struct Proof {
     /// Subset of all of the evaluations added to the proof.
     #[cfg_attr(feature = "rkyv-impl", omit_bounds)]
     pub(crate) evaluations: ProofEvaluations,
-}
-
-#[cfg(feature = "rkyv-impl")]
-impl<C> CheckBytes<C> for ArchivedProof {
-    type Error = StructCheckError;
-
-    unsafe fn check_bytes<'a>(
-        value: *const Self,
-        context: &mut C,
-    ) -> Result<&'a Self, Self::Error> {
-        unsafe {
-            check_field(&(*value).a_comm, context, "a_comm")?;
-            check_field(&(*value).b_comm, context, "b_comm")?;
-            check_field(&(*value).c_comm, context, "c_comm")?;
-            check_field(&(*value).d_comm, context, "d_comm")?;
-
-            check_field(&(*value).z_comm, context, "z_comm")?;
-
-            check_field(&(*value).t_low_comm, context, "t_low_comm")?;
-            check_field(&(*value).t_mid_comm, context, "t_mid_comm")?;
-            check_field(&(*value).t_high_comm, context, "t_high_comm")?;
-            check_field(&(*value).t_fourth_comm, context, "t_fourth_comm")?;
-
-            check_field(&(*value).w_z_chall_comm, context, "w_z_chall_comm")?;
-            check_field(
-                &(*value).w_z_chall_w_comm,
-                context,
-                "w_z_chall_w_comm",
-            )?;
-            check_field(&(*value).evaluations, context, "evaluations")?;
-
-            Ok(&*value)
-        }
-    }
 }
 
 // The struct Proof has 11 commitments + 1 ProofEvaluations
@@ -1260,6 +1226,20 @@ mod proof_tests {
         let proof_bytes = proof.to_bytes();
         let got_proof = Proof::from_bytes(&proof_bytes).unwrap();
         assert_eq!(got_proof, proof);
+
+        #[cfg(feature = "rkyv-impl")]
+        {
+            let bytes = rkyv::to_bytes::<_, 256>(&proof).unwrap();
+            let decoded = rkyv::from_bytes::<Proof>(&bytes).unwrap();
+            assert_eq!(decoded, proof);
+            assert_eq!(
+                rkyv::to_bytes::<_, 256>(&decoded).unwrap().as_slice(),
+                bytes.as_slice()
+            );
+            assert!(
+                rkyv::from_bytes::<Proof>(&bytes[..bytes.len() - 1]).is_err()
+            );
+        }
     }
 }
 

--- a/src/proof_system/widget.rs
+++ b/src/proof_system/widget.rs
@@ -4,6 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#![forbid(unsafe_code)]
+
 use dusk_bytes::{DeserializableSlice, Serializable};
 
 use crate::BufferWriter;
@@ -16,15 +18,12 @@ pub mod permutation;
 pub mod range;
 
 #[cfg(feature = "rkyv-impl")]
-use bytecheck::{CheckBytes, StructCheckError};
+use bytecheck::CheckBytes;
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{
     Archive, Deserialize, Serialize,
     ser::{ScratchSpace, Serializer},
 };
-
-#[cfg(feature = "rkyv-impl")]
-use crate::util::check_field;
 
 /// PLONK circuit Verification Key.
 ///
@@ -34,7 +33,8 @@ use crate::util::check_field;
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Deserialize, Serialize),
-    archive(bound(serialize = "__S: Serializer + ScratchSpace"))
+    archive(bound(serialize = "__S: Serializer + ScratchSpace")),
+    archive_attr(derive(CheckBytes))
 )]
 pub struct VerifierKey {
     /// Circuit size (not padded to a power of two).
@@ -58,28 +58,6 @@ pub struct VerifierKey {
     /// VerifierKey for permutation checks
     #[cfg_attr(feature = "rkyv-impl", omit_bounds)]
     pub(crate) permutation: permutation::VerifierKey,
-}
-
-#[cfg(feature = "rkyv-impl")]
-impl<C> CheckBytes<C> for ArchivedVerifierKey {
-    type Error = StructCheckError;
-
-    unsafe fn check_bytes<'a>(
-        value: *const Self,
-        context: &mut C,
-    ) -> Result<&'a Self, Self::Error> {
-        unsafe {
-            check_field(&(*value).n, context, "n")?;
-            check_field(&(*value).arithmetic, context, "arithmetic")?;
-            check_field(&(*value).logic, context, "logic")?;
-            check_field(&(*value).range, context, "range")?;
-            check_field(&(*value).fixed_base, context, "fixed_base")?;
-            check_field(&(*value).variable_base, context, "variable_base")?;
-            check_field(&(*value).permutation, context, "permutation")?;
-
-            Ok(&*value)
-        }
-    }
 }
 
 impl Serializable<{ 20 * Commitment::SIZE + u64::SIZE }> for VerifierKey {
@@ -1018,6 +996,21 @@ mod test {
                 .all(|byte| *byte == 0)
         );
         assert_eq!(got, verifier_key);
+
+        #[cfg(feature = "rkyv-impl")]
+        {
+            let bytes = rkyv::to_bytes::<_, 256>(&verifier_key).unwrap();
+            let decoded = rkyv::from_bytes::<VerifierKey>(&bytes).unwrap();
+            assert_eq!(decoded, verifier_key);
+            assert_eq!(
+                rkyv::to_bytes::<_, 256>(&decoded).unwrap().as_slice(),
+                bytes.as_slice()
+            );
+            assert!(
+                rkyv::from_bytes::<VerifierKey>(&bytes[..bytes.len() - 1])
+                    .is_err()
+            );
+        }
     }
 
     #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,6 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#![forbid(unsafe_code)]
+
 use alloc::vec::Vec;
 
 use dusk_bls12_381::{
@@ -11,27 +13,6 @@ use dusk_bls12_381::{
 };
 use ff::Field;
 use rand_core::{CryptoRng, RngCore};
-
-#[cfg(feature = "rkyv-impl")]
-#[inline(always)]
-pub unsafe fn check_field<F, C>(
-    field: *const F,
-    context: &mut C,
-    field_name: &'static str,
-) -> Result<(), bytecheck::StructCheckError>
-where
-    F: bytecheck::CheckBytes<C>,
-{
-    unsafe {
-        F::check_bytes(field, context).map_err(|e| {
-            bytecheck::StructCheckError {
-                field_name,
-                inner: bytecheck::ErrorBox::new(e),
-            }
-        })?;
-    }
-    Ok(())
-}
 
 /// Returns a vector of BlsScalars of increasing powers of x from x^0 to x^d.
 pub(crate) fn powers_of(


### PR DESCRIPTION
This PR replaces the handwritten `unsafe` rkyv validation code with derive-based `CheckBytes` and safe checked archive access.

By that we remove the custom field-by-field validation helpers from `Proof` and `VerifierKey` and also preserve the existing custom validators where semantic checks are still required.

This PR leaves public API, serialization format, or runtime behavior unchanged.
